### PR TITLE
add -lgcc flag to fix "undefined reference to __aeabi_llsr"

### DIFF
--- a/board/build.mk
+++ b/board/build.mk
@@ -55,7 +55,7 @@ obj/$(PROJ_NAME).bin: obj/$(STARTUP_FILE).o obj/main.$(PROJ_NAME).o
 
 
 obj/bootstub.$(PROJ_NAME).bin: obj/$(STARTUP_FILE).o obj/bootstub.$(PROJ_NAME).o obj/sha.$(PROJ_NAME).o obj/rsa.$(PROJ_NAME).o
-	$(CC) $(CFLAGS) -o obj/bootstub.$(PROJ_NAME).elf $^
+	$(CC) $(CFLAGS) -o obj/bootstub.$(PROJ_NAME).elf $^ -lgcc
 	$(OBJCOPY) -v -O binary obj/bootstub.$(PROJ_NAME).elf $@
 
 clean:


### PR DESCRIPTION
fixes https://github.com/commaai/openpilot/issues/522

The sizes look fine:
```
make clean && make recover; ls -l obj/bootstub.panda.*

with this pull request (-Os and -lgcc)
   8024 Feb  5 21:57 obj/bootstub.panda.bin
 182460 Feb  5 21:57 obj/bootstub.panda.elf
  60272 Feb  5 21:57 obj/bootstub.panda.o

original before the -Os commit (-O2 and no -lgcc)
   8988 Feb  5 22:00 obj/bootstub.panda.bin
 187596 Feb  5 22:00 obj/bootstub.panda.elf
  68400 Feb  5 22:00 obj/bootstub.panda.o
```

However I'm not sure how to test bootstub beyond using it to flash a Panda and seeing if the Panda works.

Saw this fix suggested here: https://stackoverflow.com/questions/23410221/linking-libgcc-into-a-nostdlib-compilation