### PR TITLE
Match Panda DFU entry fix in "make recover" process

### DIFF
--- a/board/build.mk
+++ b/board/build.mk
@@ -42,6 +42,7 @@ bin: obj/$(PROJ_NAME).bin
 
 # this flashes everything
 recover: obj/bootstub.$(PROJ_NAME).bin obj/$(PROJ_NAME).bin
+	-PYTHONPATH=../ python3 -c "from python import Panda; Panda().reset(enter_bootstub=True)"
 	-PYTHONPATH=../ python3 -c "from python import Panda; Panda().reset(enter_bootloader=True)"
 	sleep 1.0
 	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08004000 -D obj/$(PROJ_NAME).bin

--- a/board/build.mk
+++ b/board/build.mk
@@ -42,8 +42,7 @@ bin: obj/$(PROJ_NAME).bin
 
 # this flashes everything
 recover: obj/bootstub.$(PROJ_NAME).bin obj/$(PROJ_NAME).bin
-	-PYTHONPATH=../ python3 -c "from python import Panda; Panda().reset(enter_bootstub=True)"
-	-PYTHONPATH=../ python3 -c "from python import Panda; Panda().reset(enter_bootloader=True)"
+	-PYTHONPATH=../ python3 -c "from python import Panda; Panda().reset(enter_bootstub=True); Panda().reset(enter_bootloader=True)"
 	sleep 1.0
 	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08004000 -D obj/$(PROJ_NAME).bin
 	$(DFU_UTIL) -d 0483:df11 -a 0 -s 0x08000000:leave -D obj/bootstub.$(PROJ_NAME).bin


### PR DESCRIPTION
Title says it all. This helped at least one user get unstuck from Panda refusing to accept DEBUG signed firmware by flashing it via DFU from the command line. Original update process fix taken from f07a6ee.

This fix may help users experiencing #449.