### PR TITLE
Support code for unsafe mode unit tests

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -472,9 +472,9 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, bool hardwired) 
     // **** 0xdf: set unsafe mode
     case 0xdf:
       // you can only set this if you are in a non car safety mode
-      if (current_safety_mode == SAFETY_SILENT ||
-          current_safety_mode == SAFETY_NOOUTPUT ||
-          current_safety_mode == SAFETY_ELM327) {
+      if ((current_safety_mode == SAFETY_SILENT) ||
+          (current_safety_mode == SAFETY_NOOUTPUT) ||
+          (current_safety_mode == SAFETY_ELM327)) {
         unsafe_mode = setup->b.wValue.w;
       }
       break;

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -2,6 +2,13 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
+class UNSAFE_MODE:
+  DEFAULT = 0
+  DISABLE_DISENGAGE_ON_GAS = 1
+  DISABLE_STOCK_AEB = 2
+  ENABLE_WEAK_STEERING_WHILE_NOT_ENGAGED = 4
+  RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
+
 def make_msg(bus, addr, length=8):
   to_send = libpandasafety_py.ffi.new('CAN_FIFOMailBox_TypeDef *')
   if addr >= 0x800:

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -32,6 +32,8 @@ typedef struct
 
 void set_controls_allowed(bool c);
 bool get_controls_allowed(void);
+void set_unsafe_mode(int mode);
+int get_unsafe_mode(void);
 void set_relay_malfunction(bool c);
 bool get_relay_malfunction(void);
 void set_gas_interceptor_detected(bool c);

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -81,6 +81,10 @@ void set_controls_allowed(bool c){
   controls_allowed = c;
 }
 
+void set_unsafe_mode(int mode){
+  unsafe_mode = mode;
+}
+
 void set_relay_malfunction(bool c){
   relay_malfunction = c;
 }
@@ -91,6 +95,10 @@ void set_gas_interceptor_detected(bool c){
 
 bool get_controls_allowed(void){
   return controls_allowed;
+}
+
+int get_unsafe_mode(void){
+  return unsafe_mode;
 }
 
 bool get_relay_malfunction(void){


### PR DESCRIPTION
Required to validate changes in Panda safety operation after use of the "unsafe mode" flag.

When this lands I have the appropriate changes and tests for "no disengage on gas" for both Volkswagen MQB and PQ.