### PR TITLE
use __auto_type in max/min

### DIFF
--- a/board/config.h
+++ b/board/config.h
@@ -25,13 +25,13 @@
 #define COMPILE_TIME_ASSERT(pred) switch(0){case 0:case pred:;}
 
 #define min(a,b) \
- ({ __typeof__ (a) _a = (a); \
-     __typeof__ (b) _b = (b); \
+ ({ __auto_type _a = (a); \
+     __auto_type _b = (b); \
    _a < _b ? _a : _b; })
 
 #define max(a,b) \
- ({ __typeof__ (a) _a = (a); \
-     __typeof__ (b) _b = (b); \
+ ({ __auto_type _a = (a); \
+     __auto_type _b = (b); \
    _a > _b ? _a : _b; })
 
 #define MAX_RESP_LEN 0x40

--- a/boardesp/proxy.c
+++ b/boardesp/proxy.c
@@ -10,13 +10,13 @@
 #include "crypto/sha.h"
 
 #define min(a,b) \
- ({ __typeof__ (a) _a = (a); \
-     __typeof__ (b) _b = (b); \
+ ({ __auto_type _a = (a); \
+     __auto_type _b = (b); \
    _a < _b ? _a : _b; })
 
 #define max(a,b) \
- ({ __typeof__ (a) _a = (a); \
-     __typeof__ (b) _b = (b); \
+ ({ __auto_type _a = (a); \
+     __auto_type _b = (b); \
    _a > _b ? _a : _b; })
 
 char ssid[32];

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -32,14 +32,14 @@ struct sample_t subaru_torque_driver;
 TIM_TypeDef timer;
 TIM_TypeDef *TIM2 = &timer;
 
-#define min(a,b)                                \
-  ({ __typeof__ (a) _a = (a);                   \
-    __typeof__ (b) _b = (b);                    \
+#define min(a,b) \
+ ({ __auto_type _a = (a); \
+     __auto_type _b = (b); \
     _a < _b ? _a : _b; })
 
-#define max(a,b)                                \
-  ({ __typeof__ (a) _a = (a);                   \
-    __typeof__ (b) _b = (b);                    \
+#define max(a,b) \
+ ({ __auto_type _a = (a); \
+     __auto_type _b = (b); \
     _a > _b ? _a : _b; })
 
 


### PR DESCRIPTION
from doc:

> Using __auto_type instead of typeof has two advantages:
>
> - Each argument to the macro appears only once in the expansion of the macro. This prevents the size of the macro expansion growing exponentially when calls to such macros are nested inside arguments of such macros.
>
> - If the argument to the macro has variably modified type, it is evaluated only once when using __auto_type, but twice if typeof is used.