### PR TITLE
Remove inline keywords, cleaned up build.md, set compiler standard.

### DIFF
--- a/board/Makefile
+++ b/board/Makefile
@@ -1,10 +1,8 @@
-# :set noet
 PROJ_NAME = panda
-CFLAGS  = -g -O0 -Wall
+CFLAGS  = -g -O0 -Wall -std=gnu90
 
 CFLAGS += -mlittle-endian -mthumb -mcpu=cortex-m4
 CFLAGS += -mhard-float -DSTM32F4 -DSTM32F413xx
 STARTUP_FILE = startup_stm32f413xx
 
 include build.mk
-

--- a/board/build.mk
+++ b/board/build.mk
@@ -23,7 +23,7 @@ endif
 DFU_UTIL = "./tools/dfu-util-$(MACHINE)"
 
 # this pushes the unchangable bootstub too
-all: compileall #dfu
+all: compileall dfu
 
 compileall: obj/bootstub.$(PROJ_NAME).bin obj/$(PROJ_NAME).bin
 
@@ -77,13 +77,13 @@ obj/%.$(PROJ_NAME).o: ../crypto/%.c
 obj/$(STARTUP_FILE).o: $(STARTUP_FILE).s
 	$(CC) $(CFLAGS) -o $@ -c $<
 
-obj/$(PROJ_NAME).bin: obj/$(STARTUP_FILE).o obj/main.$(PROJ_NAME).o
+obj/$(PROJ_NAME).bin: obj/$(STARTUP_FILE).o obj/main.$(PROJ_NAME).o obj/early.$(PROJ_NAME).o
   # hack
 	$(CC) -Wl,--section-start,.isr_vector=0x8004000 $(CFLAGS) -o obj/$(PROJ_NAME).elf $^
 	$(OBJCOPY) -v -O binary obj/$(PROJ_NAME).elf obj/code.bin
 	SETLEN=1 ../crypto/sign.py obj/code.bin $@ $(CERT)
 
-obj/bootstub.$(PROJ_NAME).bin: obj/$(STARTUP_FILE).o obj/bootstub.$(PROJ_NAME).o obj/sha.$(PROJ_NAME).o obj/rsa.$(PROJ_NAME).o
+obj/bootstub.$(PROJ_NAME).bin: obj/$(STARTUP_FILE).o obj/bootstub.$(PROJ_NAME).o obj/sha.$(PROJ_NAME).o obj/rsa.$(PROJ_NAME).o obj/early.$(PROJ_NAME).o
 	$(CC) $(CFLAGS) -o obj/bootstub.$(PROJ_NAME).elf $^
 	$(OBJCOPY) -v -O binary obj/bootstub.$(PROJ_NAME).elf $@
 

--- a/board/early.c
+++ b/board/early.c
@@ -1,0 +1,106 @@
+#ifdef STM32F4
+  #define PANDA
+  #include "stm32f4xx.h"
+#else
+  #include "stm32f2xx.h"
+#endif
+
+#include "early.h"
+
+int has_external_debug_serial = 0;
+int is_giant_panda = 0;
+void *g_pfnVectors;
+
+// must call again from main because BSS is zeroed
+void detect() {
+  volatile int i;
+  // detect has_external_debug_serial
+  GPIOA->PUPDR |= GPIO_PUPDR_PUPDR3_1;
+  for (i=0;i<PULL_EFFECTIVE_DELAY;i++);
+  has_external_debug_serial = (GPIOA->IDR & (1 << 3)) == (1 << 3);
+
+  // detect is_giant_panda
+  is_giant_panda = 0;
+#ifdef PANDA
+  GPIOB->PUPDR |= GPIO_PUPDR_PUPDR1_1;
+  for (i=0;i<PULL_EFFECTIVE_DELAY;i++);
+  is_giant_panda = (GPIOB->IDR & (1 << 1)) == (1 << 1);
+#endif
+}
+
+void early() {
+  // after it's been in the bootloader, things are initted differently, so we reset
+  if (enter_bootloader_mode == POST_BOOTLOADER_MAGIC) {
+    enter_bootloader_mode = 0;
+    NVIC_SystemReset();
+  }
+
+  volatile int i;
+  // if wrong chip, reboot
+  volatile unsigned int id = DBGMCU->IDCODE;
+  #ifdef STM32F4
+    if ((id&0xFFF) != 0x463) enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+  #else
+    if ((id&0xFFF) != 0x411) enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+  #endif
+
+  // setup interrupt table
+  SCB->VTOR = (uint32_t)&g_pfnVectors;
+
+  // early GPIOs
+  RCC->AHB1ENR = RCC_AHB1ENR_GPIOAEN | RCC_AHB1ENR_GPIOBEN | RCC_AHB1ENR_GPIOCEN;
+  GPIOA->MODER = 0; GPIOB->MODER = 0; GPIOC->MODER = 0;
+  GPIOA->ODR = 0; GPIOB->ODR = 0; GPIOC->ODR = 0;
+  GPIOA->PUPDR = 0; GPIOB->PUPDR = 0; GPIOC->PUPDR = 0;
+
+  detect();
+
+  #ifdef PANDA
+    // enable the ESP, disable ESP boot mode
+    // unless we are on a giant panda, then there's no ESP
+    if (!is_giant_panda) {
+      GPIOC->ODR = (1 << 14) | (1 << 5);
+    }
+
+    // these are outputs to control the ESP
+    GPIOC->MODER = GPIO_MODER_MODER14_0 | GPIO_MODER_MODER5_0;
+
+    // check if the ESP is trying to put me in boot mode
+    // enable pull up
+    GPIOB->PUPDR |= GPIO_PUPDR_PUPDR0_0;
+    for (i=0;i<PULL_EFFECTIVE_DELAY;i++);
+
+    #ifdef BOOTSTUB
+      // if it's driven low, jump to spi flasher
+      if (!(GPIOB->IDR & 1)) {
+        spi_flasher();
+      }
+    #endif
+
+  #endif
+
+  if (enter_bootloader_mode == ENTER_BOOTLOADER_MAGIC) {
+    // ESP OFF
+    GPIOC->ODR &= ~((1 << 14) | (1 << 5));
+
+    // green LED on
+    // sadly, on the NEO board the bootloader turns it off
+    #ifdef PANDA
+      GPIOC->MODER |= GPIO_MODER_MODER7_0;
+      GPIOC->ODR &= ~(1 << (6 + 1));
+    #else
+      GPIOB->MODER |= GPIO_MODER_MODER11_0;
+      GPIOB->ODR &= ~(1 << (10 + 1));
+    #endif
+
+    // do enter bootloader
+    enter_bootloader_mode = POST_BOOTLOADER_MAGIC;
+    void (*bootloader)(void) = (void (*)(void)) (*((uint32_t *)0x1fff0004));
+
+    // jump to bootloader
+    bootloader();
+
+    // LOOP
+    while(1);
+  }
+}

--- a/board/early.h
+++ b/board/early.h
@@ -1,105 +1,13 @@
 #define ENTER_BOOTLOADER_MAGIC 0xdeadbeef
 #define POST_BOOTLOADER_MAGIC 0xdeadb111
-extern uint32_t enter_bootloader_mode;
-extern void *_app_start[];
-void *g_pfnVectors;
-void spi_flasher();
-
-int has_external_debug_serial = 0;
-int is_giant_panda = 0;
 #define PULL_EFFECTIVE_DELAY 10
 
-// must call again from main because BSS is zeroed
-inline void detect() {
-  volatile int i;
-  // detect has_external_debug_serial
-  GPIOA->PUPDR |= GPIO_PUPDR_PUPDR3_1;
-  for (i=0;i<PULL_EFFECTIVE_DELAY;i++);
-  has_external_debug_serial = (GPIOA->IDR & (1 << 3)) == (1 << 3);
-  
-  // detect is_giant_panda
-  is_giant_panda = 0;
-#ifdef PANDA
-  GPIOB->PUPDR |= GPIO_PUPDR_PUPDR1_1;
-  for (i=0;i<PULL_EFFECTIVE_DELAY;i++);
-  is_giant_panda = (GPIOB->IDR & (1 << 1)) == (1 << 1);
-#endif
-}
+extern uint32_t enter_bootloader_mode;
+extern void *_app_start[];
+extern void *g_pfnVectors;
+extern int has_external_debug_serial;
+extern int is_giant_panda;
 
-inline void early() {
-  // after it's been in the bootloader, things are initted differently, so we reset
-  if (enter_bootloader_mode == POST_BOOTLOADER_MAGIC) {
-    enter_bootloader_mode = 0;
-    NVIC_SystemReset();
-  }
-
-  volatile int i;
-  // if wrong chip, reboot
-  volatile unsigned int id = DBGMCU->IDCODE;
-  #ifdef STM32F4
-    if ((id&0xFFF) != 0x463) enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-  #else
-    if ((id&0xFFF) != 0x411) enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-  #endif
-
-  // setup interrupt table
-  SCB->VTOR = (uint32_t)&g_pfnVectors;
-
-  // early GPIOs
-  RCC->AHB1ENR = RCC_AHB1ENR_GPIOAEN | RCC_AHB1ENR_GPIOBEN | RCC_AHB1ENR_GPIOCEN;
-  GPIOA->MODER = 0; GPIOB->MODER = 0; GPIOC->MODER = 0;
-  GPIOA->ODR = 0; GPIOB->ODR = 0; GPIOC->ODR = 0;
-  GPIOA->PUPDR = 0; GPIOB->PUPDR = 0; GPIOC->PUPDR = 0;
-
-  detect();
-  
-  #ifdef PANDA
-    // enable the ESP, disable ESP boot mode
-    // unless we are on a giant panda, then there's no ESP
-    if (!is_giant_panda) {
-      GPIOC->ODR = (1 << 14) | (1 << 5);
-    }
-
-    // these are outputs to control the ESP
-    GPIOC->MODER = GPIO_MODER_MODER14_0 | GPIO_MODER_MODER5_0;
-
-    // check if the ESP is trying to put me in boot mode
-    // enable pull up
-    GPIOB->PUPDR |= GPIO_PUPDR_PUPDR0_0;
-    for (i=0;i<PULL_EFFECTIVE_DELAY;i++);
-    
-    #ifdef BOOTSTUB
-      // if it's driven low, jump to spi flasher
-      if (!(GPIOB->IDR & 1)) {
-        spi_flasher();
-      }
-    #endif
-
-  #endif
-
-  if (enter_bootloader_mode == ENTER_BOOTLOADER_MAGIC) {
-    // ESP OFF
-    GPIOC->ODR &= ~((1 << 14) | (1 << 5));
-
-    // green LED on
-    // sadly, on the NEO board the bootloader turns it off
-    #ifdef PANDA
-      GPIOC->MODER |= GPIO_MODER_MODER7_0;
-      GPIOC->ODR &= ~(1 << (6 + 1));
-    #else
-      GPIOB->MODER |= GPIO_MODER_MODER11_0;
-      GPIOB->ODR &= ~(1 << (10 + 1));
-    #endif
-
-    // do enter bootloader
-    enter_bootloader_mode = POST_BOOTLOADER_MAGIC;
-    void (*bootloader)(void) = (void (*)(void)) (*((uint32_t *)0x1fff0004));
-
-    // jump to bootloader
-    bootloader();
-
-    // LOOP
-    while(1);
-  }
-}
-
+void spi_flasher();
+void detect();
+void early();

--- a/board/main.c
+++ b/board/main.c
@@ -73,7 +73,7 @@ can_buffer(tx3_q, 0x100)
 
 // ********************* interrupt safe queue *********************
 
-inline int pop(can_ring *q, CAN_FIFOMailBox_TypeDef *elem) {
+int pop(can_ring *q, CAN_FIFOMailBox_TypeDef *elem) {
   if (q->w_ptr != q->r_ptr) {
     *elem = q->elems[q->r_ptr];
     if ((q->r_ptr + 1) == q->fifo_size) q->r_ptr = 0;
@@ -83,7 +83,7 @@ inline int pop(can_ring *q, CAN_FIFOMailBox_TypeDef *elem) {
   return 0;
 }
 
-inline int push(can_ring *q, CAN_FIFOMailBox_TypeDef *elem) {
+int push(can_ring *q, CAN_FIFOMailBox_TypeDef *elem) {
   uint32_t next_w_ptr;
   if ((q->w_ptr + 1) == q->fifo_size) next_w_ptr = 0;
   else next_w_ptr = q->w_ptr + 1;
@@ -111,8 +111,8 @@ typedef struct uart_ring {
   void (*callback)(struct uart_ring*);
 } uart_ring;
 
-inline int getc(uart_ring *q, char *elem);
-inline int putc(uart_ring *q, char elem);
+int getc(uart_ring *q, char *elem);
+int putc(uart_ring *q, char elem);
 
 // esp = USART1
 uart_ring esp_ring = { .w_ptr_tx = 0, .r_ptr_tx = 0,
@@ -175,7 +175,7 @@ void accord_framing_callback(uart_ring *q) {
     }
     r_ptr_rx_tmp++;
   }
-  
+
   // drop until SOF1
   if (sof1 != -1) {
     for (i = 0; i < jlen; i++) getc(q, &junk);
@@ -285,7 +285,7 @@ void UART5_IRQHandler(void) {
   NVIC_EnableIRQ(UART5_IRQn);
 }
 
-inline int getc(uart_ring *q, char *elem) {
+int getc(uart_ring *q, char *elem) {
   if (q->w_ptr_rx != q->r_ptr_rx) {
     *elem = q->elems_rx[q->r_ptr_rx];
     q->r_ptr_rx += 1;
@@ -294,7 +294,7 @@ inline int getc(uart_ring *q, char *elem) {
   return 0;
 }
 
-inline int injectc(uart_ring *q, char elem) {
+int injectc(uart_ring *q, char elem) {
   uint8_t next_w_ptr = q->w_ptr_rx + 1;
   int ret = 0;
   if (next_w_ptr != q->r_ptr_rx) {
@@ -305,7 +305,7 @@ inline int injectc(uart_ring *q, char elem) {
   return ret;
 }
 
-inline int putc(uart_ring *q, char elem) {
+int putc(uart_ring *q, char elem) {
   uint8_t next_w_ptr = q->w_ptr_tx + 1;
   int ret = 0;
   if (next_w_ptr != q->r_ptr_tx) {
@@ -1035,4 +1035,3 @@ int main() {
 
   return 0;
 }
-

--- a/board/main.c
+++ b/board/main.c
@@ -53,6 +53,9 @@ int started_signal_detected = 0;
 // TODO: check for UART high
 int did_usb_enumerate = 0;
 
+// Declare puts to supress warning
+int puts ( const char * str );
+
 // ********************* instantiate queues *********************
 
 typedef struct {


### PR DESCRIPTION
Closes #4 
Removed inline keywords on all functions. 
Split early.h into a header and c file.
Updated Makefile rules to be more consistent.