### PR TITLE
chrysler: forward bus 0 to bus 2

### DIFF
--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -5,7 +5,7 @@ const int CHRYSLER_MAX_RATE_UP = 3;
 const int CHRYSLER_MAX_RATE_DOWN = 3;
 const int CHRYSLER_MAX_TORQUE_ERROR = 80;    // max torque cmd in excess of torque motor
 
-int chrysler_camera_detected = 0;
+int chrysler_camera_detected = 0;             // is giraffe switch 2 high?
 int chrysler_rt_torque_last = 0;
 int chrysler_desired_torque_last = 0;
 int chrysler_cruise_engaged_last = 0;
@@ -125,18 +125,26 @@ static int chrysler_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   return true;
 }
 
+static void chrysler_init(int16_t param) {
+  chrysler_camera_detected = 0;
+}
+
 static int chrysler_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
   int32_t addr = to_fwd->RIR >> 21;
   // forward CAN 0 -> 2 so stock LKAS camera sees messages
-  if (bus_num == 0 && addr != 0x2d9 && addr != 0x2a6 && addr != 0x292) {
+  if (bus_num == 0 && !chrysler_camera_detected) {
     return 2;
+  }
+  // forward LKAS_HEARTBIT message from stock camera
+  if (bus_num == 2 && !chrysler_camera_detected && addr == 0x2d9) {
+    return 0;
   }
   return -1;  // do not forward
 }
 
 
 const safety_hooks chrysler_hooks = {
-  .init = nooutput_init,
+  .init = chrysler_init,
   .rx = chrysler_rx_hook,
   .tx = chrysler_tx_hook,
   .tx_lin = nooutput_tx_lin_hook,

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -125,6 +125,15 @@ static int chrysler_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   return true;
 }
 
+static int chrysler_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
+  int32_t addr = to_fwd->RIR >> 21;
+  // forward CAN 0 -> 2 so stock LKAS camera sees messages
+  if (bus_num == 0 && addr != 0x2d9 && addr != 0x2a6 && addr != 0x292) {
+    return 2;
+  }
+  return -1;  // do not forward
+}
+
 
 const safety_hooks chrysler_hooks = {
   .init = nooutput_init,
@@ -132,5 +141,5 @@ const safety_hooks chrysler_hooks = {
   .tx = chrysler_tx_hook,
   .tx_lin = nooutput_tx_lin_hook,
   .ignition = default_ign_hook,
-  .fwd = nooutput_fwd_hook,
+  .fwd = chrysler_fwd_hook,
 };


### PR DESCRIPTION
This keeps the stock LKAS camera active so that we can copy data from its messages.

I'll open a PR in openpilot with code that uses this to support arbitrary Chrysler models, including 2019.