### PR TITLE
capitalize MIN and MAX macros

### DIFF
--- a/board/config.h
+++ b/board/config.h
@@ -24,12 +24,12 @@
 #define NULL ((void*)0)
 #define COMPILE_TIME_ASSERT(pred) switch(0){case 0:case pred:;}
 
-#define min(a,b) \
+#define MIN(a,b) \
  ({ __typeof__ (a) _a = (a); \
      __typeof__ (b) _b = (b); \
    _a < _b ? _a : _b; })
 
-#define max(a,b) \
+#define MAX(a,b) \
  ({ __typeof__ (a) _a = (a); \
      __typeof__ (b) _b = (b); \
    _a > _b ? _a : _b; })

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -433,7 +433,7 @@ void USB_WritePacket_EP0(uint8_t *src, uint16_t len) {
   hexdump(src, len);
   #endif
 
-  uint16_t wplen = min(len, 0x40);
+  uint16_t wplen = MIN(len, 0x40);
   USB_WritePacket(src, wplen, 0);
 
   if (wplen < len) {
@@ -545,29 +545,29 @@ void usb_setup() {
           //puts("    writing device descriptor\n");
 
           // setup transfer
-          USB_WritePacket(device_desc, min(sizeof(device_desc), setup.b.wLength.w), 0);
+          USB_WritePacket(device_desc, MIN(sizeof(device_desc), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
 
           //puts("D");
           break;
         case USB_DESC_TYPE_CONFIGURATION:
-          USB_WritePacket(configuration_desc, min(sizeof(configuration_desc), setup.b.wLength.w), 0);
+          USB_WritePacket(configuration_desc, MIN(sizeof(configuration_desc), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
           break;
         case USB_DESC_TYPE_DEVICE_QUALIFIER:
-          USB_WritePacket(device_qualifier, min(sizeof(device_qualifier), setup.b.wLength.w), 0);
+          USB_WritePacket(device_qualifier, MIN(sizeof(device_qualifier), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
           break;
         case USB_DESC_TYPE_STRING:
           switch (setup.b.wValue.bw.msb) {
             case STRING_OFFSET_LANGID:
-              USB_WritePacket((uint8_t*)string_language_desc, min(sizeof(string_language_desc), setup.b.wLength.w), 0);
+              USB_WritePacket((uint8_t*)string_language_desc, MIN(sizeof(string_language_desc), setup.b.wLength.w), 0);
               break;
             case STRING_OFFSET_IMANUFACTURER:
-              USB_WritePacket((uint8_t*)string_manufacturer_desc, min(sizeof(string_manufacturer_desc), setup.b.wLength.w), 0);
+              USB_WritePacket((uint8_t*)string_manufacturer_desc, MIN(sizeof(string_manufacturer_desc), setup.b.wLength.w), 0);
               break;
             case STRING_OFFSET_IPRODUCT:
-              USB_WritePacket((uint8_t*)string_product_desc, min(sizeof(string_product_desc), setup.b.wLength.w), 0);
+              USB_WritePacket((uint8_t*)string_product_desc, MIN(sizeof(string_product_desc), setup.b.wLength.w), 0);
               break;
             case STRING_OFFSET_ISERIAL:
               #ifdef UID_BASE
@@ -583,16 +583,16 @@ void usb_setup() {
                   resp[2 + i*4 + 3] = '\0';
                 }
 
-                USB_WritePacket(resp, min(resp[0], setup.b.wLength.w), 0);
+                USB_WritePacket(resp, MIN(resp[0], setup.b.wLength.w), 0);
               #else
-                USB_WritePacket((const uint8_t *)string_serial_desc, min(sizeof(string_serial_desc), setup.b.wLength.w), 0);
+                USB_WritePacket((const uint8_t *)string_serial_desc, MIN(sizeof(string_serial_desc), setup.b.wLength.w), 0);
               #endif
               break;
             case STRING_OFFSET_ICONFIGURATION:
-              USB_WritePacket((uint8_t*)string_configuration_desc, min(sizeof(string_configuration_desc), setup.b.wLength.w), 0);
+              USB_WritePacket((uint8_t*)string_configuration_desc, MIN(sizeof(string_configuration_desc), setup.b.wLength.w), 0);
               break;
             case 238:
-              USB_WritePacket((uint8_t*)string_238_desc, min(sizeof(string_238_desc), setup.b.wLength.w), 0);
+              USB_WritePacket((uint8_t*)string_238_desc, MIN(sizeof(string_238_desc), setup.b.wLength.w), 0);
               break;
             default:
               // nothing
@@ -602,7 +602,7 @@ void usb_setup() {
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
           break;
         case USB_DESC_TYPE_BINARY_OBJECT_STORE:
-          USB_WritePacket(binary_object_store_desc, min(sizeof(binary_object_store_desc), setup.b.wLength.w), 0);
+          USB_WritePacket(binary_object_store_desc, MIN(sizeof(binary_object_store_desc), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
           break;
         default:
@@ -628,7 +628,7 @@ void usb_setup() {
     case WEBUSB_VENDOR_CODE:
       switch (setup.b.wIndex.w) {
         case WEBUSB_REQ_GET_URL:
-          USB_WritePacket(webusb_url_descriptor, min(sizeof(webusb_url_descriptor), setup.b.wLength.w), 0);
+          USB_WritePacket(webusb_url_descriptor, MIN(sizeof(webusb_url_descriptor), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
           break;
         default:
@@ -642,15 +642,15 @@ void usb_setup() {
       switch (setup.b.wIndex.w) {
         // winusb 2.0 descriptor from BOS
         case WINUSB_REQ_GET_DESCRIPTOR:
-          USB_WritePacket_EP0((uint8_t*)winusb_20_desc, min(sizeof(winusb_20_desc), setup.b.wLength.w));
+          USB_WritePacket_EP0((uint8_t*)winusb_20_desc, MIN(sizeof(winusb_20_desc), setup.b.wLength.w));
           break;
         // Extended Compat ID OS Descriptor
         case WINUSB_REQ_GET_COMPATID_DESCRIPTOR:
-          USB_WritePacket_EP0((uint8_t*)winusb_ext_compatid_os_desc, min(sizeof(winusb_ext_compatid_os_desc), setup.b.wLength.w));
+          USB_WritePacket_EP0((uint8_t*)winusb_ext_compatid_os_desc, MIN(sizeof(winusb_ext_compatid_os_desc), setup.b.wLength.w));
           break;
         // Extended Properties OS Descriptor
         case WINUSB_REQ_GET_EXT_PROPS_OS:
-          USB_WritePacket_EP0((uint8_t*)winusb_ext_prop_os_desc, min(sizeof(winusb_ext_prop_os_desc), setup.b.wLength.w));
+          USB_WritePacket_EP0((uint8_t*)winusb_ext_prop_os_desc, MIN(sizeof(winusb_ext_prop_os_desc), setup.b.wLength.w));
           break;
         default:
           USB_WritePacket_EP0(0, 0);
@@ -658,7 +658,7 @@ void usb_setup() {
       break;
     default:
       resp_len = usb_cb_control_msg(&setup, resp, 1);
-      USB_WritePacket(resp, min(resp_len, setup.b.wLength.w), 0);
+      USB_WritePacket(resp, MIN(resp_len, setup.b.wLength.w), 0);
       USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
   }
 }
@@ -972,7 +972,7 @@ void usb_irqhandler(void) {
       #endif
 
       if (ep0_txlen != 0 && (USBx_INEP(0)->DTXFSTS & USB_OTG_DTXFSTS_INEPTFSAV) >= 0x40) {
-        uint16_t len = min(ep0_txlen, 0x40);
+        uint16_t len = MIN(ep0_txlen, 0x40);
         USB_WritePacket(ep0_txdata, len, 0);
         ep0_txdata += len;
         ep0_txlen -= len;

--- a/board/main.c
+++ b/board/main.c
@@ -142,7 +142,7 @@ int get_health_pkt(void *dat) {
 int usb_cb_ep1_in(uint8_t *usbdata, int len, int hardwired) {
   CAN_FIFOMailBox_TypeDef *reply = (CAN_FIFOMailBox_TypeDef *)usbdata;
   int ilen = 0;
-  while (ilen < min(len/0x10, 4) && can_pop(&can_rx_q, &reply[ilen])) ilen++;
+  while (ilen < MIN(len/0x10, 4) && can_pop(&can_rx_q, &reply[ilen])) ilen++;
   return ilen*0x10;
 }
 
@@ -337,7 +337,7 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, int hardwired) {
       if (!ur) break;
       if (ur == &esp_ring) uart_dma_drain();
       // read
-      while ((resp_len < min(setup->b.wLength.w, MAX_RESP_LEN)) &&
+      while ((resp_len < MIN(setup->b.wLength.w, MAX_RESP_LEN)) &&
                          getc(ur, (char*)&resp[resp_len])) {
         ++resp_len;
       }

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -56,7 +56,7 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, int hardwired) {
       if (!ur) break;
       if (ur == &esp_ring) uart_dma_drain();
       // read
-      while ((resp_len < min(setup->b.wLength.w, MAX_RESP_LEN)) &&
+      while ((resp_len < MIN(setup->b.wLength.w, MAX_RESP_LEN)) &&
                          getc(ur, (char*)&resp[resp_len])) {
         ++resp_len;
       }
@@ -246,8 +246,8 @@ void pedal() {
 
   // write the pedal to the DAC
   if (state == NO_FAULT) {
-    dac_set(0, max(gas_set_0, pdl0));
-    dac_set(1, max(gas_set_1, pdl1));
+    dac_set(0, MAX(gas_set_0, pdl0));
+    dac_set(1, MAX(gas_set_1, pdl1));
   } else {
     dac_set(0, pdl0);
     dac_set(1, pdl1);

--- a/board/safety.h
+++ b/board/safety.h
@@ -103,8 +103,8 @@ uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last) {
 // convert a trimmed integer to signed 32 bit int
 int to_signed(int d, int bits) {
   int d_signed = d;
-  if (d >= (1 << max((bits - 1), 0))) {
-    d_signed = d - (1 << max(bits, 0));
+  if (d >= (1 << MAX((bits - 1), 0))) {
+    d_signed = d - (1 << MAX(bits, 0));
   }
   return d_signed;
 }
@@ -139,12 +139,12 @@ bool dist_to_meas_check(int val, int val_last, struct sample_t *val_meas,
   const int MAX_RATE_UP, const int MAX_RATE_DOWN, const int MAX_ERROR) {
 
   // *** val rate limit check ***
-  int highest_allowed_val = max(val_last, 0) + MAX_RATE_UP;
-  int lowest_allowed_val = min(val_last, 0) - MAX_RATE_UP;
+  int highest_allowed_val = MAX(val_last, 0) + MAX_RATE_UP;
+  int lowest_allowed_val = MIN(val_last, 0) - MAX_RATE_UP;
 
   // if we've exceeded the meas val, we must start moving toward 0
-  highest_allowed_val = min(highest_allowed_val, max(val_last - MAX_RATE_DOWN, max(val_meas->max, 0) + MAX_ERROR));
-  lowest_allowed_val = max(lowest_allowed_val, min(val_last + MAX_RATE_DOWN, min(val_meas->min, 0) - MAX_ERROR));
+  highest_allowed_val = MIN(highest_allowed_val, MAX(val_last - MAX_RATE_DOWN, MAX(val_meas->max, 0) + MAX_ERROR));
+  lowest_allowed_val = MAX(lowest_allowed_val, MIN(val_last + MAX_RATE_DOWN, MIN(val_meas->min, 0) - MAX_ERROR));
 
   // check for violation
   return (val < lowest_allowed_val) || (val > highest_allowed_val);
@@ -155,17 +155,17 @@ bool driver_limit_check(int val, int val_last, struct sample_t *val_driver,
   const int MAX, const int MAX_RATE_UP, const int MAX_RATE_DOWN,
   const int MAX_ALLOWANCE, const int DRIVER_FACTOR) {
 
-  int highest_allowed = max(val_last, 0) + MAX_RATE_UP;
-  int lowest_allowed = min(val_last, 0) - MAX_RATE_UP;
+  int highest_allowed = MAX(val_last, 0) + MAX_RATE_UP;
+  int lowest_allowed = MIN(val_last, 0) - MAX_RATE_UP;
 
   int driver_max_limit = MAX + (MAX_ALLOWANCE + val_driver->max) * DRIVER_FACTOR;
   int driver_min_limit = -MAX + (-MAX_ALLOWANCE + val_driver->min) * DRIVER_FACTOR;
 
   // if we've exceeded the applied torque, we must start moving toward 0
-  highest_allowed = min(highest_allowed, max(val_last - MAX_RATE_DOWN,
-                                             max(driver_max_limit, 0)));
-  lowest_allowed = max(lowest_allowed, min(val_last + MAX_RATE_DOWN,
-                                           min(driver_min_limit, 0)));
+  highest_allowed = MIN(highest_allowed, MAX(val_last - MAX_RATE_DOWN,
+                                             MAX(driver_max_limit, 0)));
+  lowest_allowed = MAX(lowest_allowed, MIN(val_last + MAX_RATE_DOWN,
+                                           MIN(driver_min_limit, 0)));
 
   // check for violation
   return (val < lowest_allowed) || (val > highest_allowed);
@@ -176,8 +176,8 @@ bool driver_limit_check(int val, int val_last, struct sample_t *val_driver,
 bool rt_rate_limit_check(int val, int val_last, const int MAX_RT_DELTA) {
 
   // *** torque real time rate limit check ***
-  int highest_val = max(val_last, 0) + MAX_RT_DELTA;
-  int lowest_val = min(val_last, 0) - MAX_RT_DELTA;
+  int highest_val = MAX(val_last, 0) + MAX_RT_DELTA;
+  int lowest_val = MIN(val_last, 0) - MAX_RT_DELTA;
 
   // check for violation
   return (val < lowest_val) || (val > highest_val);

--- a/board/safety/safety_cadillac.h
+++ b/board/safety/safety_cadillac.h
@@ -20,7 +20,7 @@ int cadillac_supercruise_on = 0;
 struct sample_t cadillac_torque_driver;         // last few driver torques measured
 
 int cadillac_get_torque_idx(int addr, int array_size) {
-  return min(max(addr - 0x151, 0), array_size);  // 0x151 is id 0, 0x152 is id 1 and so on...
+  return MIN(MAX(addr - 0x151, 0), array_size);  // 0x151 is id 0, 0x152 is id 1 and so on...
 }
 
 static void cadillac_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {

--- a/boardesp/elm327.c
+++ b/boardesp/elm327.c
@@ -10,8 +10,8 @@
 
 //#define ELM_DEBUG
 
-#define min(a,b) ((a) < (b) ? (a) : (b))
-#define max(a,b) ((a) > (b) ? (a) : (b))
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
 int ICACHE_FLASH_ATTR spi_comm(char *dat, int len, uint32_t *recvData, int recvDataLen);
 
 #define ELM_PORT 35000
@@ -855,7 +855,7 @@ static void ICACHE_FLASH_ATTR elm_process_obd_cmd_LINFast(const elm_protocol_t* 
 
     panda_kline_wakeup_pulse();
   } else {
-    bytelen = min(bytelen, 7);
+    bytelen = MIN(bytelen, 7);
     for(int i = 0; i < bytelen; i++){
       msg.dat[i] = elm_decode_hex_byte(&cmd[i*2]);
       msg.dat[bytelen] += msg.dat[i];
@@ -1059,7 +1059,7 @@ static void ICACHE_FLASH_ATTR elm_process_obd_cmd_ISO15765(const elm_protocol_t*
     return;
   }
 
-  msg.len = min(msg.len, 7);
+  msg.len = MIN(msg.len, 7);
 
   for(int i = 0; i < msg.len; i++)
     msg.dat[i] = elm_decode_hex_byte(&cmd[i*2]);
@@ -1398,7 +1398,7 @@ static void ICACHE_FLASH_ATTR elm_process_at_cmd(char *cmd, uint16_t len) {
     }
 
     tmp = elm_decode_hex_byte(&cmd[2]);
-    elm_mode_keepalive_period = tmp ? max(tmp, 0x20) * 20 : 0;
+    elm_mode_keepalive_period = tmp ? MAX(tmp, 0x20) * 20 : 0;
 
     if(lin_bus_initialized){
       os_timer_disarm(&elm_proto_aux_timeout);

--- a/boardesp/proxy.c
+++ b/boardesp/proxy.c
@@ -9,12 +9,12 @@
 #include "driver/uart.h"
 #include "crypto/sha.h"
 
-#define min(a,b) \
+#define MIN(a,b) \
  ({ __typeof__ (a) _a = (a); \
      __typeof__ (b) _b = (b); \
    _a < _b ? _a : _b; })
 
-#define max(a,b) \
+#define MAX(a,b) \
  ({ __typeof__ (a) _a = (a); \
      __typeof__ (b) _b = (b); \
    _a > _b ? _a : _b; })

--- a/boardesp/webserver.c
+++ b/boardesp/webserver.c
@@ -14,8 +14,8 @@
 #include "obj/gitversion.h"
 #include "obj/cert.h"
 
-#define max(a,b) ((a) > (b) ? (a) : (b))
-#define min(a,b) ((a) < (b) ? (a) : (b))
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
 #define espconn_send_string(conn, x) espconn_send(conn, x, strlen(x))
 
 #define MAX_RESP 0x800
@@ -116,7 +116,7 @@ void ICACHE_FLASH_ATTR st_flash() {
     // real content length will always be 0x10 aligned
     os_printf("st_flash: flashing\n");
     for (int i = 0; i < real_content_length; i += 0x10) {
-      int rl = min(0x10, real_content_length-i);
+      int rl = MIN(0x10, real_content_length-i);
       usb_cmd(2, rl, 0, 0, 0, &st_firmware[i]);
       system_soft_wdt_feed();
     }
@@ -288,7 +288,7 @@ static void ICACHE_FLASH_ATTR web_rx_cb(void *arg, char *data, uint16_t len) {
     }
   } else if (state == RECEIVING_ST_FIRMWARE) {
     os_printf("receiving st firmware: %d/%d\n", len, content_length);
-    memcpy(st_firmware_ptr, data, min(content_length, len));
+    memcpy(st_firmware_ptr, data, MIN(content_length, len));
     st_firmware_ptr += len;
     content_length -= len;
 
@@ -333,7 +333,7 @@ static void ICACHE_FLASH_ATTR web_rx_cb(void *arg, char *data, uint16_t len) {
         SHA_init(&ctx);
         for (ll = start_address; ll < esp_address-RSANUMBYTES; ll += 0x80) {
           spi_flash_read(ll, dat, 0x80);
-          SHA_update(&ctx, dat, min((esp_address-RSANUMBYTES)-ll, 0x80));
+          SHA_update(&ctx, dat, MIN((esp_address-RSANUMBYTES)-ll, 0x80));
         }
         memcpy(digest, SHA_final(&ctx), SHA_DIGEST_SIZE);
 

--- a/drivers/windows/pandaJ2534DLL/MessageRx.h
+++ b/drivers/windows/pandaJ2534DLL/MessageRx.h
@@ -21,7 +21,7 @@ public:
 		}
 
 		this->next_part = (this->next_part + 1) % 0x10;
-		unsigned int payload_len = min(expected_size - msg.size(), max_packet_size);
+		unsigned int payload_len = MIN(expected_size - msg.size(), max_packet_size);
 		if (piece.size() < payload_len) {
 			//A frame was received that could have held more data.
 			//No examples of this protocol show that happening, so

--- a/drivers/windows/pandaJ2534DLL/PandaJ2534Device.cpp
+++ b/drivers/windows/pandaJ2534DLL/PandaJ2534Device.cpp
@@ -170,7 +170,7 @@ DWORD PandaJ2534Device::msg_tx_thread() {
 				} else { //Ran out of things that need to be sent now. Sleep!
 					auto time_diff = std::chrono::duration_cast<std::chrono::milliseconds>
 						(this->task_queue.front()->expire - std::chrono::steady_clock::now());
-					sleepDuration = max(1, time_diff.count());
+					sleepDuration = MAX(1, time_diff.count());
 					goto break_flow_ctrl_loop;
 				}
 			}

--- a/python/esptool.py
+++ b/python/esptool.py
@@ -1216,7 +1216,7 @@ def main():
     operation_func = globals()[args.operation]
     operation_args,_,_,_ = inspect.getargspec(operation_func)
     if operation_args[0] == 'esp':  # operation function takes an ESPROM connection object
-        initial_baud = min(ESPROM.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
+        initial_baud = MIN(ESPROM.ESP_ROM_BAUD, args.baud)  # don't sync faster than the default baud rate
         esp = ESPROM(args.port, initial_baud)
         esp.connect()
         operation_func(esp, args)

--- a/tests/elm_car_simulator.py
+++ b/tests/elm_car_simulator.py
@@ -152,7 +152,7 @@ class ELMCarSimulator():
             if len(outmsg) <= 5:
                 self._lin_send(0x10, obd_header + outmsg)
             else:
-                first_msg_len = min(4, len(outmsg)%4) or 4
+                first_msg_len = MIN(4, len(outmsg)%4) or 4
                 self._lin_send(0x10, obd_header + b'\x01' +
                                b'\x00'*(4-first_msg_len) +
                                outmsg[:first_msg_len])
@@ -229,7 +229,7 @@ class ELMCarSimulator():
                 outaddr = 0x7E8 if address == 0x7DF or address == 0x7E0 else 0x18DAF110
                 msgnum = 1
                 while(self.__can_multipart_data):
-                    datalen = min(7, len(self.__can_multipart_data))
+                    datalen = MIN(7, len(self.__can_multipart_data))
                     msgpiece = struct.pack("B", 0x20 | msgnum) + self.__can_multipart_data[:datalen]
                     self._can_send(outaddr, msgpiece)
                     self.__can_multipart_data = self.__can_multipart_data[7:]
@@ -246,7 +246,7 @@ class ELMCarSimulator():
                     self._can_send(outaddr,
                                    struct.pack("BBB", len(outmsg)+2, 0x40|data[1], pid) + outmsg)
                 else:
-                    first_msg_len = min(3, len(outmsg)%7)
+                    first_msg_len = MIN(3, len(outmsg)%7)
                     payload_len = len(outmsg)+3
                     msgpiece = struct.pack("BBBBB", 0x10 | ((payload_len>>8)&0xF),
                                            payload_len&0xFF,

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -32,12 +32,12 @@ struct sample_t subaru_torque_driver;
 TIM_TypeDef timer;
 TIM_TypeDef *TIM2 = &timer;
 
-#define min(a,b)                                \
+#define MIN(a,b)                                \
   ({ __typeof__ (a) _a = (a);                   \
     __typeof__ (b) _b = (b);                    \
     _a < _b ? _a : _b; })
 
-#define max(a,b)                                \
+#define MAX(a,b)                                \
   ({ __typeof__ (a) _a = (a);                   \
     __typeof__ (b) _b = (b);                    \
     _a > _b ? _a : _b; })


### PR DESCRIPTION
Resolves some Misra violations, since `min` and `max` are also used in the def of a strcut.