### PR TITLE
update J2534 driver for new health data structure

### DIFF
--- a/drivers/windows/README.md
+++ b/drivers/windows/README.md
@@ -20,7 +20,7 @@ ______/\\\\\\\\\\\____/\\\\\\\\\_______/\\\\\\\\\\\\\\\______/\\\\\\\\\\________
 
 # Installing J2534 driver:
 
-[Download](https://github.com/commaai/panda/files/4008481/panda.J2534.driver.install.zip)
+[Download](https://github.com/commaai/panda/files/4017364/panda.J2534.driver.install.zip)
 
 Depending on what version of windows you are on, you may need to separately install the WinUSB driver (see next section).
 

--- a/drivers/windows/panda_shared/panda.h
+++ b/drivers/windows/panda_shared/panda.h
@@ -78,13 +78,23 @@ namespace panda {
 
 	#pragma pack(1)
 	typedef struct _PANDA_HEALTH {
+		uint32_t uptime;
 		uint32_t voltage;
 		uint32_t current;
-		uint8_t started;
+		uint32_t can_rx_errs;
+		uint32_t can_send_errs;
+		uint32_t can_fwd_errs;
+		uint32_t gmlan_send_errs;
+		uint32_t faults;
+		uint8_t ignition_line;
+		uint8_t ignition_can;
 		uint8_t controls_allowed;
 		uint8_t gas_interceptor_detected;
-		uint8_t started_signal_detected;
-		uint8_t started_alt;
+		uint8_t car_harness_status;
+		uint8_t usb_power_mode;
+		uint8_t safety_mode;
+		uint8_t fault_status;
+		uint8_t power_save_enabled;
 	} PANDA_HEALTH, *PPANDA_HEALTH;
 
 	typedef struct _PANDA_CAN_MSG {


### PR DESCRIPTION
HDS for pre-2017 vehicles won't open because it can't read the car battery voltage due to https://github.com/commaai/panda/pull/391 changing the order of the health packet type def