### PR TITLE
patch to be able to switch from EON to PC with a Panda that has EON b…

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -183,14 +183,6 @@ void black_init(void) {
 
   // init multiplexer
   can_set_obd(car_harness_status, false);
-
-  // init usb power mode
-  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
-  if (voltage > 10000U) {
-    black_set_usb_power_mode(USB_POWER_CDP);
-  } else {
-    black_set_usb_power_mode(USB_POWER_CLIENT);
-  }
 }
 
 const harness_configuration black_harness_config = {

--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -185,7 +185,12 @@ void black_init(void) {
   can_set_obd(car_harness_status, false);
 
   // init usb power mode
-  black_set_usb_power_mode(USB_POWER_CDP);
+  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
+  if (voltage > 10000U) {
+    black_set_usb_power_mode(USB_POWER_CDP);
+  } else {
+    black_set_usb_power_mode(USB_POWER_CLIENT);
+  }
 }
 
 const harness_configuration black_harness_config = {

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -241,20 +241,6 @@ void white_init(void) {
   set_gpio_alternate(GPIOA, 6, GPIO_AF5_SPI1);
   set_gpio_alternate(GPIOA, 7, GPIO_AF5_SPI1);
 
-  // on PC, set USB power mode to CLIENT
-#ifdef EON
-  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
-  // go in CDP mode only if panda can be powered by 12V.
-  // Otherwise a PC would not be able to flash a panda with EON build
-  if (voltage > 10000U) {
-    white_set_usb_power_mode(USB_POWER_CDP);
-  } else {
-    white_set_usb_power_mode(USB_POWER_CLIENT);
-  }
-#else
-  white_set_usb_power_mode(USB_POWER_CLIENT);
-#endif
-
   // B12: GMLAN, ignition sense, pull up
   set_gpio_pullup(GPIOB, 12, PULL_UP);
 

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -243,7 +243,14 @@ void white_init(void) {
 
   // on PC, set USB power mode to CLIENT
 #ifdef EON
-  white_set_usb_power_mode(USB_POWER_CDP);
+  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
+  // go in CDP mode only if panda can be powered by 12V.
+  // Otherwise a PC would not be able to flash a panda with EON build
+  if (voltage > 10000U) {
+    white_set_usb_power_mode(USB_POWER_CDP);
+  } else {
+    white_set_usb_power_mode(USB_POWER_CLIENT);
+  }
 #else
   white_set_usb_power_mode(USB_POWER_CLIENT);
 #endif

--- a/board/drivers/adc.h
+++ b/board/drivers/adc.h
@@ -36,3 +36,13 @@ uint32_t adc_get(unsigned int channel) {
   return ADC1->JDR1;
 }
 
+uint32_t adc_get_voltage(void) {
+  // REVC has a 10, 1 (1/11) voltage divider
+  // Here is the calculation for the scale (s)
+  // ADCV = VIN_S * (1/11) * (4095/3.3)
+  // RETVAL = ADCV * s = VIN_S*1000
+  // s = 1000/((4095/3.3)*(1/11)) = 8.8623046875
+
+  // Avoid needing floating point math, so output in mV
+  return (adc_get(ADCCHAN_VOLTAGE) * 8862U) / 1000U;
+}

--- a/board/main.c
+++ b/board/main.c
@@ -663,6 +663,16 @@ int main(void) {
   // init board
   current_board->init();
 
+  // init usb power mode
+  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
+  // init in CDP mode only if panda is powered by 12V.
+  // Otherwise a PC would not be able to flash a panda with EON build
+  if (voltage > 10000U) {
+    current_board->set_usb_power_mode(USB_POWER_CDP);
+  } else {
+    current_board->set_usb_power_mode(USB_POWER_CLIENT);
+  }
+
   // panda has an FPU, let's use it!
   enable_fpu();
 

--- a/board/main.c
+++ b/board/main.c
@@ -657,7 +657,7 @@ int main(void) {
   uint32_t voltage = adc_get_voltage();
   // init in CDP mode only if panda is powered by 12V.
   // Otherwise a PC would not be able to flash a standalone panda with EON build
-  if (voltage > 5000U) {  // 5V threshold
+  if (voltage > 8000U) {  // 8V threshold
     current_board->set_usb_power_mode(USB_POWER_CDP);
   } else {
     current_board->set_usb_power_mode(USB_POWER_CLIENT);

--- a/board/main.c
+++ b/board/main.c
@@ -166,17 +166,7 @@ int get_health_pkt(void *dat) {
     uint8_t usb_power_mode_pkt;
   } *health = dat;
 
-  //Voltage will be measured in mv. 5000 = 5V
-  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
-
-  // REVC has a 10, 1 (1/11) voltage divider
-  // Here is the calculation for the scale (s)
-  // ADCV = VIN_S * (1/11) * (4095/3.3)
-  // RETVAL = ADCV * s = VIN_S*1000
-  // s = 1000/((4095/3.3)*(1/11)) = 8.8623046875
-
-  // Avoid needing floating point math
-  health->voltage_pkt = (voltage * 8862U) / 1000U;
+  health->voltage_pkt = adc_get_voltage();
 
   // No current sense on panda black
   if(hw_type != HW_TYPE_BLACK_PANDA){
@@ -664,10 +654,10 @@ int main(void) {
   current_board->init();
 
   // init usb power mode
-  uint32_t voltage = adc_get(ADCCHAN_VOLTAGE);
+  uint32_t voltage = adc_get_voltage();
   // init in CDP mode only if panda is powered by 12V.
-  // Otherwise a PC would not be able to flash a panda with EON build
-  if (voltage > 10000U) {
+  // Otherwise a PC would not be able to flash a standalone panda with EON build
+  if (voltage > 5000U) {  // 5V threshold
     current_board->set_usb_power_mode(USB_POWER_CDP);
   } else {
     current_board->set_usb_power_mode(USB_POWER_CLIENT);


### PR DESCRIPTION
Fix to be able to switch from EON to PC with a Panda that has EON build and not 12V supply.

This avoids having to flash the panda with a paw in recovery mode.