### PR TITLE
Subaru: fix steer torque scaling

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -76,10 +76,11 @@ static int subaru_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       int torque_driver_new;
       if (subaru_global) {
         torque_driver_new = ((GET_BYTES_04(to_push) >> 16) & 0x7FF);
+        torque_driver_new = -1 * to_signed(torque_driver_new, 11);
       } else {
         torque_driver_new = (GET_BYTE(to_push, 3) >> 5) + (GET_BYTE(to_push, 4) << 3);
+        torque_driver_new = to_signed(torque_driver_new, 11);
       }
-      torque_driver_new = to_signed(torque_driver_new, 11);
       update_sample(&subaru_torque_driver, torque_driver_new);
     }
 
@@ -153,7 +154,7 @@ static int subaru_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
     int desired_torque = ((GET_BYTES_04(to_send) >> bit_shift) & 0x1FFF);
     bool violation = 0;
     uint32_t ts = TIM2->CNT;
-    desired_torque = to_signed(desired_torque, 13);
+    desired_torque = -1 * to_signed(desired_torque, 13);
 
     if (controls_allowed) {
 

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -192,7 +192,7 @@ class TestSubaruLegacySafety(TestSubaruSafety):
     return self.packer.make_can_msg_panda("Steering_Torque", 0, values)
 
   def _torque_msg(self, torque):
-    values = {"LKAS_Command": -torque}
+    values = {"LKAS_Command": torque}
     return self.packer.make_can_msg_panda("ES_LKAS", 0, values)
 
   def _gas_msg(self, gas):

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -60,14 +60,15 @@ class TestSubaruSafety(unittest.TestCase):
     self.safety.set_subaru_rt_torque_last(t)
 
   def _torque_driver_msg(self, torque):
-    t = twos_comp(torque, 11)
     if self.safety.get_subaru_global():
+      t = twos_comp(-torque, 11)
       to_send = make_msg(0, 0x119)
       to_send[0].RDLR = ((t & 0x7FF) << 16)
       to_send[0].RDLR |= (self.cnt_torque_driver & 0xF) << 8
       to_send[0].RDLR |= subaru_checksum(to_send, 0x119, 8)
       self.__class__.cnt_torque_driver += 1
     else:
+      t = twos_comp(torque, 11)
       to_send = make_msg(0, 0x371)
       to_send[0].RDLR = (t & 0x7) << 29
       to_send[0].RDHR = (t >> 3) & 0xFF
@@ -92,7 +93,7 @@ class TestSubaruSafety(unittest.TestCase):
     return to_send
 
   def _torque_msg(self, torque):
-    t = twos_comp(torque, 13)
+    t = twos_comp(-torque, 13)
     if self.safety.get_subaru_global():
       to_send = make_msg(0, 0x122)
       to_send[0].RDLR = (t << 16)


### PR DESCRIPTION
I was hesitant to change the legacy scaling for driver torque since the [DBC](https://github.com/commaai/opendbc/blob/master/subaru_outback_2015_eyesight.dbc#L280) has a wildly different factor.

@bugsy924 can you verify the scaling factor for driver torque for legacy? or maybe the DBC needs to be updated?