### PR TITLE
Enable optimization to reduce firmware size

### DIFF
--- a/board/build.mk
+++ b/board/build.mk
@@ -1,4 +1,4 @@
-CFLAGS += -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -O0
+CFLAGS += -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -O2
 CFLAGS += -Tstm32_flash.ld
 
 CC = arm-none-eabi-gcc


### PR DESCRIPTION
With no optimization, Chevy Volt safety makes panda.bin larger than 32k and it no longer fits in a Panda.