### PR TITLE
panda safety test that replays drives of saved CAN messages

### DIFF
--- a/tests/safety/trim_csv.py
+++ b/tests/safety/trim_csv.py
@@ -17,5 +17,5 @@ for line in fileinput.input():
     continue
   if (int(bus) == 128):  # Keep all messages sent by OpenPilot.
     print line
-  if (int(addr) in addr_to_keep):
+  elif (int(addr) in addr_to_keep):
     print line

--- a/tests/safety/trim_csv.py
+++ b/tests/safety/trim_csv.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python2
+
+# This trims CAN message CSV files to just the messages relevant for Panda testing.
+# Usage:
+# cat input.csv | ./trim_csv.py > output.csv
+import fileinput
+
+addr_to_keep = [544, 0x1f4, 0x292]  # For Chrysler, update to the addresses that matter for you.
+
+for line in fileinput.input():
+  line = line.strip()
+  cols = line.split(',')
+  if len(cols) != 4:
+    continue  # malformed, such as at the end or every 60s.
+  (_, addr, bus, _) = cols
+  if (addr == 'addr'):
+    continue
+  if (int(bus) == 128):  # Keep all messages sent by OpenPilot.
+    print line
+  if (int(addr) in addr_to_keep):
+    print line


### PR DESCRIPTION
I've found this super useful when working on the chrysler panda safety code.
In Cabana, download "Save Log" and then put it into the panda/tests/safety/ directory. Then run test.sh and it will fail if any of the transmitted messages are blocked by Panda's safety code.

Optionally use trim_csv.py to make your logs smaller.