### PR TITLE
Chrysler: fix missing button signal on TX

### DIFF
--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -194,7 +194,7 @@ static int chrysler_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
   // FORCE CANCEL: only the cancel button press is allowed
   if (addr == 571) {
-    if (GET_BYTE(to_send, 0) != 1) {
+    if ((GET_BYTE(to_send, 0) != 1) || ((GET_BYTE(to_send, 1) & 1) == 1)) {
       tx = 0;
     }
   }

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -239,7 +239,7 @@ class TestChryslerSafety(unittest.TestCase):
 
   def test_cancel_button(self):
     CANCEL = 1
-    for b in range(0, 0xff):
+    for b in range(0, 0x1ff):
       if b == CANCEL:
         self.assertTrue(self.safety.safety_tx_hook(self._button_msg(b)))
       else:


### PR DESCRIPTION
The Chrysler TX hook only allows spoofing of cancel, but since it only checked the first byte, it missed the `ACC_FOLLOW_INC` signal. The test also didn't check for this.

https://github.com/commaai/opendbc/blob/master/chrysler_pacifica_2017_hybrid.dbc#L208