### PR TITLE
Toyota gas cancellation

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -46,6 +46,7 @@ typedef struct {
 // This can be set by the safety hooks.
 int controls_allowed = 0;
 int gas_interceptor_detected = 0;
+int gas_interceptor_prev = 0;
 
 // Include the actual safety policies.
 #include "safety/safety_defaults.h"

--- a/board/safety.h
+++ b/board/safety.h
@@ -104,7 +104,6 @@ typedef struct {
 #define SAFETY_SUBARU 10
 #define SAFETY_GM_ASCM 0x1334
 #define SAFETY_TOYOTA_IPAS 0x1335
-#define SAFETY_TOYOTA_NOLIMITS 0x1336
 #define SAFETY_ALLOUTPUT 0x1337
 #define SAFETY_ELM327 0xE327
 
@@ -119,7 +118,6 @@ const safety_hook_config safety_hook_registry[] = {
   {SAFETY_HYUNDAI, &hyundai_hooks},
   {SAFETY_CHRYSLER, &chrysler_hooks},
   {SAFETY_SUBARU, &subaru_hooks},
-  {SAFETY_TOYOTA_NOLIMITS, &toyota_nolimits_hooks},
   {SAFETY_TOYOTA_IPAS, &toyota_ipas_hooks},
   {SAFETY_GM_ASCM, &gm_ascm_hooks},
   {SAFETY_TESLA, &tesla_hooks},

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -7,12 +7,11 @@
 //      brake rising edge
 //      brake > 0mph
 
-const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 328;
+const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 328;  // ratio between offset and gain from dbc file
 int honda_brake_prev = 0;
 int honda_gas_prev = 0;
 int honda_gas_interceptor_prev = 0;
 int honda_ego_speed = 0;
-// TODO: auto-detect bosch hardware based on CAN messages?
 bool honda_bosch_hardware = false;
 bool honda_alt_brake_msg = false;
 

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -10,7 +10,6 @@
 const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 328;  // ratio between offset and gain from dbc file
 int honda_brake_prev = 0;
 int honda_gas_prev = 0;
-int honda_gas_interceptor_prev = 0;
 int honda_ego_speed = 0;
 bool honda_bosch_hardware = false;
 bool honda_alt_brake_msg = false;
@@ -58,10 +57,10 @@ static void honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     gas_interceptor_detected = 1;
     int gas_interceptor = ((to_push->RDLR & 0xFF) << 8) | ((to_push->RDLR & 0xFF00) >> 8);
     if ((gas_interceptor > HONDA_GAS_INTERCEPTOR_THRESHOLD) &&
-        (honda_gas_interceptor_prev <= HONDA_GAS_INTERCEPTOR_THRESHOLD)) {
+        (gas_interceptor_prev <= HONDA_GAS_INTERCEPTOR_THRESHOLD)) {
       controls_allowed = 0;
     }
-    honda_gas_interceptor_prev = gas_interceptor;
+    gas_interceptor_prev = gas_interceptor;
   }
 
   // exit controls on rising edge of gas press if no interceptor
@@ -86,7 +85,7 @@ static int honda_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
   // disallow actuator commands if gas or brake (with vehicle moving) are pressed
   // and the the latching controls_allowed flag is True
-  int pedal_pressed = honda_gas_prev || (honda_gas_interceptor_prev > HONDA_GAS_INTERCEPTOR_THRESHOLD) ||
+  int pedal_pressed = honda_gas_prev || (gas_interceptor_prev > HONDA_GAS_INTERCEPTOR_THRESHOLD) ||
                       (honda_brake_prev && honda_ego_speed);
   int current_controls_allowed = controls_allowed && !(pedal_pressed);
 

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -54,12 +54,15 @@ static void toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   if ((to_push->RIR>>21) == 0x1D2) {
     // 5th bit is CRUISE_ACTIVE
     int cruise_engaged = to_push->RDLR & 0x20;
-    if (cruise_engaged && !toyota_cruise_engaged_last) {
-      controls_allowed = 1;
-    } else if (!cruise_engaged) {
+    // 4th bit is GAS_RELEASED
+    int gas = !(to_push->RDLR & 0x10);
+    if (!cruise_engaged || (gas && !toyota_gas_prev && !gas_interceptor_detected)) {
       controls_allowed = 0;
+    } else if (cruise_engaged && !toyota_cruise_engaged_last) {
+      controls_allowed = 1;
     }
     toyota_cruise_engaged_last = cruise_engaged;
+    toyota_gas_prev = gas;
   }
 
   // exit controls on rising edge of gas press if interceptor (0x201)
@@ -71,17 +74,6 @@ static void toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       controls_allowed = 0;
     }
     toyota_gas_interceptor_prev = gas_interceptor;
-  }
-
-  // exit controls on rising edge of gas press if no interceptor
-  if (!gas_interceptor_detected) {
-    if ((to_push->RIR>>21) == 0x17C) {
-      int gas = to_push->RDLR & 0xFF;
-      if (gas && !(toyota_gas_prev)) {
-        controls_allowed = 0;
-      }
-      toyota_gas_prev = gas;
-    }
   }
 
   int bus = (to_push->RDTR >> 4) & 0xF;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -199,19 +199,3 @@ const safety_hooks toyota_hooks = {
   .ignition = default_ign_hook,
   .fwd = toyota_fwd_hook,
 };
-
-static void toyota_nolimits_init(int16_t param) {
-  controls_allowed = 0;
-  toyota_giraffe_switch_1 = 0;
-  toyota_camera_forwarded = 0;
-  toyota_dbc_eps_torque_factor = param;
-}
-
-const safety_hooks toyota_nolimits_hooks = {
-  .init = toyota_nolimits_init,
-  .rx = toyota_rx_hook,
-  .tx = toyota_tx_hook,
-  .tx_lin = nooutput_tx_lin_hook,
-  .ignition = default_ign_hook,
-  .fwd = toyota_fwd_hook,
-};

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -29,7 +29,6 @@ int toyota_rt_torque_last = 0;            // last desired torque for real time c
 uint32_t toyota_ts_last = 0;
 int toyota_cruise_engaged_last = 0;       // cruise state
 int toyota_gas_prev = 0;
-int toyota_gas_interceptor_prev = 0;
 struct sample_t toyota_torque_meas;       // last 3 motor torques produced by the eps
 
 
@@ -70,10 +69,10 @@ static void toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     gas_interceptor_detected = 1;
     int gas_interceptor = ((to_push->RDLR & 0xFF) << 8) | ((to_push->RDLR & 0xFF00) >> 8);
     if ((gas_interceptor > TOYOTA_GAS_INTERCEPTOR_THRESHOLD) &&
-        (toyota_gas_interceptor_prev <= TOYOTA_GAS_INTERCEPTOR_THRESHOLD)) {
+        (gas_interceptor_prev <= TOYOTA_GAS_INTERCEPTOR_THRESHOLD)) {
       controls_allowed = 0;
     }
-    toyota_gas_interceptor_prev = gas_interceptor;
+    gas_interceptor_prev = gas_interceptor;
   }
 
   int bus = (to_push->RDTR >> 4) & 0xF;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -1,6 +1,3 @@
-int toyota_giraffe_switch_1 = 0;          // is giraffe switch 1 high?
-int toyota_camera_forwarded = 0;          // should we forward the camera bus?
-
 // global torque limit
 const int TOYOTA_MAX_TORQUE = 1500;       // max torque cmd allowed ever
 
@@ -19,15 +16,20 @@ const int TOYOTA_RT_INTERVAL = 250000;    // 250ms between real time checks
 const int TOYOTA_MAX_ACCEL = 1500;        // 1.5 m/s2
 const int TOYOTA_MIN_ACCEL = -3000;       // 3.0 m/s2
 
-// global actuation limit state
-int toyota_actuation_limits = 1;          // by default steer limits are imposed
+const int TOYOTA_GAS_INTERCEPTOR_THRESHOLD = 475;  // ratio between offset and gain from dbc file
+
+// global actuation limit states
 int toyota_dbc_eps_torque_factor = 100;   // conversion factor for STEER_TORQUE_EPS in %: see dbc file
 
-// state of torque limits
+// states
+int toyota_giraffe_switch_1 = 0;          // is giraffe switch 1 high?
+int toyota_camera_forwarded = 0;          // should we forward the camera bus?
 int toyota_desired_torque_last = 0;       // last desired steer torque
 int toyota_rt_torque_last = 0;            // last desired torque for real time check
 uint32_t toyota_ts_last = 0;
 int toyota_cruise_engaged_last = 0;       // cruise state
+int toyota_gas_prev = 0;
+int toyota_gas_interceptor_prev = 0;
 struct sample_t toyota_torque_meas;       // last 3 motor torques produced by the eps
 
 
@@ -46,7 +48,6 @@ static void toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // increase torque_meas by 1 to be conservative on rounding
     toyota_torque_meas.min--;
     toyota_torque_meas.max++;
-
   }
 
   // enter controls on rising edge of ACC, exit controls on ACC off
@@ -59,6 +60,28 @@ static void toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       controls_allowed = 0;
     }
     toyota_cruise_engaged_last = cruise_engaged;
+  }
+
+  // exit controls on rising edge of gas press if interceptor (0x201)
+  if ((to_push->RIR>>21) == 0x201) {
+    gas_interceptor_detected = 1;
+    int gas_interceptor = ((to_push->RDLR & 0xFF) << 8) | ((to_push->RDLR & 0xFF00) >> 8);
+    if ((gas_interceptor > TOYOTA_GAS_INTERCEPTOR_THRESHOLD) &&
+        (toyota_gas_interceptor_prev <= TOYOTA_GAS_INTERCEPTOR_THRESHOLD)) {
+      controls_allowed = 0;
+    }
+    toyota_gas_interceptor_prev = gas_interceptor;
+  }
+
+  // exit controls on rising edge of gas press if no interceptor
+  if (!gas_interceptor_detected) {
+    if ((to_push->RIR>>21) == 0x17C) {
+      int gas = to_push->RDLR & 0xFF;
+      if (gas && !(toyota_gas_prev)) {
+        controls_allowed = 0;
+      }
+      toyota_gas_prev = gas;
+    }
   }
 
   int bus = (to_push->RDTR >> 4) & 0xF;
@@ -83,7 +106,7 @@ static int toyota_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
     // GAS PEDAL: safety check
     if ((to_send->RIR>>21) == 0x200) {
-      if (controls_allowed && toyota_actuation_limits) {
+      if (controls_allowed) {
         // all messages are fine here
       } else {
         if ((to_send->RDLR & 0xFFFF0000) != to_send->RDLR) return 0;
@@ -94,7 +117,7 @@ static int toyota_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
     if ((to_send->RIR>>21) == 0x343) {
       int desired_accel = ((to_send->RDLR & 0xFF) << 8) | ((to_send->RDLR >> 8) & 0xFF);
       desired_accel = to_signed(desired_accel, 16);
-      if (controls_allowed && toyota_actuation_limits) {
+      if (controls_allowed) {
         int violation = max_limit_check(desired_accel, TOYOTA_MAX_ACCEL, TOYOTA_MIN_ACCEL);
         if (violation) return 0;
       } else if (!controls_allowed && (desired_accel != 0)) {
@@ -110,8 +133,7 @@ static int toyota_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
       uint32_t ts = TIM2->CNT;
 
-      // only check if controls are allowed and actuation_limits are imposed
-      if (controls_allowed && toyota_actuation_limits) {
+      if (controls_allowed) {
 
         // *** global torque limit check ***
         violation |= max_limit_check(desired_torque, TOYOTA_MAX_TORQUE, -TOYOTA_MAX_TORQUE);
@@ -158,7 +180,6 @@ static int toyota_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
 static void toyota_init(int16_t param) {
   controls_allowed = 0;
-  toyota_actuation_limits = 1;
   toyota_giraffe_switch_1 = 0;
   toyota_camera_forwarded = 0;
   toyota_dbc_eps_torque_factor = param;
@@ -189,7 +210,6 @@ const safety_hooks toyota_hooks = {
 
 static void toyota_nolimits_init(int16_t param) {
   controls_allowed = 0;
-  toyota_actuation_limits = 0;
   toyota_giraffe_switch_1 = 0;
   toyota_camera_forwarded = 0;
   toyota_dbc_eps_torque_factor = param;

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -34,6 +34,7 @@ void set_controls_allowed(int c);
 int get_controls_allowed(void);
 void set_gas_interceptor_detected(int c);
 int get_gas_interceptor_detetcted(void);
+int get_gas_interceptor_prev(void);
 void set_timer(int t);
 void reset_angle_control(void);
 
@@ -44,7 +45,6 @@ void toyota_init(int16_t param);
 int get_toyota_torque_meas_min(void);
 int get_toyota_torque_meas_max(void);
 int get_toyota_gas_prev(void);
-int get_toyota_gas_interceptor_prev(void);
 void set_toyota_torque_meas(int min, int max);
 void set_toyota_desired_torque_last(int t);
 void set_toyota_rt_torque_last(int t);
@@ -56,7 +56,6 @@ void honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push);
 int honda_tx_hook(CAN_FIFOMailBox_TypeDef *to_send);
 int get_honda_brake_prev(void);
 int get_honda_gas_prev(void);
-int get_honda_gas_interceptor_prev(void);
 void set_honda_alt_brake_msg(bool);
 void set_honda_bosch_hardware(bool);
 

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -41,6 +41,8 @@ int toyota_tx_hook(CAN_FIFOMailBox_TypeDef *to_send);
 void toyota_init(int16_t param);
 int get_toyota_torque_meas_min(void);
 int get_toyota_torque_meas_max(void);
+int get_toyota_gas_prev(void);
+int get_toyota_gas_interceptor_prev(void);
 void set_toyota_torque_meas(int min, int max);
 void set_toyota_desired_torque_last(int t);
 void set_toyota_rt_torque_last(int t);
@@ -52,6 +54,7 @@ void honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push);
 int honda_tx_hook(CAN_FIFOMailBox_TypeDef *to_send);
 int get_honda_brake_prev(void);
 int get_honda_gas_prev(void);
+int get_honda_gas_interceptor_prev(void);
 void set_honda_alt_brake_msg(bool);
 void set_honda_bosch_hardware(bool);
 

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -32,6 +32,8 @@ typedef struct
 
 void set_controls_allowed(int c);
 int get_controls_allowed(void);
+void set_gas_interceptor_detected(int c);
+int get_gas_interceptor_detetcted(void);
 void set_timer(int t);
 void reset_angle_control(void);
 

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -203,7 +203,6 @@ void init_tests_toyota(void){
   toyota_desired_torque_last = 0;
   toyota_rt_torque_last = 0;
   toyota_ts_last = 0;
-  gas_interceptor_detected = 0;
   set_timer(0);
 }
 
@@ -254,7 +253,6 @@ void init_tests_subaru(void){
 
 void init_tests_honda(void){
   honda_ego_speed = 0;
-  gas_interceptor_detected = 0;
   honda_brake_prev = 0;
   honda_gas_prev = 0;
 }

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -51,12 +51,20 @@ void set_controls_allowed(int c){
   controls_allowed = c;
 }
 
+void set_gas_interceptor_detected(int c){
+  gas_interceptor_detected = c;
+}
+
 void reset_angle_control(void){
   angle_control = 0;
 }
 
 int get_controls_allowed(void){
   return controls_allowed;
+}
+
+int get_gas_interceptor_detected(void){
+  return gas_interceptor_detected;
 }
 
 void set_timer(int t){
@@ -99,6 +107,14 @@ int get_chrysler_torque_meas_min(void){
 
 int get_chrysler_torque_meas_max(void){
   return chrysler_torque_meas.max;
+}
+
+int get_toyota_gas_prev(void){
+  return toyota_gas_prev;
+}
+
+int get_toyota_gas_interceptor_prev(void){
+  return toyota_gas_interceptor_prev;
 }
 
 int get_toyota_torque_meas_min(void){
@@ -169,6 +185,10 @@ int get_honda_gas_prev(void){
   return honda_gas_prev;
 }
 
+int get_honda_gas_interceptor_prev(void){
+  return honda_gas_interceptor_prev;
+}
+
 void set_honda_alt_brake_msg(bool c){
   honda_alt_brake_msg = c;
 }
@@ -183,6 +203,7 @@ void init_tests_toyota(void){
   toyota_desired_torque_last = 0;
   toyota_rt_torque_last = 0;
   toyota_ts_last = 0;
+  gas_interceptor_detected = 0;
   set_timer(0);
 }
 

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -67,6 +67,10 @@ int get_gas_interceptor_detected(void){
   return gas_interceptor_detected;
 }
 
+int get_gas_interceptor_prev(void){
+  return gas_interceptor_prev;
+}
+
 void set_timer(int t){
   timer.CNT = t;
 }
@@ -111,10 +115,6 @@ int get_chrysler_torque_meas_max(void){
 
 int get_toyota_gas_prev(void){
   return toyota_gas_prev;
-}
-
-int get_toyota_gas_interceptor_prev(void){
-  return toyota_gas_interceptor_prev;
 }
 
 int get_toyota_torque_meas_min(void){
@@ -183,10 +183,6 @@ int get_honda_brake_prev(void){
 
 int get_honda_gas_prev(void){
   return honda_gas_prev;
-}
-
-int get_honda_gas_interceptor_prev(void){
-  return honda_gas_interceptor_prev;
 }
 
 void set_honda_alt_brake_msg(bool c){

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -53,9 +53,16 @@ class TestHondaSafety(unittest.TestCase):
 
     return to_send
 
-  def _send_gas_msg(self, gas):
+  def _send_interceptor_msg(self, gas):
     to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
     to_send[0].RIR = 0x200 << 21
+    to_send[0].RDLR = gas
+
+    return to_send
+
+  def _recv_interceptor_msg(self, gas):
+    to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
+    to_send[0].RIR = 0x201 << 21
     to_send[0].RDLR = gas
 
     return to_send
@@ -158,8 +165,10 @@ class TestHondaSafety(unittest.TestCase):
 
   def test_gas_safety_check(self):
     self.safety.set_controls_allowed(0)
-    self.assertTrue(self.safety.honda_tx_hook(self._send_gas_msg(0x0000)))
-    self.assertFalse(self.safety.honda_tx_hook(self._send_gas_msg(0x1000)))
+    self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0x0000)))
+    self.assertFalse(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000)))
+    self.safety.set_controls_allowed(1)
+    self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000)))
 
   def test_steer_safety_check(self):
     self.safety.set_controls_allowed(0)

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -181,7 +181,7 @@ class TestHondaSafety(unittest.TestCase):
     self.assertTrue(self.safety.honda_tx_hook(self._send_brake_msg(0x1000)))
     self.assertFalse(self.safety.honda_tx_hook(self._send_brake_msg(0x00F0)))
 
-  def test_gas_safety_check(self):
+  def test_gas_interceptor_safety_check(self):
     self.safety.set_controls_allowed(0)
     self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0, 0x200)))
     self.assertFalse(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000, 0x200)))

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -141,9 +141,9 @@ class TestHondaSafety(unittest.TestCase):
 
   def test_prev_gas_interceptor(self):
     self.safety.honda_rx_hook(self._send_interceptor_msg(0x0, 0x201))
-    self.assertFalse(self.safety.get_honda_gas_interceptor_prev())
+    self.assertFalse(self.safety.get_gas_interceptor_prev())
     self.safety.honda_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
-    self.assertTrue(self.safety.get_honda_gas_interceptor_prev())
+    self.assertTrue(self.safety.get_gas_interceptor_prev())
     self.safety.honda_rx_hook(self._send_interceptor_msg(0x0, 0x201))
     self.safety.set_gas_interceptor_detected(False)
 

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -53,18 +53,11 @@ class TestHondaSafety(unittest.TestCase):
 
     return to_send
 
-  def _send_interceptor_msg(self, gas):
+  def _send_interceptor_msg(self, gas, addr):
     to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
-    to_send[0].RIR = 0x200 << 21
-    to_send[0].RDLR = gas
-
-    return to_send
-
-  def _recv_interceptor_msg(self, gas):
-    to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
-    to_send[0].RIR = 0x201 << 21
-    to_send[0].RDLR = gas
+    to_send[0].RIR = addr << 21
     to_send[0].RDTR = 6
+    to_send[0].RDLR = ((gas & 0xff) << 8) | ((gas & 0xff00) >> 8)
 
     return to_send
 
@@ -147,10 +140,11 @@ class TestHondaSafety(unittest.TestCase):
     self.assertTrue(self.safety.get_honda_gas_prev())
 
   def test_prev_gas_interceptor(self):
-    self.safety.honda_rx_hook(self._recv_interceptor_msg(0x0))
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0x0, 0x201))
     self.assertFalse(self.safety.get_honda_gas_interceptor_prev())
-    self.safety.honda_rx_hook(self._recv_interceptor_msg(0x1000))
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
     self.assertTrue(self.safety.get_honda_gas_interceptor_prev())
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0x0, 0x201))
     self.safety.set_gas_interceptor_detected(False)
 
   def test_disengage_on_gas(self):
@@ -164,34 +158,35 @@ class TestHondaSafety(unittest.TestCase):
     self.safety.honda_rx_hook(self._gas_msg(1))
     self.assertTrue(self.safety.get_controls_allowed())
 
-  #def test_disengage_on_gas_interceptor(self):
-  #  self.safety.honda_rx_hook(self._recv_interceptor_msg(0))
-  #  self.safety.set_controls_allowed(1)
-  #  self.safety.honda_rx_hook(self._recv_interceptor_msg(0x1000))
-  #  self.assertFalse(self.safety.get_controls_allowed())
-  #  self.safety.set_gas_interceptor_detected(False)
+  def test_disengage_on_gas_interceptor(self):
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0, 0x201))
+    self.safety.set_controls_allowed(1)
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
+    self.assertFalse(self.safety.get_controls_allowed())
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0, 0x201))
+    self.safety.set_gas_interceptor_detected(False)
 
   def test_allow_engage_with_gas_interceptor_pressed(self):
-    self.safety.honda_rx_hook(self._recv_interceptor_msg(0x1000))
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
     self.safety.set_controls_allowed(1)
-    self.safety.honda_rx_hook(self._recv_interceptor_msg(0x1000))
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
     self.assertTrue(self.safety.get_controls_allowed())
+    self.safety.honda_rx_hook(self._send_interceptor_msg(0, 0x201))
     self.safety.set_gas_interceptor_detected(False)
 
   def test_brake_safety_check(self):
-    self.assertTrue(self.safety.honda_tx_hook(self._send_brake_msg(0x0000)))
+    self.assertTrue(self.safety.honda_tx_hook(self._send_brake_msg(0)))
     self.assertFalse(self.safety.honda_tx_hook(self._send_brake_msg(0x1000)))
-
     self.safety.set_controls_allowed(1)
     self.assertTrue(self.safety.honda_tx_hook(self._send_brake_msg(0x1000)))
     self.assertFalse(self.safety.honda_tx_hook(self._send_brake_msg(0x00F0)))
 
   def test_gas_safety_check(self):
     self.safety.set_controls_allowed(0)
-    self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0x0000)))
-    self.assertFalse(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000)))
+    self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0, 0x200)))
+    self.assertFalse(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000, 0x200)))
     self.safety.set_controls_allowed(1)
-    self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000)))
+    self.assertTrue(self.safety.honda_tx_hook(self._send_interceptor_msg(0x1000, 0x200)))
 
   def test_steer_safety_check(self):
     self.safety.set_controls_allowed(0)

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -167,9 +167,9 @@ class TestToyotaSafety(unittest.TestCase):
 
   def test_prev_gas_interceptor(self):
     self.safety.toyota_rx_hook(self._send_interceptor_msg(0x0, 0x201))
-    self.assertFalse(self.safety.get_toyota_gas_interceptor_prev())
+    self.assertFalse(self.safety.get_gas_interceptor_prev())
     self.safety.toyota_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
-    self.assertTrue(self.safety.get_toyota_gas_interceptor_prev())
+    self.assertTrue(self.safety.get_gas_interceptor_prev())
     self.safety.toyota_rx_hook(self._send_interceptor_msg(0x0, 0x201))
     self.safety.set_gas_interceptor_detected(False)
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -126,6 +126,14 @@ class TestToyotaSafety(unittest.TestCase):
 
     return to_send
 
+  def _send_interceptor_msg(self, gas, addr):
+    to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
+    to_send[0].RIR = addr << 21
+    to_send[0].RDTR = 6
+    to_send[0].RDLR = ((gas & 0xff) << 8) | ((gas & 0xff00) >> 8)
+
+    return to_send
+
   def _pcm_cruise_msg(self, cruise_on, gas_pressed):
     to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
     to_send[0].RIR = 0x1D2 << 21
@@ -157,6 +165,14 @@ class TestToyotaSafety(unittest.TestCase):
     self.safety.toyota_rx_hook(self._pcm_cruise_msg(False, True))
     self.assertTrue(self.safety.get_toyota_gas_prev())
 
+  def test_prev_gas_interceptor(self):
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0x0, 0x201))
+    self.assertFalse(self.safety.get_toyota_gas_interceptor_prev())
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
+    self.assertTrue(self.safety.get_toyota_gas_interceptor_prev())
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0x0, 0x201))
+    self.safety.set_gas_interceptor_detected(False)
+
   def test_disengage_on_gas(self):
     self.safety.toyota_rx_hook(self._pcm_cruise_msg(False, False))
     self.safety.toyota_rx_hook(self._pcm_cruise_msg(True, False))
@@ -170,6 +186,22 @@ class TestToyotaSafety(unittest.TestCase):
     self.assertTrue(self.safety.get_controls_allowed())
     self.safety.toyota_rx_hook(self._pcm_cruise_msg(True, True))
     self.assertTrue(self.safety.get_controls_allowed())
+
+  def test_disengage_on_gas_interceptor(self):
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0, 0x201))
+    self.safety.set_controls_allowed(1)
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
+    self.assertFalse(self.safety.get_controls_allowed())
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0, 0x201))
+    self.safety.set_gas_interceptor_detected(False)
+
+  def test_allow_engage_with_gas_interceptor_pressed(self):
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
+    self.safety.set_controls_allowed(1)
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0x1000, 0x201))
+    self.assertTrue(self.safety.get_controls_allowed())
+    self.safety.toyota_rx_hook(self._send_interceptor_msg(0, 0x201))
+    self.safety.set_gas_interceptor_detected(False)
 
   def test_accel_actuation_limits(self):
     for accel in np.arange(MIN_ACCEL - 1000, MAX_ACCEL + 1000, 100):
@@ -438,11 +470,12 @@ class TestToyotaSafety(unittest.TestCase):
     self.safety.reset_angle_control()
 
   def test_gas_safety_check(self):
+
     self.safety.set_controls_allowed(0)
-    self.assertTrue(self.safety.toyota_tx_hook(self._send_gas_msg(0x0000)))
-    self.assertFalse(self.safety.toyota_tx_hook(self._send_gas_msg(0x1000)))
+    self.assertTrue(self.safety.toyota_tx_hook(self._send_interceptor_msg(0, 0x200)))
+    self.assertFalse(self.safety.toyota_tx_hook(self._send_interceptor_msg(0x1000, 0x200)))
     self.safety.set_controls_allowed(1)
-    self.assertTrue(self.safety.toyota_tx_hook(self._send_gas_msg(0x1000)))
+    self.assertTrue(self.safety.toyota_tx_hook(self._send_interceptor_msg(0x1000, 0x200)))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -469,7 +469,7 @@ class TestToyotaSafety(unittest.TestCase):
     # reset no angle control at the end of the test
     self.safety.reset_angle_control()
 
-  def test_gas_safety_check(self):
+  def test_gas_interceptor_safety_check(self):
 
     self.safety.set_controls_allowed(0)
     self.assertTrue(self.safety.toyota_tx_hook(self._send_interceptor_msg(0, 0x200)))


### PR DESCRIPTION
- Added cancellation on gas pressed for Toyota
- minor nomenclature change
- fix bug in regression test (honda hook was called instead of toyota hook in gas interceptor test)
- added a complete set of tests to cover for gas interceptor
- remove unused TOYOTA_NOLIMITS safety mode