### PR TITLE
Fix definition naming. Was this a typo?

### DIFF
--- a/board/drivers/llcan.h
+++ b/board/drivers/llcan.h
@@ -12,8 +12,8 @@
 #define GET_LEN(msg) ((msg)->RDTR & 0xF)
 #define GET_ADDR(msg) ((((msg)->RIR & 4) != 0) ? ((msg)->RIR >> 3) : ((msg)->RIR >> 21))
 #define GET_BYTE(msg, b) (((int)(b) > 3) ? (((msg)->RDHR >> (8U * ((unsigned int)(b) % 4U))) & 0xFFU) : (((msg)->RDLR >> (8U * (unsigned int)(b))) & 0xFFU))
-#define GET_BYTES_04(msg) ((msg)->RDLR)
-#define GET_BYTES_48(msg) ((msg)->RDHR)
+#define GET_BYTES_03(msg) ((msg)->RDLR)
+#define GET_BYTES_47(msg) ((msg)->RDHR)
 
 #define CAN_INIT_TIMEOUT_MS 500U
 #define CAN_NAME_FROM_CANIF(CAN_DEV) (((CAN_DEV)==CAN1) ? "CAN1" : (((CAN_DEV) == CAN2) ? "CAN2" : "CAN3"))

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -147,11 +147,11 @@ void CAN1_RX0_IRQ_Handler(void) {
     int address = CAN->sFIFOMailBox[0].RIR >> 21;
     if (address == CAN_GAS_INPUT) {
       // softloader entry
-      if (GET_BYTES_04(&CAN->sFIFOMailBox[0]) == 0xdeadface) {
-        if (GET_BYTES_48(&CAN->sFIFOMailBox[0]) == 0x0ab00b1e) {
+      if (GET_BYTES_03(&CAN->sFIFOMailBox[0]) == 0xdeadface) {
+        if (GET_BYTES_47(&CAN->sFIFOMailBox[0]) == 0x0ab00b1e) {
           enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
           NVIC_SystemReset();
-        } else if (GET_BYTES_48(&CAN->sFIFOMailBox[0]) == 0x02b00b1e) {
+        } else if (GET_BYTES_47(&CAN->sFIFOMailBox[0]) == 0x02b00b1e) {
           enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
           NVIC_SystemReset();
         } else {

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -37,7 +37,7 @@ static int hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 593) {
-      int torque_driver_new = ((GET_BYTES_04(to_push) & 0x7ff) * 0.79) - 808; // scale down new driver torque signal to match previous one
+      int torque_driver_new = ((GET_BYTES_03(to_push) & 0x7ff) * 0.79) - 808; // scale down new driver torque signal to match previous one
       // update array of samples
       update_sample(&hyundai_torque_driver, torque_driver_new);
     }
@@ -45,7 +45,7 @@ static int hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == 1057) {
       // 2 bits: 13-14
-      int cruise_engaged = (GET_BYTES_04(to_push) >> 13) & 0x3;
+      int cruise_engaged = (GET_BYTES_03(to_push) >> 13) & 0x3;
       if (cruise_engaged && !hyundai_cruise_engaged_last) {
         controls_allowed = 1;
       }
@@ -66,8 +66,8 @@ static int hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
 
     // sample subaru wheel speed, averaging opposite corners
     if (addr == 902) {
-      hyundai_speed = GET_BYTES_04(to_push) & 0x3FFF;  // FL
-      hyundai_speed += (GET_BYTES_48(to_push) >> 16) & 0x3FFF;  // RL
+      hyundai_speed = GET_BYTES_03(to_push) & 0x3FFF;  // FL
+      hyundai_speed += (GET_BYTES_47(to_push) >> 16) & 0x3FFF;  // RL
       hyundai_speed /= 2;
     }
 
@@ -104,7 +104,7 @@ static int hyundai_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
 
   // LKA STEER: safety check
   if (addr == 832) {
-    int desired_torque = ((GET_BYTES_04(to_send) >> 16) & 0x7ff) - 1024;
+    int desired_torque = ((GET_BYTES_03(to_send) >> 16) & 0x7ff) - 1024;
     uint32_t ts = TIM2->CNT;
     bool violation = 0;
 
@@ -153,7 +153,7 @@ static int hyundai_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   // ensuring that only the cancel button press is sent (VAL 4) when controls are off.
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == 1265) && !controls_allowed) {
-    if ((GET_BYTES_04(to_send) & 0x7) != 4) {
+    if ((GET_BYTES_03(to_send) & 0x7) != 4) {
       tx = 0;
     }
   }

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -46,7 +46,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       if (addr == 0x2) {
         // Current steering angle
         // Factor -0.1, little endian
-        int angle_meas_new = (GET_BYTES_04(to_push) & 0xFFFF);
+        int angle_meas_new = (GET_BYTES_03(to_push) & 0xFFFF);
         // Need to multiply by 10 here as LKAS and Steering wheel are different base unit
         angle_meas_new = to_signed(angle_meas_new, 16) * 10;
 

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -188,10 +188,10 @@ static int tesla_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       bus_fwd = 2; // Custom EPAS bus
     }
     if (addr == 0x101) {
-      to_fwd->RDLR = GET_BYTES_04(to_fwd) | 0x4000; // 0x4000: WITH_ANGLE, 0xC000: WITH_BOTH (angle and torque)
+      to_fwd->RDLR = GET_BYTES_03(to_fwd) | 0x4000; // 0x4000: WITH_ANGLE, 0xC000: WITH_BOTH (angle and torque)
       uint32_t checksum = (GET_BYTE(to_fwd, 1) + GET_BYTE(to_fwd, 0) + 2) & 0xFF;
-      to_fwd->RDLR = GET_BYTES_04(to_fwd) & 0xFFFF;
-      to_fwd->RDLR = GET_BYTES_04(to_fwd) + (checksum << 16);
+      to_fwd->RDLR = GET_BYTES_03(to_fwd) & 0xFFFF;
+      to_fwd->RDLR = GET_BYTES_03(to_fwd) + (checksum << 16);
     }
   }
   if (bus_num == 2) {

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -182,7 +182,7 @@ static int volkswagen_mqb_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // Exit controls on rising edge of gas press
     // Signal: Motor_20.MO_Fahrpedalrohwert_01
     if (addr == MSG_MOTOR_20) {
-      bool gas_pressed = ((GET_BYTES_04(to_push) >> 12) & 0xFF) != 0;
+      bool gas_pressed = ((GET_BYTES_03(to_push) >> 12) & 0xFF) != 0;
       if (gas_pressed && !gas_pressed_prev && !(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
         controls_allowed = 0;
       }

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -73,8 +73,8 @@ void fault_recovered(uint32_t fault) {
 #define GET_LEN(msg) ((msg)->RDTR & 0xf)
 #define GET_ADDR(msg) ((((msg)->RIR & 4) != 0) ? ((msg)->RIR >> 3) : ((msg)->RIR >> 21))
 #define GET_BYTE(msg, b) (((int)(b) > 3) ? (((msg)->RDHR >> (8U * ((unsigned int)(b) % 4U))) & 0XFFU) : (((msg)->RDLR >> (8U * (unsigned int)(b))) & 0xFFU))
-#define GET_BYTES_04(msg) ((msg)->RDLR)
-#define GET_BYTES_48(msg) ((msg)->RDHR)
+#define GET_BYTES_03(msg) ((msg)->RDLR)
+#define GET_BYTES_47(msg) ((msg)->RDHR)
 
 #define UNUSED(x) (void)(x)
 


### PR DESCRIPTION
AFAIK, RDLR and RDHR are 4 bytes each.