### PR TITLE
Fix python library on Windows

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -9,6 +9,7 @@ import os
 import time
 import traceback
 import subprocess
+import sys
 from .dfu import PandaDFU
 from .esptool import ESPROM, CesantaFlasher  # noqa: F401
 from .flash_release import flash_release  # noqa: F401
@@ -187,7 +188,8 @@ class Panda(object):
                 self.bootstub = device.getProductID() == 0xddee
                 self.legacy = (device.getbcdDevice() != 0x2300)
                 self._handle = device.open()
-                self._handle.setAutoDetachKernelDriver(True)
+                if not sys.platform in ["win32", "cygwin", "msys"]:
+                  self._handle.setAutoDetachKernelDriver(True)
                 if claim:
                   self._handle.claimInterface(0)
                   #self._handle.setInterfaceAltSetting(0, 0) #Issue in USB stack


### PR DESCRIPTION
On Windows, setAutoDetachKernelDriver is not supported ([libusb docs](http://libusb.sourceforge.net/api-1.0/group__libusb__dev.html#ga5e0cc1d666097e915748593effdc634a)) and causes libusb to get stuck (simple try-catch is not working). This prevents any issues when running both at native windows python and cygwined python...

How it looks without fix (running can_logger.py from examples):
```
Trying to connect to Panda over USB...
opening device asd  450033000851363038363036 0xddcc
exception LIBUSB_ERROR_NOT_SUPPORTED [-12]
Traceback (most recent call last):
  File "./git/panda/python/__init__.py", line 190, in connect
    self._handle.setAutoDetachKernelDriver(True)
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 1346, in setAutoDetachKernelDriver
    self.__handle, bool(enable),
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 133, in mayRaiseUSBError
    __raiseUSBError(value)
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 125, in raiseUSBError
    raise __STATUS_TO_EXCEPTION_DICT.get(value, __USBError)(value)
usb1.USBErrorNotSupported: LIBUSB_ERROR_NOT_SUPPORTED [-12]
connected
Traceback (most recent call last):
  File "test.py", line 18, in <module>
    can_recv = p.can_recv()
  File "./git/panda/python/__init__.py", line 521, in can_recv
    dat = self._handle.bulkRead(1, 0x10*256)
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 1519, in bulkRead
    transferred = self._bulkTransfer(endpoint, data, length, timeout)
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 1480, in _bulkTransfer
    self.__handle, endpoint, data, length, byref(transferred), timeout,
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 133, in mayRaiseUSBError
    __raiseUSBError(value)
  File "/usr/lib/python3.6/site-packages/usb1/__init__.py", line 125, in raiseUSBError
    raise __STATUS_TO_EXCEPTION_DICT.get(value, __USBError)(value)
usb1.USBErrorNotFound: LIBUSB_ERROR_NOT_FOUND [-5]
```

After fix:
```
Trying to connect to Panda over USB...
opening device asd  450033000851363038363036 0xddcc
connected
```
