### PR TITLE
fix bootstub flashing

### DIFF
--- a/board/bootstub.c
+++ b/board/bootstub.c
@@ -50,8 +50,6 @@ void fail(void) {
 // know where to sig check
 extern void *_app_start[];
 
-// FIXME: sometimes your panda will fail flashing and will quickly blink a single Green LED
-// BOUNTY: $200 coupon on shop.comma.ai or $100 check.
 
 int main(void) {
   __disable_irq();

--- a/python/dfu.py
+++ b/python/dfu.py
@@ -88,7 +88,6 @@ class PandaDFU(object):
 
   def program_bootstub(self, code_bootstub):
     self.clear_status()
-    self.erase(0x8004000)
     self.erase(0x8000000)
     self.program(0x8000000, code_bootstub, 0x800)
     self.reset()


### PR DESCRIPTION
dfu.recover() causes this failure. 
main bootstub flash defaults to soft flasher because it can't validate length with 0x8004000 erased.
soft flasher then gets stuck green flashing because 0x8004000 is erased and therefore nowhere to go. 