### PR TITLE
Propagate can_push errors

### DIFF
--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -356,7 +356,7 @@ void can_send(CAN_FIFOMailBox_TypeDef *to_push, uint8_t bus_number) {
         // TODO: why uint8 bro? only int8?
         gmlan_send_errs += !bitbang_gmlan(to_push);
       } else {
-        can_fwd_errs += can_push(can_queues[bus_number], to_push);
+        can_fwd_errs += !can_push(can_queues[bus_number], to_push);
         process_can(CAN_NUM_FROM_BUS_NUM(bus_number));
       }
     }

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -14,6 +14,9 @@ typedef struct {
 
 #define BUS_MAX 4U
 
+uint32_t can_send_errs = 0;
+uint32_t can_fwd_errs = 0;
+uint32_t gmlan_send_errs = 0;
 extern int can_live, pending_can_live;
 
 // must reinit after changing these
@@ -255,7 +258,7 @@ void process_can(uint8_t can_number) {
           to_push.RDTR = (CAN->sTxMailBox[0].TDTR & 0xFFFF000FU) | ((CAN_BUS_RET_FLAG | bus_number) << 4);
           to_push.RDLR = CAN->sTxMailBox[0].TDLR;
           to_push.RDHR = CAN->sTxMailBox[0].TDHR;
-          can_push(&can_rx_q, &to_push);
+          can_send_errs += !can_push(&can_rx_q, &to_push);
         }
 
         if ((CAN->TSR & CAN_TSR_TERR0) == CAN_TSR_TERR0) {
@@ -324,7 +327,7 @@ void can_rx(uint8_t can_number) {
     safety_rx_hook(&to_push);
 
     set_led(LED_BLUE, 1);
-    can_push(&can_rx_q, &to_push);
+    can_send_errs += !can_push(&can_rx_q, &to_push);
 
     // next
     CAN->RF0R |= CAN_RF0R_RFOM0;
@@ -351,9 +354,9 @@ void can_send(CAN_FIFOMailBox_TypeDef *to_push, uint8_t bus_number) {
       to_push->RDTR &= 0xF;
       if ((bus_number == 3U) && (can_num_lookup[3] == 0xFFU)) {
         // TODO: why uint8 bro? only int8?
-        bitbang_gmlan(to_push);
+        gmlan_send_errs += !bitbang_gmlan(to_push);
       } else {
-        can_push(can_queues[bus_number], to_push);
+        can_fwd_errs += can_push(can_queues[bus_number], to_push);
         process_can(CAN_NUM_FROM_BUS_NUM(bus_number));
       }
     }

--- a/board/main.c
+++ b/board/main.c
@@ -104,8 +104,9 @@ int get_health_pkt(void *dat) {
     uint8_t started_pkt;
     uint8_t controls_allowed_pkt;
     uint8_t gas_interceptor_detected_pkt;
-    uint8_t started_signal_detected_pkt;
-    uint8_t started_alt_pkt;
+    uint32_t can_send_errs_pkt;
+    uint32_t can_fwd_errs_pkt;
+    uint32_t gmlan_send_errs_pkt;
   } *health = dat;
 
   //Voltage will be measured in mv. 5000 = 5V
@@ -132,10 +133,9 @@ int get_health_pkt(void *dat) {
 
   health->controls_allowed_pkt = controls_allowed;
   health->gas_interceptor_detected_pkt = gas_interceptor_detected;
-
-  // DEPRECATED
-  health->started_alt_pkt = 0;
-  health->started_signal_detected_pkt = 0;
+  health->can_send_errs_pkt = can_send_errs;
+  health->can_fwd_errs_pkt = can_fwd_errs;
+  health->gmlan_send_errs_pkt = gmlan_send_errs;
 
   return sizeof(*health);
 }

--- a/board/main.c
+++ b/board/main.c
@@ -101,9 +101,9 @@ int get_health_pkt(void *dat) {
   struct __attribute__((packed)) {
     uint32_t voltage_pkt;
     uint32_t current_pkt;
-    bool started_pkt;
-    bool controls_allowed_pkt;
-    bool gas_interceptor_detected_pkt;
+    uint8_t started_pkt;
+    uint8_t controls_allowed_pkt;
+    uint8_t gas_interceptor_detected_pkt;
     uint32_t can_send_errs_pkt;
     uint32_t can_fwd_errs_pkt;
     uint32_t gmlan_send_errs_pkt;

--- a/board/main.c
+++ b/board/main.c
@@ -101,9 +101,9 @@ int get_health_pkt(void *dat) {
   struct __attribute__((packed)) {
     uint32_t voltage_pkt;
     uint32_t current_pkt;
-    uint8_t started_pkt;
-    uint8_t controls_allowed_pkt;
-    uint8_t gas_interceptor_detected_pkt;
+    bool started_pkt;
+    bool controls_allowed_pkt;
+    bool gas_interceptor_detected_pkt;
     uint32_t can_send_errs_pkt;
     uint32_t can_fwd_errs_pkt;
     uint32_t gmlan_send_errs_pkt;


### PR DESCRIPTION
Misra 17.7: The value returned by a function having non-void return type shall be used