### PR TITLE
added link to wiki for user scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ And to send one on bus 0:
 ```
 >>> panda.can_send(0x1aa, "message", 0)
 ```
-More examples coming soon
+Find user made scripts on the [wiki](https://community.comma.ai/wiki/index.php/Panda_scripts)
 
 Software interface support
 ------


### PR DESCRIPTION
I think it's better if user made scripts were linked to on a wiki page instead of PRs to the examples folder in this repo