### PR TITLE
optimize board build for size to avoid going over the limit.

### DIFF
--- a/board/build.mk
+++ b/board/build.mk
@@ -1,4 +1,4 @@
-CFLAGS += -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -O2
+CFLAGS += -I inc -I ../ -nostdlib -fno-builtin -std=gnu11 -Os
 
 CFLAGS += -Tstm32_flash.ld
 


### PR DESCRIPTION
Here are the sizes of board/obj/panda.bin with different settings:
-O2 32228
-Og 30172
-Os 28028