### PR TITLE
Misra 10.4 violations

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -78,11 +78,10 @@ const safety_hook_config safety_hook_registry[] = {
   {SAFETY_ELM327, &elm327_hooks},
 };
 
-#define HOOK_CONFIG_COUNT (sizeof(safety_hook_registry)/sizeof(safety_hook_config))
-
 int safety_set_mode(uint16_t mode, int16_t param) {
   int set_status = -1;   // not set
-  for (int i = 0; i < HOOK_CONFIG_COUNT; i++) {
+  int hook_config_count = sizeof(safety_hook_registry) / sizeof(safety_hook_config);
+  for (int i = 0; i < hook_config_count; i++) {
     if (safety_hook_registry[i].id == mode) {
       current_hooks = safety_hook_registry[i].hooks;
       set_status = 0;    // set
@@ -112,7 +111,8 @@ int to_signed(int d, int bits) {
 
 // given a new sample, update the smaple_t struct
 void update_sample(struct sample_t *sample, int sample_new) {
-  for (int i = sizeof(sample->values)/sizeof(sample->values[0]) - 1; i > 0; i--) {
+  int sample_size = sizeof(sample->values) / sizeof(sample->values[0]);
+  for (int i = sample_size - 1; i > 0; i--) {
     sample->values[i] = sample->values[i-1];
   }
   sample->values[0] = sample_new;
@@ -120,7 +120,7 @@ void update_sample(struct sample_t *sample, int sample_new) {
   // get the minimum and maximum measured samples
   sample->min = sample->values[0];
   sample->max = sample->values[0];
-  for (int i = 1; i < sizeof(sample->values) / sizeof(sample->values[0]); i++) {
+  for (int i = 1; i < sample_size; i++) {
     if (sample->values[i] < sample->min) {
       sample->min = sample->values[i];
     }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -1,6 +1,6 @@
 const int CHRYSLER_MAX_STEER = 261;
 const int CHRYSLER_MAX_RT_DELTA = 112;        // max delta torque allowed for real time checks
-const int32_t CHRYSLER_RT_INTERVAL = 250000;  // 250ms between real time checks
+const uint32_t CHRYSLER_RT_INTERVAL = 250000;  // 250ms between real time checks
 const int CHRYSLER_MAX_RATE_UP = 3;
 const int CHRYSLER_MAX_RATE_DOWN = 3;
 const int CHRYSLER_MAX_TORQUE_ERROR = 80;    // max torque cmd in excess of torque motor
@@ -26,7 +26,7 @@ static void chrysler_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   }
 
   // Measured eps torque
-  if (addr == 544) {
+  if (addr == 544U) {
     int rdhr = to_push->RDHR;
     int torque_meas_new = ((rdhr & 0x7) << 8) + ((rdhr & 0xFF00) >> 8) - 1024;
 
@@ -35,7 +35,7 @@ static void chrysler_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   }
 
   // enter controls on rising edge of ACC, exit controls on ACC off
-  if (addr == 0x1f4) {
+  if (addr == 0x1F4U) {
     int cruise_engaged = ((to_push->RDLR & 0x380000) >> 19) == 7;
     if (cruise_engaged && !chrysler_cruise_engaged_last) {
       controls_allowed = 1;
@@ -46,7 +46,7 @@ static void chrysler_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   }
 
   // check if stock camera ECU is still online
-  if ((bus == 0) && (addr == 0x292)) {
+  if ((bus == 0) && (addr == 0x292U)) {
     chrysler_camera_detected = 1;
     controls_allowed = 0;
   }
@@ -72,7 +72,7 @@ static int chrysler_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
 
   // LKA STEER
-  if (addr == 0x292) {
+  if (addr == 0x292U) {
     int rdlr = to_send->RDLR;
     int desired_torque = ((rdlr & 0x7) << 8) + ((rdlr & 0xFF00) >> 8) - 1024;
     uint32_t ts = TIM2->CNT;

--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -15,13 +15,13 @@ static int elm327_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   if ((to_send->RIR & 4) != 0) {
     uint32_t addr = to_send->RIR >> 3;
     //Check valid 29 bit send addresses for ISO 15765-4
-    if (!((addr == 0x18DB33F1) || ((addr & 0x1FFF00FF) == 0x18DA00F1))) {
+    if (!((addr == 0x18DB33F1U) || ((addr & 0x1FFF00FFU) == 0x18DA00F1U))) {
       tx = 0;
     }
   } else {
     uint32_t addr = to_send->RIR >> 21;
     //Check valid 11 bit send addresses for ISO 15765-4
-    if (!((addr == 0x7DF) || ((addr & 0x7F8) == 0x7E0))) {
+    if (!((addr == 0x7DFU) || ((addr & 0x7F8U) == 0x7E0U))) {
       tx = 0;
     }
   }
@@ -36,8 +36,8 @@ static int elm327_tx_lin_hook(int lin_num, uint8_t *data, int len) {
   if ((len < 5) || (len > 11)) {
     tx = 0;  //Valid KWP size
   }
-  if (!(((data[0] & 0xF8) == 0xC0) && ((data[0] & 0x07) > 0) &&
-        (data[1] == 0x33) && (data[2] == 0xF1))) {
+  if (!(((data[0] & 0xF8U) == 0xC0U) && ((data[0] & 0x07U) != 0U) &&
+        (data[1] == 0x33U) && (data[2] == 0xF1U))) {
     tx = 0;  //Bad msg
   }
   return tx;

--- a/board/safety/safety_gm_ascm.h
+++ b/board/safety/safety_gm_ascm.h
@@ -12,16 +12,16 @@ static int gm_ascm_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
     // block 0x152 and 0x154, which are the lkas command from ASCM1 and ASCM2
     // block 0x315 and 0x2cb, which are the brake and accel commands from ASCM1
     //if ((addr == 0x152) || (addr == 0x154) || (addr == 0x315) || (addr == 0x2cb)) {
-    if ((addr == 0x152) || (addr == 0x154)) {
+    if ((addr == 0x152U) || (addr == 0x154U)) {
       int supercruise_on = (to_fwd->RDHR>>4) & 0x1;  // bit 36
       if (!supercruise_on) {
         bus_fwd = -1;
       }
-    } else if ((addr == 0x151) || (addr == 0x153) || (addr == 0x314)) {
+    } else if ((addr == 0x151U) || (addr == 0x153U) || (addr == 0x314U)) {
       // on the chassis bus, the OBDII port is on the module side, so we need to read
       // the lkas messages sent by openpilot (put on unused 0x151 ane 0x153 addrs) and send it to
       // the actuator as 0x152 and 0x154
-      to_fwd->RIR = ((addr + 1) << 21) | (to_fwd->RIR & 0x1fffff);
+      to_fwd->RIR = ((addr + 1U) << 21) | (to_fwd->RIR & 0x1fffff);
     }
   }
 

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -1,6 +1,6 @@
 const int HYUNDAI_MAX_STEER = 255;             // like stock
 const int HYUNDAI_MAX_RT_DELTA = 112;          // max delta torque allowed for real time checks
-const int32_t HYUNDAI_RT_INTERVAL = 250000;    // 250ms between real time checks
+const uint32_t HYUNDAI_RT_INTERVAL = 250000;    // 250ms between real time checks
 const int HYUNDAI_MAX_RATE_UP = 3;
 const int HYUNDAI_MAX_RATE_DOWN = 7;
 const int HYUNDAI_DRIVER_TORQUE_ALLOWANCE = 50;
@@ -28,25 +28,25 @@ static void hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     addr = to_push->RIR >> 21;
   }
 
-  if (addr == 897) {
+  if (addr == 897U) {
     int torque_driver_new = ((to_push->RDLR >> 11) & 0xfff) - 2048;
     // update array of samples
     update_sample(&hyundai_torque_driver, torque_driver_new);
   }
 
   // check if stock camera ECU is still online
-  if ((bus == 0) && (addr == 832)) {
+  if ((bus == 0) && (addr == 832U)) {
     hyundai_camera_detected = 1;
     controls_allowed = 0;
   }
 
   // Find out which bus the camera is on
-  if (addr == 832) {
+  if (addr == 832U) {
     hyundai_camera_bus = bus;
   }
 
   // enter controls on rising edge of ACC, exit controls on ACC off
-  if (addr == 1057) {
+  if (addr == 1057U) {
     // 2 bits: 13-14
     int cruise_engaged = (to_push->RDLR >> 13) & 0x3;
     if (cruise_engaged && !hyundai_cruise_engaged_last) {
@@ -58,7 +58,7 @@ static void hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   }
 
   // 832 is lkas cmd. If it is on camera bus, then giraffe switch 2 is high
-  if ((addr == 832) && (bus == hyundai_camera_bus) && (hyundai_camera_bus != 0)) {
+  if ((addr == 832U) && (bus == hyundai_camera_bus) && (hyundai_camera_bus != 0)) {
     hyundai_giraffe_switch_2 = 1;
   }
 }
@@ -82,7 +82,7 @@ static int hyundai_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   }
 
   // LKA STEER: safety check
-  if (addr == 832) {
+  if (addr == 832U) {
     int desired_torque = ((to_send->RDLR >> 16) & 0x7ff) - 1024;
     uint32_t ts = TIM2->CNT;
     bool violation = 0;

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -2,7 +2,7 @@ const int SUBARU_MAX_STEER = 2047; // 1s
 // real time torque limit to prevent controls spamming
 // the real time limit is 1500/sec
 const int SUBARU_MAX_RT_DELTA = 940;          // max delta torque allowed for real time checks
-const int32_t SUBARU_RT_INTERVAL = 250000;    // 250ms between real time checks
+const uint32_t SUBARU_RT_INTERVAL = 250000;    // 250ms between real time checks
 const int SUBARU_MAX_RATE_UP = 50;
 const int SUBARU_MAX_RATE_DOWN = 70;
 const int SUBARU_DRIVER_TORQUE_ALLOWANCE = 60;
@@ -19,7 +19,7 @@ static void subaru_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   int bus_number = (to_push->RDTR >> 4) & 0xFF;
   uint32_t addr = to_push->RIR >> 21;
 
-  if ((addr == 0x119) && (bus_number == 0)){
+  if ((addr == 0x119U) && (bus_number == 0)){
     int torque_driver_new = ((to_push->RDLR >> 16) & 0x7FF);
     torque_driver_new = to_signed(torque_driver_new, 11);
     // update array of samples
@@ -27,7 +27,7 @@ static void subaru_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
   }
 
   // enter controls on rising edge of ACC, exit controls on ACC off
-  if ((addr == 0x240) && (bus_number == 0)) {
+  if ((addr == 0x240U) && (bus_number == 0)) {
     int cruise_engaged = (to_push->RDHR >> 9) & 1;
     if (cruise_engaged && !subaru_cruise_engaged_last) {
       controls_allowed = 1;
@@ -43,7 +43,7 @@ static int subaru_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   uint32_t addr = to_send->RIR >> 21;
 
   // steer cmd checks
-  if (addr == 0x122) {
+  if (addr == 0x122U) {
     int desired_torque = ((to_send->RDLR >> 16) & 0x1FFF);
     bool violation = 0;
     uint32_t ts = TIM2->CNT;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -10,7 +10,7 @@ const int TOYOTA_MAX_TORQUE_ERROR = 350;  // max torque cmd in excess of torque 
 // real time torque limit to prevent controls spamming
 // the real time limit is 1500/sec
 const int TOYOTA_MAX_RT_DELTA = 375;      // max delta torque allowed for real time checks
-const int TOYOTA_RT_INTERVAL = 250000;    // 250ms between real time checks
+const uint32_t TOYOTA_RT_INTERVAL = 250000;    // 250ms between real time checks
 
 // longitudinal limits
 const int TOYOTA_MAX_ACCEL = 1500;        // 1.5 m/s2


### PR DESCRIPTION
Both operands of an operator in which the usual arithmetic conversions are performed shall have the same essential type category