### PR TITLE
Cache crosstool-NG for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 
+cache:
+  directories:
+    - build/commaai/panda/boardesp/esp-open-sdk/crosstool-NG
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

The build time improved some, but reviewing the logs I still see compiles.

Maybe https://github.com/pfalcon/esp-open-sdk could be asked to publish (pre-compiled) releases?

https://github.com/commaai/panda/pull/63