### PR TITLE
Add an alternate function to use GMLAN output on panda as a GPIO

### DIFF
--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -461,8 +461,6 @@ void CAN3_SCE_IRQHandler() { can_sce(CAN3); }
 
 #endif
 
-#include "gmlan_alt.h"
-
 void can_send(CAN_FIFOMailBox_TypeDef *to_push, uint8_t bus_number) {
   if (safety_tx_hook(to_push) && !can_autobaud_enabled[bus_number]) {
     if (bus_number < BUS_MAX) {

--- a/board/main.c
+++ b/board/main.c
@@ -4,6 +4,7 @@
 // ********************* includes *********************
 
 #include "libc.h"
+#include "safety.h"
 #include "provision.h"
 
 #include "drivers/drivers.h"
@@ -14,12 +15,11 @@
 #include "drivers/uart.h"
 #include "drivers/adc.h"
 #include "drivers/usb.h"
+#include "drivers/gmlan_alt.h"
+#include "drivers/can.h"
 #include "drivers/spi.h"
 #include "drivers/timer.h"
 
-#include "drivers/gmlan_alt.h"
-#include "safety.h"
-#include "drivers/can.h"
 
 // ***************************** fan *****************************
 

--- a/board/main.c
+++ b/board/main.c
@@ -4,7 +4,6 @@
 // ********************* includes *********************
 
 #include "libc.h"
-#include "safety.h"
 #include "provision.h"
 
 #include "drivers/drivers.h"
@@ -15,10 +14,12 @@
 #include "drivers/uart.h"
 #include "drivers/adc.h"
 #include "drivers/usb.h"
-#include "drivers/can.h"
 #include "drivers/spi.h"
 #include "drivers/timer.h"
 
+#include "drivers/gmlan_alt.h"
+#include "safety.h"
+#include "drivers/can.h"
 
 // ***************************** fan *****************************
 


### PR DESCRIPTION
This PR adds an alternate mode for the GMLAN output on the panda where it can be used as a general purpose output (set high or low). To accomplish this, a timer forces the GMLAN output low if every 15ms if the desired output is high to bypass the GMLAN transceiver hardware's 17ms timeout

```
gmlan_switch_init(0); //0 = timeout disabled; 1 = timeout enabled.
// With timeout enabled you need to call reset_gmlan_switch_timeout()
// faster than every 1s or the GPIO mode will be disabled

set_gmlan_digital_output(GMLAN_HIGH); //set output high
set_gmlan_digital_output(GMLAN_LOW); //set output low
```