### PR TITLE
Fixed GMLAN interrupts when used in Tesla safety

### DIFF
--- a/board/drivers/gmlan_alt.h
+++ b/board/drivers/gmlan_alt.h
@@ -122,7 +122,12 @@ int get_bit_message(char *out, CAN_FIFOMailBox_TypeDef *to_bang) {
   return len;
 }
 
+void TIM4_IRQ_Handler(void);
+
 void setup_timer4(void) {
+  // register interrupt
+  REGISTER_INTERRUPT(TIM4_IRQn, TIM4_IRQ_Handler, 40000U, FAULT_INTERRUPT_RATE_GMLAN)
+
   // setup
   register_set(&(TIM4->PSC), (48-1), 0xFFFFU);    // Tick on 1 us
   register_set(&(TIM4->CR1), TIM_CR1_CEN, 0x3FU); // Enable
@@ -236,7 +241,6 @@ void TIM4_IRQ_Handler(void) {
         gmlan_sendmax = -1;   // exit
       }
     }
-    TIM4->SR = 0;
   } else if (gmlan_alt_mode == GPIO_SWITCH) {
     if ((TIM4->SR & TIM_SR_UIF) && (gmlan_switch_below_timeout != -1)) {
       if ((can_timeout_counter == 0) && gmlan_switch_timeout_enable) {
@@ -259,10 +263,10 @@ void TIM4_IRQ_Handler(void) {
         }
       }
     }
-    TIM4->SR = 0;
   } else {
-    puts("invalid gmlan_alt_mode\n");
+    // Invalid GMLAN mode. Do not put a print statement here, way too fast to keep up with
   }
+  TIM4->SR = 0;
 }
 
 bool bitbang_gmlan(CAN_FIFOMailBox_TypeDef *to_bang) {
@@ -280,7 +284,6 @@ bool bitbang_gmlan(CAN_FIFOMailBox_TypeDef *to_bang) {
     set_gpio_mode(GPIOB, 13, MODE_OUTPUT);
 
     // 33kbps
-    REGISTER_INTERRUPT(TIM4_IRQn, TIM4_IRQ_Handler, 40000U, FAULT_INTERRUPT_RATE_GMLAN)
     setup_timer4();
   }
   return gmlan_send_ok;


### PR DESCRIPTION
Fix for issue #416 

Debug console didn't work anymore since it was flooded with 'invalid gmlan' message. Also triggered temp fault since that interrupt was running at full speed