### PR TITLE
toyota: use universal gas pressed bit

### DIFF
--- a/board/drivers/llcan.h
+++ b/board/drivers/llcan.h
@@ -11,7 +11,7 @@
 #define GET_BUS(msg) (((msg)->RDTR >> 4) & 0xFF)
 #define GET_LEN(msg) ((msg)->RDTR & 0xF)
 #define GET_ADDR(msg) ((((msg)->RIR & 4) != 0) ? ((msg)->RIR >> 3) : ((msg)->RIR >> 21))
-#define GET_BYTE(msg, b) (((int)(b) > 3) ? (((msg)->RDHR >> (8U * ((unsigned int)(b) % 4U))) & 0XFFU) : (((msg)->RDLR >> (8U * (unsigned int)(b))) & 0xFFU))
+#define GET_BYTE(msg, b) (((int)(b) > 3) ? (((msg)->RDHR >> (8U * ((unsigned int)(b) % 4U))) & 0xFFU) : (((msg)->RDLR >> (8U * (unsigned int)(b))) & 0xFFU))
 #define GET_BYTES_04(msg) ((msg)->RDLR)
 #define GET_BYTES_48(msg) ((msg)->RDHR)
 

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -101,7 +101,7 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       toyota_cruise_engaged_last = cruise_engaged;
 
       // handle gas_pressed
-      bool gas_pressed = ((GET_BYTE(to_push, 0) >> 4) & 1) != 1;
+      bool gas_pressed = ((GET_BYTE(to_push, 0) >> 4) & 1) == 0;
       if (!unsafe_allow_gas && gas_pressed && !gas_pressed_prev && !gas_interceptor_detected) {
         controls_allowed = 0;
       }

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -88,6 +88,7 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     }
 
     // enter controls on rising edge of ACC, exit controls on ACC off
+    // exit controls on rising edge of gas press
     if (addr == 0x1D2) {
       // 5th bit is CRUISE_ACTIVE
       int cruise_engaged = GET_BYTE(to_push, 0) & 0x20;
@@ -98,6 +99,13 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
         controls_allowed = 1;
       }
       toyota_cruise_engaged_last = cruise_engaged;
+
+      // handle gas_pressed
+      bool gas_pressed = ((GET_BYTE(to_push, 0) >> 4) & 1) != 1;
+      if (!unsafe_allow_gas && gas_pressed && !gas_pressed_prev && !gas_interceptor_detected) {
+        controls_allowed = 0;
+      }
+      gas_pressed_prev = gas_pressed;
     }
 
     // sample speed
@@ -131,15 +139,6 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
         controls_allowed = 0;
       }
       gas_interceptor_prev = gas_interceptor;
-    }
-
-    // exit controls on rising edge of gas press
-    if (addr == 0x2C1) {
-      bool gas_pressed = GET_BYTE(to_push, 6) != 0;
-      if (!unsafe_allow_gas && gas_pressed && !gas_pressed_prev && !gas_interceptor_detected) {
-        controls_allowed = 0;
-      }
-      gas_pressed_prev = gas_pressed;
     }
 
     // 0x2E4 is lkas cmd. If it is on bus 0, then relay is unexpectedly closed


### PR DESCRIPTION
While refactoring the safety tests to use the can packer, I noticed that some toyota models (like prius) aren't included in the gas press check since they didn't have the `0x2c1` signal. This new signal is in the `PCM_CRUISE` message, so this should work for all toyota.

Ideally, there should be a test that tests each model and checks that panda safety and CarState agree to catch things like this.

Closes #404 