### PR TITLE
add support to can_unique.py for Cabana CSV format.

### DIFF
--- a/examples/can_unique.py
+++ b/examples/can_unique.py
@@ -4,13 +4,19 @@
 # messages, print which bits in the interesting file have never appeared
 # in the background files.
 
-# Expects the CSV file to be in the format from can_logger.py
+# Expects the CSV file to be in one of the following formats:
+
+# can_logger.py
 # Bus,MessageID,Message,MessageLength
 # 0,0x292,0x040000001068,6
 
 # The old can_logger.py format is also supported:
 # Bus,MessageID,Message
 # 0,344,c000c00000000000
+
+# Cabana "Save Log" format
+# time,addr,bus,data
+# 240.47911496100002,53,0,0acc0ade0074bf9e
 
 
 import csv
@@ -45,30 +51,58 @@ class Info():
 
   def load(self, filename):
     """Given a CSV file, adds information about message IDs and their values."""
-    with open(filename, 'rb') as input:
+    with open(filename, 'r') as input:
       reader = csv.reader(input)
-      next(reader, None)  # skip the CSV header
-      for row in reader:
-        bus = row[0]
-        if row[1].startswith('0x'):
-          message_id = row[1][2:]  # remove leading '0x'
-        else:
-          message_id = hex(int(row[1]))[2:]  # old message IDs are in decimal
-        message_id = '%s:%s' % (bus, message_id)
-        if row[1].startswith('0x'):
-          data = row[2][2:]  # remove leading '0x'
-        else:
-          data = row[2]
-        if message_id not in self.messages:
-          self.messages[message_id] = Message(message_id)
-        message = self.messages[message_id]
-        if data not in self.messages[message_id].data:
-          message.data[data] = True
-        bytes = bytearray.fromhex(data)
-        for i in range(len(bytes)):
-          message.ones[i] = message.ones[i] | int(bytes[i])
-          # Inverts the data and masks it to a byte to get the zeros as ones.
-          message.zeros[i] = message.zeros[i] | ( (~int(bytes[i])) & 0xff)
+      header = next(reader, None)
+      print(header)
+      if header[0] == 'time':
+        self.cabana(reader)
+      else:
+        self.loger(reader)
+
+  def cabana(self, reader):
+    # next(reader, None)  # skip the CSV header
+    for row in reader:
+      bus = row[2]
+      message_id = hex(int(row[1]))[2:]  # old message IDs are in decimal
+      message_id = '%s:%s' % (bus, message_id)
+      data = row[3]
+      if message_id not in self.messages:
+        self.messages[message_id] = Message(message_id)
+      message = self.messages[message_id]
+      if data not in self.messages[message_id].data:
+        message.data[data] = True
+      bytes = bytearray.fromhex(data)
+      for i in range(len(bytes)):
+        message.ones[i] = message.ones[i] | int(bytes[i])
+        # Inverts the data and masks it to a byte to get the zeros as ones.
+        message.zeros[i] = message.zeros[i] | ( (~int(bytes[i])) & 0xff)
+
+  def logger(self, reader):
+    # next(reader, None)  # skip the CSV header
+    for row in reader:
+      bus = row[0]
+      if row[1].startswith('0x'):
+        message_id = row[1][2:]  # remove leading '0x'
+      else:
+        message_id = hex(int(row[1]))[2:]  # old message IDs are in decimal
+      message_id = '%s:%s' % (bus, message_id)
+      if row[1].startswith('0x'):
+        data = row[2][2:]  # remove leading '0x'
+      else:
+        data = row[2]
+      if message_id not in self.messages:
+        self.messages[message_id] = Message(message_id)
+      message = self.messages[message_id]
+      if data not in self.messages[message_id].data:
+        message.data[data] = True
+      bytes = bytearray.fromhex(data)
+      for i in range(len(bytes)):
+        message.ones[i] = message.ones[i] | int(bytes[i])
+        # Inverts the data and masks it to a byte to get the zeros as ones.
+        message.zeros[i] = message.zeros[i] | ( (~int(bytes[i])) & 0xff)
+
+
 
 def PrintUnique(interesting_file, background_files):
   background = Info()

--- a/examples/can_unique.py
+++ b/examples/can_unique.py
@@ -57,7 +57,7 @@ class Info():
       if header[0] == 'time':
         self.cabana(reader)
       else:
-        self.loger(reader)
+        self.logger(reader)
 
   def cabana(self, reader):
     for row in reader:

--- a/examples/can_unique.py
+++ b/examples/can_unique.py
@@ -54,32 +54,20 @@ class Info():
     with open(filename, 'r') as input:
       reader = csv.reader(input)
       header = next(reader, None)
-      print(header)
       if header[0] == 'time':
         self.cabana(reader)
       else:
         self.loger(reader)
 
   def cabana(self, reader):
-    # next(reader, None)  # skip the CSV header
     for row in reader:
       bus = row[2]
-      message_id = hex(int(row[1]))[2:]  # old message IDs are in decimal
+      message_id = hex(int(row[1]))[2:]
       message_id = '%s:%s' % (bus, message_id)
       data = row[3]
-      if message_id not in self.messages:
-        self.messages[message_id] = Message(message_id)
-      message = self.messages[message_id]
-      if data not in self.messages[message_id].data:
-        message.data[data] = True
-      bytes = bytearray.fromhex(data)
-      for i in range(len(bytes)):
-        message.ones[i] = message.ones[i] | int(bytes[i])
-        # Inverts the data and masks it to a byte to get the zeros as ones.
-        message.zeros[i] = message.zeros[i] | ( (~int(bytes[i])) & 0xff)
+      self.store(message_id, data)
 
   def logger(self, reader):
-    # next(reader, None)  # skip the CSV header
     for row in reader:
       bus = row[0]
       if row[1].startswith('0x'):
@@ -91,6 +79,9 @@ class Info():
         data = row[2][2:]  # remove leading '0x'
       else:
         data = row[2]
+      self.store(message_id, data)
+
+  def store(self, message_id, data):
       if message_id not in self.messages:
         self.messages[message_id] = Message(message_id)
       message = self.messages[message_id]


### PR DESCRIPTION
also fix python3 issue where open() was in binary mode, but we want text mode.