### PR TITLE
Mazda: Lane Info msgs need to be managed by OP

### DIFF
--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -129,7 +129,7 @@ static int mazda_fwd_hook(int bus, CAN_FIFOMailBox_TypeDef *to_fwd) {
       bus_fwd = MAZDA_CAM;
     }
     else if (bus == MAZDA_CAM) {
-      if (!(addr == MAZDA_LKAS)) {
+      if (!((addr == MAZDA_LKAS) || (addr == MAZDA_LANEINFO))) {
         bus_fwd = MAZDA_MAIN;
       }
     }


### PR DESCRIPTION
The EPS drops torque messages if lane lines are not marked
visible by the camera. Drop stock laneinfo msgs  and
give control to OP to manage them.

Signed-off-by: Jafar Al-Gharaibeh <to.jafar@gmail.com>