### PR TITLE
Fix USB device enumeration on Windows 8.1 and Windows 10

### DIFF
--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -281,15 +281,16 @@ uint8_t binary_object_store_desc[] = {
   // BOS header
   BINARY_OBJECT_STORE_DESCRIPTOR_LENGTH, // bLength, this is only the length of the header
   BINARY_OBJECT_STORE_DESCRIPTOR, // bDescriptorType
-  0x40, 0x00, // wTotalLength (LSB, MSB)
-  0x03, // bNumDeviceCaps (USB 2.0 + WebUSB + WinUSB)
+  0x39, 0x00, // wTotalLength (LSB, MSB)
+  0x02, // bNumDeviceCaps (WebUSB + WinUSB *** removed USB 2.0 Extension for now ***)
 
   // -------------------------------------------------
   // USB 2.0 extension descriptor
-  0x07, // bLength, Descriptor size
-  0x10, // bDescriptorType, Device Capability Descriptor Type
-  0x02, // bDevCapabilityType, USB 2.0 extension capability type
-  0x00, 0x00, 0x00, 0x00, // bmAttributes, LIBUSB_BM_LPM_SUPPORT = 2 and its the only option
+  // *** Removed because its presence was breaking Win8.1/Win10 USB enumeration for reasons not fully explored ***
+  // 0x07, // bLength, Descriptor size
+  // 0x10, // bDescriptorType, Device Capability Descriptor Type
+  // 0x02, // bDevCapabilityType, USB 2.0 extension capability type
+  // 0x00, 0x00, 0x00, 0x00, // bmAttributes, LIBUSB_BM_LPM_SUPPORT = 2 and its the only option
 
   // -------------------------------------------------
   // WebUSB descriptor

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -282,15 +282,7 @@ uint8_t binary_object_store_desc[] = {
   BINARY_OBJECT_STORE_DESCRIPTOR_LENGTH, // bLength, this is only the length of the header
   BINARY_OBJECT_STORE_DESCRIPTOR, // bDescriptorType
   0x39, 0x00, // wTotalLength (LSB, MSB)
-  0x02, // bNumDeviceCaps (WebUSB + WinUSB *** removed USB 2.0 Extension for now ***)
-
-  // -------------------------------------------------
-  // USB 2.0 extension descriptor
-  // *** Removed because its presence was breaking Win8.1/Win10 USB enumeration for reasons not fully explored ***
-  // 0x07, // bLength, Descriptor size
-  // 0x10, // bDescriptorType, Device Capability Descriptor Type
-  // 0x02, // bDevCapabilityType, USB 2.0 extension capability type
-  // 0x00, 0x00, 0x00, 0x00, // bmAttributes, LIBUSB_BM_LPM_SUPPORT = 2 and its the only option
+  0x02, // bNumDeviceCaps (WebUSB + WinUSB)
 
   // -------------------------------------------------
   // WebUSB descriptor


### PR DESCRIPTION
# Fix Panda on Windows
Panda does not seem usable for many people on modern Windows; it won't enumerate at all. See for example #297. According to @gregjhogan on Discord, it looks like it broke last year in commit https://github.com/commaai/panda/commit/6dbd8c972ba2426ca43d176a1eee8cf7b304ee0a. This PR fixes the problem in a way that appears completely legal by USB spec.

## Problem Description
The problem was happening on two machines here, one each on Windows 8.1 and Windows 10. USB enumeration fails with code 43, "a request for the USB BOS descriptor failed." Windows 10 just complained of a device I attached malfunctioning. Those versions of Windows are known to perform stronger validation on USB devices:

- https://techcommunity.microsoft.com/t5/Microsoft-USB-Blog/Why-does-my-USB-device-work-on-Windows-8-0-but-fail-on-Windows-8/ba-p/270819
- https://techcommunity.microsoft.com/t5/Microsoft-USB-Blog/USB-2-1-2-0-1-1-device-enumeration-changes-in-Windows-8/ba-p/270775

As a test, the registry workaround to disable BOS descriptor fetch was enough to enumerate it and have it show up in Device Manager on Windows 8.1, but was not effective on Windows 10. I didn't test actual Panda library or WebUSB functionality either way.

I checked all three objects in the BOS descriptor carefully, against the spec and against other examples, and could not find anything meaningfully wrong with them.

## What Fixed It
There were three objects in the BOS descriptor. We need the WebUSB and WinUSB descriptors for plug-and-play, but while reading most current USB 3.2 spec, I noticed the following:

> 9.6.2.1 USB 2.0 Extension
An **Enhanced SuperSpeed device** shall include the USB 2.0 Extension descriptor and shall
support LPM **when operating in USB 2.0 High-Speed mode**.

And that's it. Panda isn't required to add the USB 2.0 Extension to the BOS descriptor, because the STM32 in no way resembles a USB 3.0 SuperSpeed device; it doesn't even support USB 2.0 High-Speed. As an experiment, I threw it overboard, and that fixed it. USB on Windows 10 enumerated it, attached the device, installed the WinUSB driver, and made WebUSB available to Chrome with absolutely no further action on my part.

```
[Port3]  :  Unknown Device #1


Is Port User Connectable:         yes
Is Port Debug Capable:            no
Companion Port Number:            19
Companion Hub Symbolic Link Name: USB#ROOT_HUB30#4&c52ad7a&0&0#{f18a0e88-c30c-11d0-8815-00a0c906bed8}
Protocols Supported:
 USB 1.1:                         yes
 USB 2.0:                         yes
 USB 3.0:                         no

Device Power State:               PowerDeviceD0

       ---===>Device Information<===---
English product name: "panda"

ConnectionStatus:                  
Current Config Value:              0x01  -> Device Bus Speed: Full (is not SuperSpeed or higher capable)
Device Address:                    0x0D
Open Pipes:                           3

          ===>Device Descriptor<===
bLength:                           0x12
bDescriptorType:                   0x01
bcdUSB:                          0x0210
bDeviceClass:                      0xFF  -> This is a Vendor Specific Device
bDeviceSubClass:                   0xFF
bDeviceProtocol:                   0xFF
bMaxPacketSize0:                   0x40 = (64) Bytes
idVendor:                        0xBBAA = Vendor ID not listed with USB.org
idProduct:                       0xDDCC
bcdDevice:                       0x2300
iManufacturer:                     0x01
     English (United States)  "comma.ai"
iProduct:                          0x02
     English (United States)  "panda"
iSerialNumber:                     0x03
     English (United States)  "17002f000f51363338383037"
bNumConfigurations:                0x01

          ---===>Open Pipes<===---

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x81  -> Direction: IN - EndpointID: 1
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x02  -> Direction: OUT - EndpointID: 2
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x03  -> Direction: OUT - EndpointID: 3
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

       ---===>Full Configuration Descriptor<===---

          ===>Configuration Descriptor<===
bLength:                           0x09
bDescriptorType:                   0x02
wTotalLength:                    0x0045  -> Validated
bNumInterfaces:                    0x01
bConfigurationValue:               0x01
iConfiguration:                    0x04
     English (United States)  "01"
bmAttributes:                      0xC0  -> Self Powered
MaxPower:                          0x32 = 100 mA

          ===>Interface Descriptor<===
bLength:                           0x09
bDescriptorType:                   0x04
bInterfaceNumber:                  0x00
bAlternateSetting:                 0x00
bNumEndpoints:                     0x03
bInterfaceClass:                   0xFF  -> Interface Class Unknown to USBView
bInterfaceSubClass:                0xFF
bInterfaceProtocol:                0xFF
iInterface:                        0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x81  -> Direction: IN - EndpointID: 1
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x02  -> Direction: OUT - EndpointID: 2
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x03  -> Direction: OUT - EndpointID: 3
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>Interface Descriptor<===
bLength:                           0x09
bDescriptorType:                   0x04
bInterfaceNumber:                  0x00
bAlternateSetting:                 0x01
bNumEndpoints:                     0x03
bInterfaceClass:                   0xFF  -> Interface Class Unknown to USBView
bInterfaceSubClass:                0xFF
bInterfaceProtocol:                0xFF
iInterface:                        0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x81  -> Direction: IN - EndpointID: 1
bmAttributes:                      0x03  -> Interrupt Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x05

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x02  -> Direction: OUT - EndpointID: 2
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>Endpoint Descriptor<===
bLength:                           0x07
bDescriptorType:                   0x05
bEndpointAddress:                  0x03  -> Direction: OUT - EndpointID: 3
bmAttributes:                      0x02  -> Bulk Transfer Type
wMaxPacketSize:                  0x0040 = 0x40 bytes
bInterval:                         0x00

          ===>BOS Descriptor<===
bLength:                           0x05
bDescriptorType:                   0x0F
wTotalLength:                      0x0039
bNumDeviceCaps:                    0x02

          ===>Platform Capability Descriptor<===
bLength:                           0x18
bDescriptorType:                   0x10
bDevCapabilityType:                0x05
bReserved:                         0x00
Platform Capability UUID:          3408B638-09A9-47A0-8BFD-A0768815B665
00 01 30 03 

          ===>Platform Capability Descriptor<===
bLength:                           0x1C
bDescriptorType:                   0x10
bDevCapabilityType:                0x05
bReserved:                         0x00
Platform Capability UUID:          D8DD60DF-4589-4CC7-9CD2-659D9E648A9F
00 00 03 06 9E 00 20 00 
```