### PR TITLE
Add board and boardesp to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
 language: python
 
+addons:
+  apt:
+    packages:
+    - gcc-arm-none-eabi
+    - libnewlib-arm-none-eabi
+    - gperf
+    - texinfo
+    - help2man
+
 script:
   - python setup.py install
+  - pushd board && make bin && popd
+  - pushd boardesp && git clone --recursive https://github.com/pfalcon/esp-open-sdk.git && pushd esp-open-sdk && git checkout 03f5e898a059451ec5f3de30e7feff30455f7cec && LD_LIBRARY_PATH="" make STANDALONE=y && popd && popd
+  - pushd boardesp && make proxy-0x00000.bin && popd

--- a/boardesp/Makefile
+++ b/boardesp/Makefile
@@ -19,7 +19,7 @@ flashall: user1.bin user2.bin
 proxy-0x00000.bin: proxy
 	../panda/esptool.py elf2image $^
 
-proxy: proxy.o
+proxy: proxy.o elm327.o webserver.o sha.o
 
 obj/proxy.o: proxy.c
 	$(CC) $(CFLAGS) -c $^ -o $@


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://travis-ci.org/gliptak/panda/builds/294507918 currently fails with:

```
esp-open-sdk/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc -Iinclude/ -I. -I../ -mlongcalls -Iesp-open-sdk/ESP8266_NONOS_SDK_V1.5.4_16_05_20/driver_lib/include -std=c99 -DICACHE_FLASH "-DALLOW_DEBUG"   -c -o webserver.o webserver.c

webserver.c:14:28: fatal error: obj/gitversion.h: No such file or directory

 #include "obj/gitversion.h"

                            ^

compilation terminated.

make: *** [webserver.o] Error 1
```
Where does ```gitversion.h``` load from?

Thanks