### PR TITLE
Improved GMLAN support. Minor CAN bus bug fixes and improvements

### DIFF
--- a/board/board_declarations.h
+++ b/board/board_declarations.h
@@ -8,6 +8,7 @@ typedef void (*board_set_esp_gps_mode)(uint8_t mode);
 typedef void (*board_set_can_mode)(uint8_t mode);
 typedef void (*board_usb_power_mode_tick)(uint64_t tcnt);
 typedef bool (*board_check_ignition)(void);
+typedef void (*board_set_gmlan_op_mode)(uint8_t mode);
 
 struct board {
   const char *board_type;
@@ -21,6 +22,7 @@ struct board {
   board_set_can_mode set_can_mode;
   board_usb_power_mode_tick usb_power_mode_tick;
   board_check_ignition check_ignition;
+  board_set_gmlan_op_mode set_gmlan_op_mode;
 };
 
 // ******************* Definitions ********************
@@ -52,6 +54,12 @@ struct board {
 #define CAN_MODE_GMLAN_CAN2 1U
 #define CAN_MODE_GMLAN_CAN3 2U
 #define CAN_MODE_OBD_CAN2 3U
+
+// GMLAN transceiver operation modes
+#define GMLAN_MODE_SLEEP 0U
+#define GMLAN_MODE_HIGHSPEED 1U // 100 KBps
+#define GMLAN_MODE_WAKEUP 2U // High-Voltage Wake up
+#define GMLAN_MODE_NORMAL 3U
 
 // ********************* Globals **********************
 uint8_t usb_power_mode = USB_POWER_NONE;

--- a/board/boards/grey.h
+++ b/board/boards/grey.h
@@ -14,5 +14,6 @@ const board board_grey = {
   .set_esp_gps_mode = white_set_esp_gps_mode,
   .set_can_mode = white_set_can_mode,
   .usb_power_mode_tick = white_usb_power_mode_tick,
-  .check_ignition = white_check_ignition
+  .check_ignition = white_check_ignition,
+  .set_gmlan_op_mode = white_set_gmlan_op_mode
 };

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -150,6 +150,38 @@ void white_set_can_mode(uint8_t mode){
   }
 }
 
+void white_set_gmlan_op_mode(uint8_t mode){
+  switch (mode) {
+    /* GMLAN mode pins:
+        M0(B15)  M1(B14)  mode
+        =======================
+        0        0        sleep
+        1        0        100kbit
+        0        1        high voltage wakeup
+        1        1        33kbit (normal)
+    */
+    case GMLAN_MODE_SLEEP:
+      set_gpio_output(GPIOB, 14, 0);
+      set_gpio_output(GPIOB, 15, 0);
+      break;
+    case GMLAN_MODE_HIGHSPEED:
+      set_gpio_output(GPIOB, 14, 0);
+      set_gpio_output(GPIOB, 15, 1);
+      break;
+    case GMLAN_MODE_WAKEUP:
+      set_gpio_output(GPIOB, 14, 1);
+      set_gpio_output(GPIOB, 15, 0);
+      break;
+    case GMLAN_MODE_NORMAL:
+      set_gpio_output(GPIOB, 14, 1);
+      set_gpio_output(GPIOB, 15, 1);
+      break;
+    default:
+      puts("Invalid GMLAN transceiver operation mode!\n");  // set_usb_power_mode prevents assigning invalid values
+      break;
+  }
+}
+
 uint64_t marker = 0;
 void white_usb_power_mode_tick(uint64_t tcnt){
   #ifndef BOOTSTUB
@@ -248,16 +280,8 @@ void white_init(void) {
   // B12: GMLAN, ignition sense, pull up
   set_gpio_pullup(GPIOB, 12, PULL_UP);
 
-  /* GMLAN mode pins:
-      M0(B15)  M1(B14)  mode
-      =======================
-      0        0        sleep
-      1        0        100kbit
-      0        1        high voltage wakeup
-      1        1        33kbit (normal)
-  */
-  set_gpio_output(GPIOB, 14, 1);
-  set_gpio_output(GPIOB, 15, 1);
+  // GMLAN transceiver op mode
+  white_set_gmlan_op_mode(GMLAN_MODE_NORMAL);
 
   // B7: K-line enable
   set_gpio_output(GPIOB, 7, 1);
@@ -309,5 +333,6 @@ const board board_white = {
   .set_esp_gps_mode = white_set_esp_gps_mode,
   .set_can_mode = white_set_can_mode,
   .usb_power_mode_tick = white_usb_power_mode_tick,
-  .check_ignition = white_check_ignition
+  .check_ignition = white_check_ignition,
+  .set_gmlan_op_mode = white_set_gmlan_op_mode
 };

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -132,7 +132,7 @@ uint32_t can_speed[] = {5000, 5000, 5000, 333};
 #define CAN_NAME_FROM_CANIF(CAN) ((CAN)==CAN1 ? "CAN1" : ((CAN) == CAN2 ? "CAN2" : "CAN3"))
 #define BUS_NUM_FROM_CAN_NUM(num) (bus_lookup[num])
 #define CAN_NUM_FROM_BUS_NUM(num) (can_num_lookup[num])
-#define ID_FROM_IR(rir) (rir & 0x4 ? rir >> 3 : rir >> 21)
+#define ID_FROM_IR(rir) ((rir) & 0x4U ? (rir) >> 3U : (rir) >> 21U)
 
 void process_can(uint8_t can_number);
 
@@ -302,7 +302,7 @@ void process_can(uint8_t can_number) {
           to_push.RDHR = CAN->sTxMailBox[0].TDHR;
 
           // so if rx buffer is full, we count that as tx error... ?
-          if (bus_number==3)
+          if (bus_number == 3U)
             gmlan_send_errs += !can_push(&can_rx_q, &to_push);
           else
             can_send_errs += !can_push(&can_rx_q, &to_push);
@@ -359,15 +359,15 @@ void process_can(uint8_t can_number) {
           puth((CAN->ESR & CAN_ESR_TEC_Msk)>>CAN_ESR_TEC_Pos);
           puts(" REC: ");
           puth((CAN->ESR & CAN_ESR_REC_Msk)>>CAN_ESR_REC_Pos);
-          if (CAN->ESR & CAN_ESR_EWGF_Msk)
+          if (CAN->ESR & CAN_ESR_EWGF_Msk != 0)
             puts(" ERR_WARN");
-          if (CAN->ESR & CAN_ESR_EPVF_Msk)
+          if (CAN->ESR & CAN_ESR_EPVF_Msk != 0)
             puts(" ERR_PASSV");
-          if (CAN->ESR & CAN_ESR_BOFF_Msk)
+          if (CAN->ESR & CAN_ESR_BOFF_Msk != 0)
             puts(" BUS_OFF");
           puts("\n");
         #endif
-        if (bus_number==3)
+        if (bus_number == 3U)
           gmlan_send_errs++;
         else
           can_send_errs++;
@@ -388,11 +388,11 @@ void process_can(uint8_t can_number) {
           puth((CAN->ESR & CAN_ESR_TEC_Msk)>>CAN_ESR_TEC_Pos);
           puts(" REC: ");
           puth((CAN->ESR & CAN_ESR_REC_Msk)>>CAN_ESR_REC_Pos);
-          if (CAN->ESR & CAN_ESR_EWGF_Msk)
+          if (CAN->ESR & CAN_ESR_EWGF_Msk != 0)
             puts(" ERR_WARN");
-          if (CAN->ESR & CAN_ESR_EPVF_Msk)
+          if (CAN->ESR & CAN_ESR_EPVF_Msk != 0)
             puts(" ERR_PASSV");
-          if (CAN->ESR & CAN_ESR_BOFF_Msk)
+          if (CAN->ESR & CAN_ESR_BOFF_Msk != 0)
             puts(" BUS_OFF");
           puts("\n");
         #endif

--- a/board/drivers/llcan.h
+++ b/board/drivers/llcan.h
@@ -27,7 +27,7 @@ bool llcan_set_speed(CAN_TypeDef *CAN_obj, uint32_t speed, bool loopback, bool s
             (CAN_BTR_TS2_0 * (CAN_SEQ2-1)) |
             (can_speed_to_prescaler(speed) - 1U);
 
-  if (speed == 333) {
+  if (speed == 333U) {
     // Sync Jump Width = 2 tQ recommended for GMLAN Single Wire CAN bus according to specs (GMW3089)
     CAN_obj->BTR |= CAN_BTR_SJW_0;
   }

--- a/board/drivers/llcan.h
+++ b/board/drivers/llcan.h
@@ -27,6 +27,11 @@ bool llcan_set_speed(CAN_TypeDef *CAN_obj, uint32_t speed, bool loopback, bool s
             (CAN_BTR_TS2_0 * (CAN_SEQ2-1)) |
             (can_speed_to_prescaler(speed) - 1U);
 
+  if (speed == 333) {
+    // Sync Jump Width = 2 tQ recommended for GMLAN Single Wire CAN bus according to specs (GMW3089)
+    CAN_obj->BTR |= CAN_BTR_SJW_0;
+  }
+
   // silent loopback mode for debugging
   if (loopback) {
     CAN_obj->BTR |= CAN_BTR_SILM | CAN_BTR_LBKM;

--- a/board/main.c
+++ b/board/main.c
@@ -532,6 +532,14 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, bool hardwired) 
         heartbeat_counter = 0U;
         break;
       }
+    // **** 0xf4: Change GMLAN transceiver operation mode.
+    case 0xf4:
+      {
+        if(hw_type != HW_TYPE_BLACK_PANDA) {
+          current_board->set_gmlan_op_mode(setup->b.wValue.w);
+        }
+        break;
+      }
     default:
       puts("NO HANDLER ");
       puth(setup->b.bRequest);

--- a/board/power_saving.h
+++ b/board/power_saving.h
@@ -36,11 +36,10 @@ void set_power_save_state(int state) {
     }
     
     if(hw_type != HW_TYPE_BLACK_PANDA){
-      // turn on GMLAN
-      set_gpio_output(GPIOB, 14, enable);
-      set_gpio_output(GPIOB, 15, enable);
+      // Set GMLAN transceiver power save state
+      current_board->set_gmlan_op_mode(enable ? GMLAN_MODE_NORMAL : GMLAN_MODE_SLEEP);
 
-      // turn on LIN    
+      // Set LIN power save state
       set_gpio_output(GPIOB, 7, enable);
       set_gpio_output(GPIOA, 14, enable);
     }


### PR DESCRIPTION
* Allow user to set GMLAN Single Wire CAN operation modes (Normal, High Voltage Wake Up, High Speed, Sleep)
* Change SJW=2 for GMLAN Single Wire CAN
* Add non-blocking CAN read function
* Log can_send_errs / gmland_send_errs properly
* Fix lost_rx errors counted as tx_errors
* More verbose logging in case of CAN tx/arbitration lost error