### PR TITLE
Flash error handling

### DIFF
--- a/board/build.mk
+++ b/board/build.mk
@@ -33,7 +33,7 @@ POSTCOMPILE = @mv -f $(DEPDIR)/$*.Td $(DEPDIR)/$*.d && touch $@
 
 # this no longer pushes the bootstub
 flash: obj/$(PROJ_NAME).bin
-	PYTHONPATH=../ python -c "from python import Panda; Panda().flash('obj/$(PROJ_NAME).bin')"
+	PYTHONPATH=../ python -c "from python import Panda; Panda().flash(fn='obj/$(PROJ_NAME).bin')"
 
 ota: obj/$(PROJ_NAME).bin
 	curl http://192.168.0.10/stupdate --upload-file $<

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -304,7 +304,7 @@ class Panda(object):
     dfu.recover()
 
     # reflash after recover
-    self.connect(True, True)
+    self.connect(wait=True)
     self.flash()
     return True
 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -27,7 +27,7 @@ DEBUG = os.getenv("PANDADEBUG") is not None
 def build_st(target, mkfile="Makefile"):
   from panda import BASEDIR
   CWD = os.path.join(BASEDIR, "board")
-  cmd = 'make -f %s clean && make -f %s %s >/dev/null' % (mkfile, mkfile, target)
+  cmd = 'make -f %s clean >/dev/null && make -f %s %s >/dev/null' % (mkfile, mkfile, target)
   try:
     output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True, cwd=CWD)
   except subprocess.CalledProcessError as exception:
@@ -258,9 +258,11 @@ class Panda(object):
       self.reset(enter_bootstub=True)
     assert(self.bootstub)
 
-    build_error = False
-    if fn is None and code is None:
+    if fn is None:
       fn = "obj/panda.bin"
+
+    build_error = False
+    if code is None:
       print("building panda st code")
       build_error = build_st(fn)
 
@@ -271,7 +273,6 @@ class Panda(object):
 
       fn = os.path.join(BASEDIR, "board", fn)
 
-    if code is None:
       try:
         with open(fn) as f:
           code = f.read()

--- a/python/dfu.py
+++ b/python/dfu.py
@@ -95,20 +95,20 @@ class PandaDFU(object):
 
   def recover(self):
     from panda import BASEDIR, build_st
-    if self.legacy:
-      fn = "obj/bootstub.comma.bin"
-      print("building legacy bootstub")
-      build_st(fn, "Makefile.legacy")
-    else:
-      fn = "obj/bootstub.panda.bin"
-      print("building panda bootstub")
-      build_st(fn)
+    fn = "obj/bootstub.panda.bin"
+    print("building panda bootstub")
+    build_error = build_st(fn)
     fn = os.path.join(BASEDIR, "board", fn)
+    try:
+      with open(fn) as f:
+        code = f.read()
+    except Exception:
+      pass
 
-    with open(fn) as f:
-      code = f.read()
-
-    self.program_bootstub(code)
+    if not bool(build_error):
+      self.program_bootstub(code)
+    else:
+      print("build failed")
 
   def reset(self):
     # **** Reset ****

--- a/python/update.py
+++ b/python/update.py
@@ -6,13 +6,12 @@ def ensure_st_up_to_date():
   from panda import Panda, PandaDFU, BASEDIR
 
   with open(os.path.join(BASEDIR, "VERSION")) as f:
-    repo_version = f.read()
+    repo_version = f.read().strip()
 
   repo_version += "-EON" if os.path.isfile('/EON') else "-DEV"
 
   panda = None
   panda_dfu = None
-  should_flash_recover = False
 
   while 1:
     # break on normal mode Panda
@@ -30,10 +29,12 @@ def ensure_st_up_to_date():
     print "waiting for board..."
     time.sleep(1)
 
-  if panda.bootstub or not panda.get_version().startswith(repo_version):
+  # entered from bootloader, dfu already flashed
+  if panda.bootstub and (panda_dfu is not None):
     panda.flash()
 
-  if panda.bootstub:
+  # flash everything
+  if panda.bootstub or not panda.get_version().startswith(repo_version):
     panda.recover()
 
   assert(not panda.bootstub)

--- a/tests/automated/0_builds.py
+++ b/tests/automated/0_builds.py
@@ -2,8 +2,11 @@ import os
 from panda import build_st
 
 def test_build_panda():
-  build_st("obj/panda.bin")
+  build_error = build_st("obj/panda.bin")
+  if build_error:
+    raise Exception(build_error)
 
 def test_build_bootstub_panda():
-  build_st("obj/bootstub.panda.bin")
-
+  build_error = build_st("obj/bootstub.panda.bin")
+  if build_error:
+    raise Exception(build_error)

--- a/tests/automated/0_builds.py
+++ b/tests/automated/0_builds.py
@@ -3,10 +3,10 @@ from panda import build_st
 
 def test_build_panda():
   build_error = build_st("obj/panda.bin")
-  if build_error:
+  if bool(build_error):
     raise Exception(build_error)
 
 def test_build_bootstub_panda():
   build_error = build_st("obj/bootstub.panda.bin")
-  if build_error:
+  if bool(build_error):
     raise Exception(build_error)


### PR DESCRIPTION
- Don't flash if makefile returns error, reset instead of hanging in bootstub.

- More flash protections in place.

- Calling Panda().reconnect() while in bootloader previously trapped us blinking in bootstub. Finish flashing now.

- Remove makefile.legacy calls

- "Make clean" for every flash call.

- ensure_st_up_to_date() now essentially performs "make recover" when called from bootloader, bootstub, or version difference.

- update.py strips newline from version file so it will not deceive assert