### PR TITLE
Update gas_interceptor_threshold due to experiments wth RDX and Odyssey

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -8,7 +8,7 @@
 //      brake > 0mph
 
 // these are set in the Honda safety hooks...this is the wrong place
-const int gas_interceptor_threshold = 328;
+const int gas_interceptor_threshold = 800;
 int gas_interceptor_detected = 0;
 int brake_prev = 0;
 int gas_prev = 0;


### PR DESCRIPTION
This new threshold value was arrived at through experimentation with the RDX and Odyssey. Values much lower than this would cause OP to suddenly disengage due to anomolies with the Gas Pedal analog readings. 