### PR TITLE
Unsafe mode gas disengage for VW MQB and PQ

### DIFF
--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -183,7 +183,7 @@ static int volkswagen_mqb_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // Signal: Motor_20.MO_Fahrpedalrohwert_01
     if (addr == MSG_MOTOR_20) {
       bool gas_pressed = ((GET_BYTES_04(to_push) >> 12) & 0xFF) != 0;
-      if (gas_pressed && !gas_pressed_prev) {
+      if (gas_pressed && !gas_pressed_prev && !(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
         controls_allowed = 0;
       }
       gas_pressed_prev = gas_pressed;
@@ -250,7 +250,7 @@ static int volkswagen_pq_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // Signal: Motor_3.Fahrpedal_Rohsignal
     if ((bus == 0) && (addr == MSG_MOTOR_3)) {
       int gas_pressed = (GET_BYTE(to_push, 2));
-      if (gas_pressed && !gas_pressed_prev) {
+      if (gas_pressed && !gas_pressed_prev && !(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
         controls_allowed = 0;
       }
       gas_pressed_prev = gas_pressed;

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -72,7 +72,9 @@ uint8_t hw_type = HW_TYPE_UNKNOWN;
 
 #define UNUSED(x) (void)(x)
 
+#ifndef PANDA
 #define PANDA
+#endif
 #define NULL ((void*)0)
 #define static
 #include "safety.h"

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -4,7 +4,7 @@ import numpy as np
 import crcmod
 from panda import Panda
 from panda.tests.safety import libpandasafety_py
-from panda.tests.safety.common import StdTest, make_msg, MAX_WRONG_COUNTERS
+from panda.tests.safety.common import StdTest, make_msg, MAX_WRONG_COUNTERS, UNSAFE_MODE
 
 MAX_RATE_UP = 4
 MAX_RATE_DOWN = 10
@@ -197,6 +197,14 @@ class TestVolkswagenMqbSafety(unittest.TestCase):
     self.safety.set_controls_allowed(True)
     self.safety.safety_rx_hook(self._motor_20_msg(1))
     self.assertFalse(self.safety.get_controls_allowed())
+
+  def test_unsafe_mode_no_disengage_on_gas(self):
+    self.safety.safety_rx_hook(self._motor_20_msg(0))
+    self.safety.set_controls_allowed(True)
+    self.safety.set_unsafe_mode(UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS)
+    self.safety.safety_rx_hook(self._motor_20_msg(1))
+    self.assertTrue(self.safety.get_controls_allowed())
+    self.safety.set_unsafe_mode(UNSAFE_MODE.DEFAULT)
 
   def test_allow_engage_with_gas_pressed(self):
     self.safety.safety_rx_hook(self._motor_20_msg(1))

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 from panda import Panda
 from panda.tests.safety import libpandasafety_py
-from panda.tests.safety.common import StdTest, make_msg, MAX_WRONG_COUNTERS
+from panda.tests.safety.common import StdTest, make_msg, MAX_WRONG_COUNTERS, UNSAFE_MODE
 
 MAX_RATE_UP = 4
 MAX_RATE_DOWN = 10
@@ -175,6 +175,14 @@ class TestVolkswagenPqSafety(unittest.TestCase):
     self.safety.set_controls_allowed(True)
     self.safety.safety_rx_hook(self._motor_3_msg(1))
     self.assertFalse(self.safety.get_controls_allowed())
+
+  def test_unsafe_mode_no_disengage_on_gas(self):
+    self.safety.safety_rx_hook(self._motor_3_msg(0))
+    self.safety.set_controls_allowed(True)
+    self.safety.set_unsafe_mode(UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS)
+    self.safety.safety_rx_hook(self._motor_3_msg(1))
+    self.assertTrue(self.safety.get_controls_allowed())
+    self.safety.set_unsafe_mode(UNSAFE_MODE.DEFAULT)
 
   def test_allow_engage_with_gas_pressed(self):
     self.safety.safety_rx_hook(self._motor_3_msg(1))


### PR DESCRIPTION
Implement `UNSAFE_DISABLE_DISENGAGE_ON_GAS` for both Volkswagen MQB and PQ, with tests. Also fix a test compile warning (not VW specific) that's been annoying me for a while.

Regarding the other unsafe_mode flags:

`UNSAFE_DISABLE_STOCK_AEB`, N/A because Volkswagen never needs to disable stock FCW/AEB
`UNSAFE_ENABLE_WEAK_STEERING_WHILE_NOT_ENGAGED`, might do this at some point
`UNSAFE_RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX`, N/A until we take long control
