### PR TITLE
Lkas only safty mode

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -141,7 +141,7 @@ int safety_set_mode(uint16_t mode, int16_t param) {
 
 // compute the time elapsed (in microseconds) from 2 counter samples
 uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last) {
-  return ts > ts_last ? ts - ts_last : (0xFFFFFFFF - ts_last) + 1 + ts;
+  return ts >= ts_last ? ts - ts_last : (0xFFFFFFFF - ts_last) + 1 + ts;
 }
 
 // convert a trimmed integer to signed 32 bit int


### PR DESCRIPTION
Untested WIP

• detect stock long control if you see a long controls message on bus 0
• go back to op long controls after 1s of not seeing long controls messages