### PR TITLE
can_printer.py bytearray encode error

### DIFF
--- a/tests/can_printer.py
+++ b/tests/can_printer.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 from collections import defaultdict
+import binascii
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), ".."))
 from panda import Panda
@@ -28,7 +29,7 @@ def can_printer():
     if sec_since_boot() - lp > 0.1:
       dd = chr(27) + "[2J"
       dd += "%5.2f\n" % (sec_since_boot() - start)
-      for k,v in sorted(zip(msgs.keys(), map(lambda x: str(x[-1]).encode("hex"), msgs.values()))):
+      for k,v in sorted(zip(msgs.keys(), map(lambda x: binascii.hexlify(x[-1]), msgs.values()))):
         dd += "%s(%6d) %s\n" % ("%04X(%4d)" % (k,k),len(msgs[k]), v)
       print(dd)
       lp = sec_since_boot()


### PR DESCRIPTION
This fixes the below error I was running into:
```
opening device 148013800f51363038363036 0xddcc
connected
Traceback (most recent call last):
  File "tests/can_printer.py", line 37, in <module>
    can_printer()
  File "tests/can_printer.py", line 31, in can_printer
    for k,v in sorted(zip(msgs.keys(), map(lambda x: x[-1].encode("hex"), msgs.values()))):
  File "tests/can_printer.py", line 31, in <lambda>
    for k,v in sorted(zip(msgs.keys(), map(lambda x: x[-1].encode("hex"), msgs.values()))):
AttributeError: 'bytearray' object has no attribute 'encode'
```