### PR TITLE
Fix CAN Ignition for Black Panda and Uno

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -2,7 +2,7 @@
 // Black Panda + Harness //
 // ///////////////////// //
 
-uint8_t transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus in default orientation
+uint8_t black_transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus in default orientation
 
 void black_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
@@ -27,7 +27,7 @@ void black_enable_can_transciever(uint8_t transciever, bool enabled) {
 void black_enable_can_transcievers(bool enabled) {
   uint8_t first_bus = enabled ? 0U : 1U;  // leave transciever for bus 0 enabled to detect CAN ignition
   for(uint8_t bus=first_bus; bus<=3U; bus++) {
-    uno_enable_can_transciever(transciever_lookup[bus], enabled);
+    black_enable_can_transciever(black_transciever_lookup[bus], enabled);
   }
 }
 
@@ -202,8 +202,8 @@ void black_init(void) {
   // flip CAN0 and CAN2 if we are flipped
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
-    transciever_lookup[0] = 3U;
-    transciever_lookup[2] = 1U;
+    black_transciever_lookup[0] = 3U;
+    black_transciever_lookup[2] = 1U;
   }
 
   // init multiplexer

--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -2,8 +2,6 @@
 // Black Panda + Harness //
 // ///////////////////// //
 
-uint8_t black_transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus in default orientation
-
 void black_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
     case 1U:
@@ -25,9 +23,13 @@ void black_enable_can_transciever(uint8_t transciever, bool enabled) {
 }
 
 void black_enable_can_transcievers(bool enabled) {
-  uint8_t first_bus = enabled ? 0U : 1U;  // leave transciever for bus 0 enabled to detect CAN ignition
-  for(uint8_t bus=first_bus; bus<=3U; bus++) {
-    black_enable_can_transciever(black_transciever_lookup[bus], enabled);
+  for(uint8_t i=1U; i<=4U; i++){
+    // Leave main CAN always on for CAN-based ignition detection
+    if((car_harness_status == HARNESS_STATUS_FLIPPED) ? (i == 3U) : (i == 1U)){
+      black_enable_can_transciever(i, true);
+    } else {
+      black_enable_can_transciever(i, enabled);
+    }
   }
 }
 
@@ -202,8 +204,6 @@ void black_init(void) {
   // flip CAN0 and CAN2 if we are flipped
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
-    black_transciever_lookup[0] = 3U;
-    black_transciever_lookup[2] = 1U;
   }
 
   // init multiplexer

--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -2,26 +2,18 @@
 // Black Panda + Harness //
 // ///////////////////// //
 
+uint8_t transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus in default orientation
+
 void black_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
     case 1U:
-      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
-        set_gpio_output(GPIOA, 0, !enabled);
-      }
-      else {
-        set_gpio_output(GPIOC, 1, !enabled);
-      }
+      set_gpio_output(GPIOC, 1, !enabled);
       break;
     case 2U:
       set_gpio_output(GPIOC, 13, !enabled);
       break;
     case 3U:
-      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
-        set_gpio_output(GPIOC, 1, !enabled);
-      }
-      else {
-        set_gpio_output(GPIOA, 0, !enabled);
-      }
+      set_gpio_output(GPIOA, 0, !enabled);
       break;
     case 4U:
       set_gpio_output(GPIOB, 10, !enabled);
@@ -33,9 +25,9 @@ void black_enable_can_transciever(uint8_t transciever, bool enabled) {
 }
 
 void black_enable_can_transcievers(bool enabled) {
-  uint8_t t1 = enabled ? 1U : 2U;  // leave transciever 1 enabled to detect CAN ignition
-  for(uint8_t i=t1; i<=4U; i++) {
-    black_enable_can_transciever(i, enabled);
+  uint8_t first_bus = enabled ? 0U : 1U;  // leave transciever for bus 0 enabled to detect CAN ignition
+  for(uint8_t bus=first_bus; bus<=3U; bus++) {
+    uno_enable_can_transciever(transciever_lookup[bus], enabled);
   }
 }
 
@@ -210,6 +202,8 @@ void black_init(void) {
   // flip CAN0 and CAN2 if we are flipped
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
+    transciever_lookup[0] = 3U;
+    transciever_lookup[2] = 1U;
   }
 
   // init multiplexer

--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -5,13 +5,23 @@
 void black_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
     case 1U:
-      set_gpio_output(GPIOC, 1, !enabled);
+      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
+        set_gpio_output(GPIOA, 0, !enabled);
+      }
+      else {
+        set_gpio_output(GPIOC, 1, !enabled);
+      }
       break;
     case 2U:
       set_gpio_output(GPIOC, 13, !enabled);
       break;
     case 3U:
-      set_gpio_output(GPIOA, 0, !enabled);
+      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
+        set_gpio_output(GPIOC, 1, !enabled);
+      }
+      else {
+        set_gpio_output(GPIOA, 0, !enabled);
+      }
       break;
     case 4U:
       set_gpio_output(GPIOB, 10, !enabled);

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -4,7 +4,7 @@
 #define BOOTKICK_TIME 3U
 uint8_t bootkick_timer = 0U;
 
-uint8_t transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus
+uint8_t uno_transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus
 
 void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
@@ -29,7 +29,7 @@ void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
 void uno_enable_can_transcievers(bool enabled) {
   uint8_t first_bus = enabled ? 0U : 1U;  // leave transciever for bus 0 enabled to detect CAN ignition
   for(uint8_t bus=first_bus; bus<=3U; bus++) {
-    uno_enable_can_transciever(transciever_lookup[bus], enabled);
+    uno_enable_can_transciever(uno_transciever_lookup[bus], enabled);
   }
 }
 
@@ -235,8 +235,8 @@ void uno_init(void) {
   // flip CAN0 and CAN2 if we are flipped
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
-    transciever_lookup[0] = 3U;
-    transciever_lookup[2] = 1U;
+    uno_transciever_lookup[0] = 3U;
+    uno_transciever_lookup[2] = 1U;
   }
 
   // init multiplexer

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -7,13 +7,23 @@ uint8_t bootkick_timer = 0U;
 void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
     case 1U:
-      set_gpio_output(GPIOC, 1, !enabled);
+      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
+        set_gpio_output(GPIOA, 0, !enabled);
+      }
+      else {
+        set_gpio_output(GPIOC, 1, !enabled);
+      }
       break;
     case 2U:
       set_gpio_output(GPIOC, 13, !enabled);
       break;
     case 3U:
-      set_gpio_output(GPIOA, 0, !enabled);
+      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
+        set_gpio_output(GPIOC, 1, !enabled);
+      }
+      else {
+        set_gpio_output(GPIOA, 0, !enabled);
+      }
       break;
     case 4U:
       set_gpio_output(GPIOB, 10, !enabled);
@@ -25,7 +35,8 @@ void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
 }
 
 void uno_enable_can_transcievers(bool enabled) {
-  for(uint8_t i=1U; i<=4U; i++){
+  uint8_t t1 = enabled ? 1U : 2U;  // leave transciever 1 enabled to detect CAN ignition
+  for(uint8_t i=t1; i<=4U; i++){
     uno_enable_can_transciever(i, enabled);
   }
 }

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -4,7 +4,7 @@
 #define BOOTKICK_TIME 3U
 uint8_t bootkick_timer = 0U;
 
-uint8_t uno_transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus
+uint8_t uno_transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus in default orientation
 
 void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -4,26 +4,18 @@
 #define BOOTKICK_TIME 3U
 uint8_t bootkick_timer = 0U;
 
+uint8_t transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus
+
 void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
     case 1U:
-      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
-        set_gpio_output(GPIOA, 0, !enabled);
-      }
-      else {
-        set_gpio_output(GPIOC, 1, !enabled);
-      }
+      set_gpio_output(GPIOC, 1, !enabled);
       break;
     case 2U:
       set_gpio_output(GPIOC, 13, !enabled);
       break;
     case 3U:
-      if (car_harness_status == HARNESS_STATUS_FLIPPED) {
-        set_gpio_output(GPIOC, 1, !enabled);
-      }
-      else {
         set_gpio_output(GPIOA, 0, !enabled);
-      }
       break;
     case 4U:
       set_gpio_output(GPIOB, 10, !enabled);
@@ -35,9 +27,9 @@ void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
 }
 
 void uno_enable_can_transcievers(bool enabled) {
-  uint8_t t1 = enabled ? 1U : 2U;  // leave transciever 1 enabled to detect CAN ignition
-  for(uint8_t i=t1; i<=4U; i++){
-    uno_enable_can_transciever(i, enabled);
+  uint8_t first_bus = enabled ? 0U : 1U;  // leave transciever for bus 0 enabled to detect CAN ignition
+  for(uint8_t bus=first_bus; bus<=3U; bus++) {
+    uno_enable_can_transciever(transciever_lookup[bus], enabled);
   }
 }
 
@@ -243,6 +235,8 @@ void uno_init(void) {
   // flip CAN0 and CAN2 if we are flipped
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
+    transciever_lookup[0] = 3U;
+    transciever_lookup[2] = 1U;
   }
 
   // init multiplexer

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -15,7 +15,7 @@ void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
       set_gpio_output(GPIOC, 13, !enabled);
       break;
     case 3U:
-        set_gpio_output(GPIOA, 0, !enabled);
+      set_gpio_output(GPIOA, 0, !enabled);
       break;
     case 4U:
       set_gpio_output(GPIOB, 10, !enabled);

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -4,8 +4,6 @@
 #define BOOTKICK_TIME 3U
 uint8_t bootkick_timer = 0U;
 
-uint8_t uno_transciever_lookup[] = {1U, 2U, 3U, 4U}; // Map transciever to bus in default orientation
-
 void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
   switch (transciever){
     case 1U:
@@ -27,9 +25,13 @@ void uno_enable_can_transciever(uint8_t transciever, bool enabled) {
 }
 
 void uno_enable_can_transcievers(bool enabled) {
-  uint8_t first_bus = enabled ? 0U : 1U;  // leave transciever for bus 0 enabled to detect CAN ignition
-  for(uint8_t bus=first_bus; bus<=3U; bus++) {
-    uno_enable_can_transciever(uno_transciever_lookup[bus], enabled);
+  for(uint8_t i=1U; i<=4U; i++){
+    // Leave main CAN always on for CAN-based ignition detection
+    if((car_harness_status == HARNESS_STATUS_FLIPPED) ? (i == 3U) : (i == 1U)){
+      uno_enable_can_transciever(i, true);
+    } else {
+      uno_enable_can_transciever(i, enabled);
+    }
   }
 }
 
@@ -235,8 +237,6 @@ void uno_init(void) {
   // flip CAN0 and CAN2 if we are flipped
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
-    uno_transciever_lookup[0] = 3U;
-    uno_transciever_lookup[2] = 1U;
   }
 
   // init multiplexer


### PR DESCRIPTION
Both Black Panda and Uno transceiver enabled code needed to be updated to match ODB-C orientation. Otherwise it only works in one orientation.

Uno needed to be updated to leave the transceiver mapped to BUS 0 enabled while sleeping to listen for CAN based ignition. 