### PR TITLE
GPS UART fix until boardd is refactored

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -399,6 +399,12 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, bool hardwired) 
       if (!ur) {
         break;
       }
+
+      // TODO: Remove this again and fix boardd code to hande the message bursts instead of single chars
+      if(ur == &uart_ring_esp_gps){
+        dma_pointer_handler(ur, DMA2_Stream5->NDTR);
+      }
+
       // read
       while ((resp_len < MIN(setup->b.wLength.w, MAX_RESP_LEN)) &&
                          getc(ur, (char*)&resp[resp_len])) {

--- a/board/main.c
+++ b/board/main.c
@@ -401,7 +401,7 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, bool hardwired) 
       }
 
       // TODO: Remove this again and fix boardd code to hande the message bursts instead of single chars
-      if(ur == &uart_ring_esp_gps){
+      if (ur == &uart_ring_esp_gps) {
         dma_pointer_handler(ur, DMA2_Stream5->NDTR);
       }
 


### PR DESCRIPTION
This makes sure that each time the last available characters are available to be sent when the usb command is used.

This results in the message length coming in to boardd only being 1 or 2 chars, not ruining the logic there.