### PR TITLE
#307 Update board/README.md for MacOs instructions and move ./get_sdk…

### DIFF
--- a/board/README.md
+++ b/board/README.md
@@ -4,6 +4,7 @@ Dependencies
 **Mac**
 
 ```
+xcode-select --install
 ./get_sdk_mac.sh
 ```
 

--- a/board/get_sdk_mac.sh
+++ b/board/get_sdk_mac.sh
@@ -2,4 +2,5 @@
 # Need formula for gcc
 brew tap ArmMbed/homebrew-formulae
 brew install python dfu-util arm-none-eabi-gcc
-pip2 install libusb1 pycrypto requests
+pip2 install libusb1 requests
+pip2 install --user pycrypto


### PR DESCRIPTION
Errors while running ./board/get_sdk_mac.sh were twofold:
- Command Line Tools needs to be installed (added to the documentation)
- pip2 install pycrypto will throw errors while running ./get_sdk_mac.sh because of permissions issues.  ./get_sdk_mac.sh could be run via sudo, but that's not advisable for pip, so install pycrypto in --user space instead.