### PR TITLE
disable stock honda AEB in unsafe mode

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -138,18 +138,22 @@ static int honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
         gas_pressed_prev = gas_pressed;
       }
     }
-    if ((bus == 2) && (addr == 0x1FA)) {
-      bool honda_stock_aeb = GET_BYTE(to_push, 3) & 0x20;
-      int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) + ((GET_BYTE(to_push, 1) >> 6) & 0x3);
+    
+    // disable stock Honda AEB in unsafe mode
+    if (unsafe_mode != UNSAFE_DISABLE_STOCK_AEB) {
+      if ((bus == 2) && (addr == 0x1FA)) {
+        bool honda_stock_aeb = GET_BYTE(to_push, 3) & 0x20;
+        int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) + ((GET_BYTE(to_push, 1) >> 6) & 0x3);
 
-      // Forward AEB when stock braking is higher than openpilot braking
-      // only stop forwarding when AEB event is over
-      if (!honda_stock_aeb) {
-        honda_fwd_brake = false;
-      } else if (honda_stock_brake >= honda_brake) {
-        honda_fwd_brake = true;
-      } else {
-        // Leave Honda forward brake as is
+        // Forward AEB when stock braking is higher than openpilot braking
+        // only stop forwarding when AEB event is over
+        if (!honda_stock_aeb) {
+          honda_fwd_brake = false;
+        } else if (honda_stock_brake >= honda_brake) {
+          honda_fwd_brake = true;
+        } else {
+          // Leave Honda forward brake as is
+        }
       }
     }
 

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -140,7 +140,7 @@ static int honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     }
     
     // disable stock Honda AEB in unsafe mode
-    if (unsafe_mode != UNSAFE_DISABLE_STOCK_AEB) {
+    if ( !(unsafe_mode & UNSAFE_DISABLE_STOCK_AEB) ) {
       if ((bus == 2) && (addr == 0x1FA)) {
         bool honda_stock_aeb = GET_BYTE(to_push, 3) & 0x20;
         int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) + ((GET_BYTE(to_push, 1) >> 6) & 0x3);


### PR DESCRIPTION
for some Honda models when OP is engaged, stock AEB will activate in unexpected circumstances, such as when there are 2 lane highways when driving on a curve with opposing traffic.  When this occurs the car may brake unexpectedly (Honda Civic) or loss of gas pedal function may occur for a few seconds (Honda Pilot).  This PR disables the stock Honda AEB in the Panda code gated under unsafe_mode.