### PR TITLE
Can bus numbers now sequential (0,1,2 not 0,1,4).

### DIFF
--- a/board/can.h
+++ b/board/can.h
@@ -1,4 +1,5 @@
-void can_init(CAN_TypeDef *CAN, int silent) {
+void can_init(uint8_t bus_number, int silent) {
+  CAN_TypeDef *CAN = CANIF_FROM_BUS_NUM(bus_number);
   set_can_enable(CAN, 1);
 
   CAN->MCR = CAN_MCR_TTCM | CAN_MCR_INRQ;

--- a/panda/__init__.py
+++ b/panda/__init__.py
@@ -148,7 +148,11 @@ class Panda(object):
   # ******************* configuration *******************
 
   def set_controls_allowed(self, on):
-      self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdc, (0x1337 if on else 0), 0, b'')
+    self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdc, (0x1337 if on else 0), 0, b'')
+
+  def set_can_forwarding(self, from_bus, to_bus):
+    """This feature may not work correctly with saturated busses"""
+    self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdd, from_bus, to_bus, b'')
 
   def set_gmlan(self, on, bus=2):
     self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdb, on, bus, b'')

--- a/panda/__init__.py
+++ b/panda/__init__.py
@@ -24,7 +24,7 @@ def parse_can_buffer(dat):
       address = f1 >> 3
     else:
       address = f1 >> 21
-    ret.append((address, f2>>16, ddat[8:8+(f2&0xF)], (f2>>4)&0xf))
+    ret.append((address, f2>>16, ddat[8:8+(f2&0xF)], (f2>>4)&0xFF))
   return ret
 
 class PandaWifiStreaming(object):
@@ -81,6 +81,7 @@ class Panda(object):
   REQUEST_TYPE = usb1.TYPE_VENDOR | usb1.RECIPIENT_DEVICE
 
   def __init__(self, serial=None, claim=True):
+    self._serial = serial
     if serial == "WIFI":
       self._handle = WifiHandle()
       print("opening WIFI device")
@@ -95,7 +96,7 @@ class Panda(object):
             self._handle = device.open()
             if claim:
               self._handle.claimInterface(0)
-              self._handle.setInterfaceAltSetting(0, 0)
+              #self._handle.setInterfaceAltSetting(0, 0) #Issue in USB stack
             break
 
     assert self._handle != None
@@ -150,7 +151,7 @@ class Panda(object):
       self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdc, (0x1337 if on else 0), 0, b'')
 
   def set_gmlan(self, on, bus=2):
-    self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdb, 1, bus, b'')
+    self._handle.controlWrite(Panda.REQUEST_TYPE, 0xdb, on, bus, b'')
 
   def set_uart_baud(self, uart, rate):
     self._handle.controlWrite(Panda.REQUEST_TYPE, 0xe1, uart, rate, b'')

--- a/tests/loopback_test.py
+++ b/tests/loopback_test.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import random
+import argparse
 
 from hexdump import hexdump
 from itertools import permutations
@@ -14,7 +15,7 @@ from panda import Panda
 def get_test_string():
   return b"test"+os.urandom(10)
 
-def run_test():
+def run_test(sleep_duration):
   pandas = Panda.list()
   print(pandas)
 
@@ -25,9 +26,9 @@ def run_test():
   if len(pandas) == 1:
     # if we only have one on USB, assume the other is on wifi
     pandas.append("WIFI")
-  run_test_w_pandas(pandas)
+  run_test_w_pandas(pandas, sleep_duration)
 
-def run_test_w_pandas(pandas):
+def run_test_w_pandas(pandas, sleep_duration):
   h = list(map(lambda x: Panda(x), pandas))
   print("H", h)
 
@@ -37,6 +38,12 @@ def run_test_w_pandas(pandas):
   # test both directions
   for ho in permutations(range(len(h)), r=2):
     print("***************** TESTING", ho)
+
+    panda0, panda1 = h[ho[0]], h[ho[1]]
+
+    if(panda0._serial == "WIFI"):
+      print("  *** Can not send can data over wifi panda. Skipping! ***")
+      continue
 
     # **** test health packet ****
     print("health", ho[0], h[ho[0]].health())
@@ -60,29 +67,18 @@ def run_test_w_pandas(pandas):
       hexdump(ret)
       assert st == ret
       print("K/L pass", bus, ho, "\n")
+      time.sleep(sleep_duration)
 
     # **** test can line loopback ****
-    for bus in [0,1,4,5,6]:
-      panda0 = h[ho[0]]
-      panda1 = h[ho[1]]
+    for bus, gmlan in [(0, None), (1, False), (2, False), (1, True), (2, True)]:
       print("\ntest can", bus)
       # flush
       cans_echo = panda0.can_recv()
       cans_loop = panda1.can_recv()
 
-      # set GMLAN mode
-      if bus == 5:
-        panda0.set_gmlan(True,2)
-        panda1.set_gmlan(True,2)
-        bus = 1    # GMLAN is multiplexed with CAN2
-      elif bus == 6:
-        # on REV B panda, this just retests CAN2 GMLAN
-        panda0.set_gmlan(True,3)
-        panda1.set_gmlan(True,3)
-        bus = 4    # GMLAN is also multiplexed with CAN3
-      else:
-        panda0.set_gmlan(False)
-        panda1.set_gmlan(False)
+      if gmlan is not None:
+        panda0.set_gmlan(gmlan, bus)
+        panda1.set_gmlan(gmlan, bus)
 
       # send the characters
       # pick addresses high enough to not conflict with honda code
@@ -106,20 +102,23 @@ def run_test_w_pandas(pandas):
       assert cans_echo[0][2] == st
       assert cans_loop[0][2] == st
 
-      assert cans_echo[0][3] == bus+2
+      assert cans_echo[0][3] == 0x80 | bus
       if cans_loop[0][3] != bus:
         print("EXPECTED %d GOT %d" % (bus, cans_loop[0][3]))
       assert cans_loop[0][3] == bus
 
       print("CAN pass", bus, ho)
+      time.sleep(sleep_duration)
 
 if __name__ == "__main__":
-  if len(sys.argv) > 1:
-    for i in range(int(sys.argv[1])):
-      run_test()
-  else :
-    i = 0
+  parser = argparse.ArgumentParser()
+  parser.add_argument("-n", type=int, help="Number of test iterations to run")
+  parser.add_argument("-sleep", type=int, help="Sleep time between tests", default=0)
+  args = parser.parse_args()
+
+  if args.n is None:
     while True:
-      print("************* testing %d" % i)
-      run_test()
-      i += 1
+      run_test(sleep_duration=args.sleep)
+  else:
+    for i in range(args.n):
+      run_test(sleep_duration=args.sleep)


### PR DESCRIPTION
Can bus numbers are 7 bit numbers with the 8th bit marking receipt busses (0x80,0x81,0x82 not 2,3,6).
Clear can forwarding by setting to 0xFF.