### PR TITLE
Power saving refactor

### DIFF
--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -302,13 +302,6 @@ void white_grey_common_init(void) {
   // Set normal CAN mode
   white_set_can_mode(CAN_MODE_NORMAL);
 
-  // Setup ignition interrupts
-  SYSCFG->EXTICR[1] = SYSCFG_EXTICR1_EXTI1_PA;
-  EXTI->IMR |= (1U << 1);
-  EXTI->RTSR |= (1U << 1);
-  EXTI->FTSR |= (1U << 1);
-  NVIC_EnableIRQ(EXTI1_IRQn);
-
   // Init usb power mode
   uint32_t voltage = adc_get_voltage();
   // Init in CDP mode only if panda is powered by 12V.

--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -8,7 +8,7 @@ uint8_t car_harness_status = 0U;
 
 struct harness_configuration {
   const bool has_harness;
-  GPIO_TypeDef *GPIO_SBU1;  
+  GPIO_TypeDef *GPIO_SBU1;
   GPIO_TypeDef *GPIO_SBU2;
   GPIO_TypeDef *GPIO_relay_normal;
   GPIO_TypeDef *GPIO_relay_flipped;
@@ -50,28 +50,6 @@ bool harness_check_ignition(void) {
       break;
   }
   return ret;
-}
-
-// TODO: refactor to use harness config
-void harness_setup_ignition_interrupts(void){
-  if(car_harness_status == HARNESS_STATUS_NORMAL){
-    SYSCFG->EXTICR[0] = SYSCFG_EXTICR1_EXTI3_PC;
-    EXTI->IMR |= (1U << 3);
-    EXTI->RTSR |= (1U << 3);
-    EXTI->FTSR |= (1U << 3);
-    puts("setup interrupts: normal\n");
-  } else if(car_harness_status == HARNESS_STATUS_FLIPPED) {
-    SYSCFG->EXTICR[0] = SYSCFG_EXTICR1_EXTI0_PC;
-    EXTI->IMR |= (1U << 0);
-    EXTI->RTSR |= (1U << 0);
-    EXTI->FTSR |= (1U << 0);
-    NVIC_EnableIRQ(EXTI1_IRQn);
-    puts("setup interrupts: flipped\n");
-  } else {
-    puts("tried to setup ignition interrupts without harness connected\n");
-  }
-  NVIC_EnableIRQ(EXTI0_IRQn);
-  NVIC_EnableIRQ(EXTI3_IRQn);
 }
 
 uint8_t harness_detect_orientation(void) {
@@ -117,13 +95,10 @@ void harness_init(void) {
       set_gpio_mode(current_board->harness_config->GPIO_SBU2, current_board->harness_config->pin_SBU2, MODE_INPUT);
     } else {
       set_gpio_mode(current_board->harness_config->GPIO_SBU1, current_board->harness_config->pin_SBU1, MODE_INPUT);
-    }      
+    }
 
     // keep busses connected by default
     set_intercept_relay(false);
-
-    // setup ignition interrupts
-    harness_setup_ignition_interrupts();
   } else {
     puts("failed to detect car harness!\n");
   }

--- a/board/main.c
+++ b/board/main.c
@@ -141,6 +141,7 @@ int get_health_pkt(void *dat) {
     uint8_t usb_power_mode_pkt;
     uint8_t safety_mode_pkt;
     uint8_t fault_status_pkt;
+    uint8_t power_save_enabled_pkt;
   } *health = dat;
 
   health->voltage_pkt = adc_get_voltage();
@@ -159,6 +160,7 @@ int get_health_pkt(void *dat) {
   health->usb_power_mode_pkt = usb_power_mode;
   health->safety_mode_pkt = (uint8_t)(current_safety_mode);
   health->fault_status_pkt = 0U;  // TODO: populate this field
+  health->power_save_enabled_pkt = (uint8_t)(power_save_status == POWER_SAVE_STATUS_ENABLED);
 
   return sizeof(*health);
 }

--- a/board/main.c
+++ b/board/main.c
@@ -510,6 +510,10 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, bool hardwired) 
     case 0xe6:
       current_board->set_usb_power_mode(setup->b.wValue.w);
       break;
+    // **** 0xe7: set power save state
+    case 0xe7:
+      set_power_save_state(setup->b.wValue.w);
+      break;
     // **** 0xf0: do k-line wValue pulse on uart2 for Acura
     case 0xf0:
       if (setup->b.wValue.w == 1U) {

--- a/board/main.c
+++ b/board/main.c
@@ -677,7 +677,7 @@ void TIM1_BRK_TIM9_IRQHandler(void) {
     }
 
     // Power saving state machine: go in power save mode when car is off
-    if ((power_save_status == POWER_SAVE_STATUS_ENABLE) && check_started()) {
+    if ((power_save_status == POWER_SAVE_STATUS_ENABLED) && check_started()) {
       set_power_save_state(POWER_SAVE_STATUS_DISABLED);
       // ensure CDP usb power mode everytime that the car starts to make sure EON is charging
       if (usb_power_mode != USB_POWER_CDP) {

--- a/board/main.c
+++ b/board/main.c
@@ -677,13 +677,13 @@ void TIM1_BRK_TIM9_IRQHandler(void) {
     }
 
     // Power saving state machine: go in power save mode when car is off
-    if (power_save_status == POWER_SAVE_STATUS_ENABLE && check_started()) {
+    if ((power_save_status == POWER_SAVE_STATUS_ENABLE) && check_started()) {
       set_power_save_state(POWER_SAVE_STATUS_DISABLED);
       // ensure CDP usb power mode everytime that the car starts to make sure EON is charging
       if (usb_power_mode != USB_POWER_CDP) {
         current_board->set_usb_power_mode(USB_POWER_CDP);
       }
-    } else if (power_save_status == POWER_SAVE_STATUS_DISABLED && !check_started()) {
+    } else if ((power_save_status == POWER_SAVE_STATUS_DISABLED) && !check_started()) {
        set_power_save_state(POWER_SAVE_STATUS_ENABLED);
     } else {}  // keep same power_save_status
     #endif

--- a/board/main.c
+++ b/board/main.c
@@ -677,9 +677,13 @@ void TIM1_BRK_TIM9_IRQHandler(void) {
     }
 
     // Power saving state machine: go in power save mode when car is off
-    if (power_save_status == POWER_SAVE_STATUS_DISABLED && check_started()) {
-       set_power_save_state(POWER_SAVE_STATUS_ENABLED);
-    else if(power_save_status == POWER_SAVE_STATUS_ENABLED && !check_started()) {
+    if (power_save_status == POWER_SAVE_STATUS_ENABLE && check_started()) {
+      set_power_save_state(POWER_SAVE_STATUS_DISABLED);
+      // ensure CDP usb power mode everytime that the car starts to make sure EON is charging
+      if (usb_power_mode != USB_POWER_CDP) {
+        current_board->set_usb_power_mode(USB_POWER_CDP);
+      }
+    } else if (power_save_status == POWER_SAVE_STATUS_DISABLED && !check_started()) {
        set_power_save_state(POWER_SAVE_STATUS_ENABLED);
     } else {}  // keep same power_save_status
     #endif

--- a/board/main.c
+++ b/board/main.c
@@ -684,7 +684,7 @@ void TIM1_BRK_TIM9_IRQHandler(void) {
 
     // enter CDP mode when car starts to ensure we are charging a turned off EON
     if (check_started() && (usb_power_mode != USB_POWER_CDP)) {
-      set_usb_power_mode(USB_POWER_CDP);
+      current_board->set_usb_power_mode(USB_POWER_CDP);
     }
     #endif
 

--- a/board/main.c
+++ b/board/main.c
@@ -667,8 +667,8 @@ void TIM1_BRK_TIM9_IRQHandler(void) {
       heartbeat_counter += 1U;
     }
 
-    // check heartbeat counter if we are running EON code. If the heartbeat has been gone for a while, go to SILENT safety mode.
     #ifdef EON
+    // check heartbeat counter if we are running EON code. If the heartbeat has been gone for a while, go to SILENT safety mode.
     if (heartbeat_counter >= (check_started() ? EON_HEARTBEAT_IGNITION_CNT_ON : EON_HEARTBEAT_IGNITION_CNT_OFF)) {
       puts("EON hasn't sent a heartbeat for 0x"); puth(heartbeat_counter); puts(" seconds. Safety is set to SILENT mode.\n");
       if(current_safety_mode != SAFETY_SILENT){

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -347,7 +347,7 @@ class Panda(object):
 
   def health(self):
     dat = self._handle.controlRead(Panda.REQUEST_IN, 0xd2, 0, 0, 28)
-    a = struct.unpack("IIIIIBBBBBBBB", dat)
+    a = struct.unpack("IIIIIBBBBBBBBB", dat)
     return {
       "voltage": a[0],
       "current": a[1],
@@ -361,7 +361,8 @@ class Panda(object):
       "car_harness_status": a[9],
       "usb_power_mode": a[10],
       "safety_mode": a[11],
-      "fault_status": a[12]
+      "fault_status": a[12],
+      "power_save_enabled": a[13]
     }
 
   # ******************* control *******************


### PR DESCRIPTION
What was wrong:
- can based ignition would not trigger the interrupt on ignition line that changes the power save mode and set usb power mode to CDP.
- easy to trigger race conditions where EON changes the safety mode and re-enables some of the CAN lines after the ignition off interrupt is triggered. 

What is done:
- Move power save mode logic to boardd (openpilot). ON when car is ON, OFF when car is ON.
- Only set_power_save_state call in panda is when EON is disconnected: we already enter SILENT safety mode and now we also enter power saving mode, to ensure that if EON is disconnected while car is ON, panda won't remain in high consumption mode.
- enter CDP mode when (check_started) is True
- added usb command to change power save state
- added power save state to the health packet
- disable ignition line interrupt