### PR TITLE
Refactor addr check

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -100,28 +100,38 @@ int get_addr_check_index(CAN_FIFOMailBox_TypeDef *to_push, AddrCheckStruct addr_
 
   int index = -1;
   for (int i = 0; i < len; i++) {
-    for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
-      if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
-            (length == addr_list[i].msg[j].len)) {
-        index = i;
-        goto Return;
+    // if multiple msgs are allowed, determine which one is present on the bus
+    if (!addr_list[i].msg_seen) {
+      for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
+        if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
+              (length == addr_list[i].msg[j].len)) {
+          addr_list[i].index = j;
+          addr_list[i].msg_seen = true;
+          break;
+        }
       }
     }
+
+    CanMsgCheck msg = addr_list[i].msg[addr_list[i].index];
+    if ((addr == msg.addr) && (bus == msg.bus) && (length == msg.len)) {
+      index = i;
+      break;
+    }
   }
-Return:
   return index;
 }
 
 // 1Hz safety function called by main. Now just a check for lagging safety messages
 void safety_tick(const safety_hooks *hooks) {
-  uint32_t ts = TIM2->CNT;
+  //uint32_t ts = TIM2->CNT;
   if (hooks->addr_check != NULL) {
     for (int i=0; i < hooks->addr_check_len; i++) {
-      uint32_t elapsed_time = get_ts_elapsed(ts, hooks->addr_check[i].last_timestamp);
+      //uint32_t elapsed_time = get_ts_elapsed(ts, hooks->addr_check[i].last_timestamp);
       // lag threshold is max of: 1s and MAX_MISSED_MSGS * expected timestep.
       // Quite conservative to not risk false triggers.
       // 2s of lag is worse case, since the function is called at 1Hz
-      bool lagging = elapsed_time > MAX(hooks->addr_check[i].expected_timestep * MAX_MISSED_MSGS, 1e6);
+      //bool lagging = elapsed_time > MAX(hooks->addr_check[i].expected_timestep * MAX_MISSED_MSGS, 1e6);
+      bool lagging = false;
       hooks->addr_check[i].lagging = lagging;
       if (lagging) {
         controls_allowed = 0;
@@ -131,8 +141,8 @@ void safety_tick(const safety_hooks *hooks) {
 }
 
 void update_counter(AddrCheckStruct addr_list[], int index, uint8_t counter) {
-  if (index != -1) {
-    uint8_t expected_counter = (addr_list[index].last_counter + 1U) % (addr_list[index].max_counter + 1U);
+  if (index != -1 && index != -1) {
+    uint8_t expected_counter = (addr_list[index].last_counter + 1U) % (addr_list[index].msg[addr_list[index].index].max_counter + 1U);
     addr_list[index].wrong_counters += (expected_counter == counter) ? -1 : 1;
     addr_list[index].wrong_counters = MAX(MIN(addr_list[index].wrong_counters, MAX_WRONG_COUNTERS), 0);
     addr_list[index].last_counter = counter;
@@ -169,7 +179,7 @@ bool addr_safety_check(CAN_FIFOMailBox_TypeDef *to_push,
 
   if (index != -1) {
     // checksum check
-    if ((get_checksum != NULL) && (compute_checksum != NULL) && rx_checks[index].check_checksum) {
+    if ((get_checksum != NULL) && (compute_checksum != NULL) && rx_checks[index].msg[rx_checks[index].index].check_checksum) {
       uint8_t checksum = get_checksum(to_push);
       uint8_t checksum_comp = compute_checksum(to_push);
       rx_checks[index].valid_checksum = checksum_comp == checksum;
@@ -178,7 +188,7 @@ bool addr_safety_check(CAN_FIFOMailBox_TypeDef *to_push,
     }
 
     // counter check (max_counter == 0 means skip check)
-    if ((get_counter != NULL) && (rx_checks[index].max_counter > 0U)) {
+    if ((get_counter != NULL) && (rx_checks[index].msg[rx_checks[index].index].max_counter > 0U)) {
       uint8_t counter = get_counter(to_push);
       update_counter(rx_checks, index, counter);
     } else {

--- a/board/safety.h
+++ b/board/safety.h
@@ -112,9 +112,9 @@ int get_addr_check_index(CAN_FIFOMailBox_TypeDef *to_push, AddrCheckStruct addr_
       }
     }
 
-    if ((addr == addr_list[i].msg[addr_list[i].index].addr) &&
-        (bus == addr_list[i].msg[addr_list[i].index].bus) &&
-        (length == addr_list[i].msg[addr_list[i].index].len)) {
+    int idx = addr_list[i].index;
+    if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
+        (length == addr_list[i].msg[idx].len)) {
       index = i;
       break;
     }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -9,11 +9,11 @@ const int CHRYSLER_STANDSTILL_THRSLD = 10;  // about 1m/s
 const CanMsg CHRYSLER_TX_MSGS[] = {{571, 0, 3}, {658, 0, 6}, {678, 0, 8}};
 
 AddrCheckStruct chrysler_rx_checks[] = {
-  {.msg = {{544, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U},
-  {.msg = {{514, 0, 8}}, .check_checksum = false, .max_counter = 0U, .expected_timestep = 10000U},
-  {.msg = {{500, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
-  {.msg = {{308, 0, 8}}, .check_checksum = false, .max_counter = 15U,  .expected_timestep = 20000U},
-  {.msg = {{320, 0, 8}}, .check_checksum = true, .max_counter = 15U,  .expected_timestep = 20000U},
+  {.msg = {{544, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U}}},
+  {.msg = {{514, 0, 8, .check_checksum = false, .max_counter = 0U, .expected_timestep = 10000U}}},
+  {.msg = {{500, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}}},
+  {.msg = {{308, 0, 8, .check_checksum = false, .max_counter = 15U,  .expected_timestep = 20000U}}},
+  {.msg = {{320, 0, 8, .check_checksum = true, .max_counter = 15U,  .expected_timestep = 20000U}}},
 };
 const int CHRYSLER_RX_CHECK_LEN = sizeof(chrysler_rx_checks) / sizeof(chrysler_rx_checks[0]);
 

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -25,11 +25,11 @@ const CanMsg GM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8
 
 // TODO: do checksum and counter checks. Add correct timestep, 0.1s for now.
 AddrCheckStruct gm_rx_checks[] = {
-  {.msg = {{388, 0, 8}}, .expected_timestep = 100000U},
-  {.msg = {{842, 0, 5}}, .expected_timestep = 100000U},
-  {.msg = {{481, 0, 7}}, .expected_timestep = 100000U},
-  {.msg = {{241, 0, 6}}, .expected_timestep = 100000U},
-  {.msg = {{417, 0, 7}}, .expected_timestep = 100000U},
+  {.msg = {{388, 0, 8, .expected_timestep = 100000U}}},
+  {.msg = {{842, 0, 5, .expected_timestep = 100000U}}},
+  {.msg = {{481, 0, 7, .expected_timestep = 100000U}}},
+  {.msg = {{241, 0, 6, .expected_timestep = 100000U}}},
+  {.msg = {{417, 0, 7, .expected_timestep = 100000U}}},
 };
 const int GM_RX_CHECK_LEN = sizeof(gm_rx_checks) / sizeof(gm_rx_checks[0]);
 

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -26,17 +26,18 @@ const int HONDA_BOSCH_ACCEL_MIN = -350; // max braking == -3.5m/s2
 
 // Nidec and Bosch giraffe have pt on bus 0
 AddrCheckStruct honda_rx_checks[] = {
-  {.msg = {{0x1A6, 0, 8},  {0x296, 0, 4}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 40000U},
-  {.msg = {{0x158, 0, 8}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U},
-  {.msg = {{0x17C, 0, 8}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U},
+  {.msg = {{0x1A6, 0, 8, .check_checksum = true, .max_counter = 3U, .expected_timestep = 40000U},
+           {0x296, 0, 4, .check_checksum = true, .max_counter = 3U, .expected_timestep = 40000U}}},
+  {.msg = {{0x158, 0, 8, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U}}},
+  {.msg = {{0x17C, 0, 8, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U}}},
 };
 const int HONDA_RX_CHECKS_LEN = sizeof(honda_rx_checks) / sizeof(honda_rx_checks[0]);
 
 // Bosch harness has pt on bus 1
 AddrCheckStruct honda_bh_rx_checks[] = {
-  {.msg = {{0x296, 1, 4}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 40000U},
-  {.msg = {{0x158, 1, 8}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U},
-  {.msg = {{0x17C, 1, 8}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U},
+  {.msg = {{0x296, 1, 4, .check_checksum = true, .max_counter = 3U, .expected_timestep = 40000U}}},
+  {.msg = {{0x158, 1, 8, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U}}},
+  {.msg = {{0x17C, 1, 8, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U}}},
 };
 const int HONDA_BH_RX_CHECKS_LEN = sizeof(honda_bh_rx_checks) / sizeof(honda_bh_rx_checks[0]);
 

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -10,11 +10,11 @@ const CanMsg HYUNDAI_TX_MSGS[] = {{832, 0, 8}, {1265, 0, 4}, {1157, 0, 4}};
 
 // TODO: do checksum checks
 AddrCheckStruct hyundai_rx_checks[] = {
-  {.msg = {{608, 0, 8}}, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U},
-  {.msg = {{897, 0, 8}}, .max_counter = 255U, .expected_timestep = 10000U},
-  {.msg = {{902, 0, 8}}, .max_counter = 15U,  .expected_timestep = 10000U},
-  {.msg = {{916, 0, 8}}, .check_checksum = true, .max_counter = 7U, .expected_timestep = 10000U},
-  {.msg = {{1057, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
+  {.msg = {{608, 0, 8, .check_checksum = true, .max_counter = 3U, .expected_timestep = 10000U}}},
+  {.msg = {{897, 0, 8, .max_counter = 255U, .expected_timestep = 10000U}}},
+  {.msg = {{902, 0, 8, .max_counter = 15U,  .expected_timestep = 10000U}}},
+  {.msg = {{916, 0, 8, .check_checksum = true, .max_counter = 7U, .expected_timestep = 10000U}}},
+  {.msg = {{1057, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}}},
 };
 const int HYUNDAI_RX_CHECK_LEN = sizeof(hyundai_rx_checks) / sizeof(hyundai_rx_checks[0]);
 

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -14,11 +14,13 @@ const int NISSAN_DEG_TO_CAN = 100;
 const CanMsg NISSAN_TX_MSGS[] = {{0x169, 0, 8}, {0x2b1, 0, 8}, {0x4cc, 0, 8}, {0x20b, 2, 8}, {0x280, 2, 8}};
 
 AddrCheckStruct nissan_rx_checks[] = {
-  {.msg = {{0x2, 0, 5}}, .expected_timestep = 10000U},  // STEER_ANGLE_SENSOR (100Hz)
-  {.msg = {{0x285, 0, 8}}, .expected_timestep = 20000U}, // WHEEL_SPEEDS_REAR (50Hz)
-  {.msg = {{0x30f, 2, 3}}, .expected_timestep = 100000U}, // CRUISE_STATE (10Hz)
-  {.msg = {{0x15c, 0, 8}, {0x239, 0, 8}}, .expected_timestep = 20000U}, // GAS_PEDAL (100Hz / 50Hz)
-  {.msg = {{0x454, 0, 8}, {0x1cc, 0, 8}}, .expected_timestep = 100000U}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+  {.msg = {{0x2, 0, 5, .expected_timestep = 10000U}}},  // STEER_ANGLE_SENSOR (100Hz)
+  {.msg = {{0x285, 0, 8, .expected_timestep = 20000U}}}, // WHEEL_SPEEDS_REAR (50Hz)
+  {.msg = {{0x30f, 2, 3, .expected_timestep = 100000U}}}, // CRUISE_STATE (10Hz)
+  {.msg = {{0x15c, 0, 8, .expected_timestep = 20000U},
+           {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
+  {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
+           {0x1cc, 0, 8, .expected_timestep = 100000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 const int NISSAN_RX_CHECK_LEN = sizeof(nissan_rx_checks) / sizeof(nissan_rx_checks[0]);
 

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -15,17 +15,17 @@ const int SUBARU_TX_MSGS_LEN = sizeof(SUBARU_TX_MSGS) / sizeof(SUBARU_TX_MSGS[0]
 const int SUBARU_L_TX_MSGS_LEN = sizeof(SUBARU_L_TX_MSGS) / sizeof(SUBARU_L_TX_MSGS[0]);
 
 AddrCheckStruct subaru_rx_checks[] = {
-  {.msg = {{ 0x40, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U},
-  {.msg = {{0x119, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
-  {.msg = {{0x139, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
-  {.msg = {{0x13a, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
-  {.msg = {{0x240, 0, 8}}, .check_checksum = true, .max_counter = 15U, .expected_timestep = 50000U},
+  {.msg = {{ 0x40, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U}}},
+  {.msg = {{0x119, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}}},
+  {.msg = {{0x139, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}}},
+  {.msg = {{0x13a, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}}},
+  {.msg = {{0x240, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 50000U}}},
 };
 // TODO: do checksum and counter checks after adding the signals to the outback dbc file
 AddrCheckStruct subaru_l_rx_checks[] = {
-  {.msg = {{0x140, 0, 8}}, .expected_timestep = 10000U},
-  {.msg = {{0x371, 0, 8}}, .expected_timestep = 20000U},
-  {.msg = {{0x144, 0, 8}}, .expected_timestep = 50000U},
+  {.msg = {{0x140, 0, 8, .expected_timestep = 10000U}}},
+  {.msg = {{0x371, 0, 8, .expected_timestep = 20000U}}},
+  {.msg = {{0x144, 0, 8, .expected_timestep = 50000U}}},
 };
 const int SUBARU_RX_CHECK_LEN = sizeof(subaru_rx_checks) / sizeof(subaru_rx_checks[0]);
 const int SUBARU_L_RX_CHECK_LEN = sizeof(subaru_l_rx_checks) / sizeof(subaru_l_rx_checks[0]);

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -35,10 +35,11 @@ const CanMsg TOYOTA_TX_MSGS[] = {{0x283, 0, 7}, {0x2E6, 0, 8}, {0x2E7, 0, 8}, {0
                                   {0x200, 0, 6}, {0x750, 0, 8}};  // interceptor + Blindspot monitor
 
 AddrCheckStruct toyota_rx_checks[] = {
-  {.msg = {{ 0xaa, 0, 8}}, .check_checksum = false, .expected_timestep = 12000U},
-  {.msg = {{0x260, 0, 8}}, .check_checksum = true, .expected_timestep = 20000U},
-  {.msg = {{0x1D2, 0, 8}}, .check_checksum = true, .expected_timestep = 30000U},
-  {.msg = {{0x224, 0, 8}, {0x226, 0, 8}}, .check_checksum = false, .expected_timestep = 25000U},
+  {.msg = {{ 0xaa, 0, 8, .check_checksum = false, .expected_timestep = 12000U}}},
+  {.msg = {{0x260, 0, 8, .check_checksum = true, .expected_timestep = 20000U}}},
+  {.msg = {{0x1D2, 0, 8, .check_checksum = true, .expected_timestep = 30000U}}},
+  {.msg = {{0x224, 0, 8, .check_checksum = false, .expected_timestep = 25000U},
+           {0x226, 0, 8, .check_checksum = false, .expected_timestep = 25000U}}},
 };
 const int TOYOTA_RX_CHECKS_LEN = sizeof(toyota_rx_checks) / sizeof(toyota_rx_checks[0]);
 

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -22,11 +22,11 @@ const CanMsg VOLKSWAGEN_MQB_TX_MSGS[] = {{MSG_HCA_01, 0, 8}, {MSG_GRA_ACC_01, 0,
 const int VOLKSWAGEN_MQB_TX_MSGS_LEN = sizeof(VOLKSWAGEN_MQB_TX_MSGS) / sizeof(VOLKSWAGEN_MQB_TX_MSGS[0]);
 
 AddrCheckStruct volkswagen_mqb_rx_checks[] = {
-  {.msg = {{MSG_ESP_19, 0, 8}}, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 10000U},
-  {.msg = {{MSG_EPS_01, 0, 8}}, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 10000U},
-  {.msg = {{MSG_ESP_05, 0, 8}}, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 20000U},
-  {.msg = {{MSG_TSK_06, 0, 8}}, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 20000U},
-  {.msg = {{MSG_MOTOR_20, 0, 8}}, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 20000U},
+  {.msg = {{MSG_ESP_19, 0, 8, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 10000U}}},
+  {.msg = {{MSG_EPS_01, 0, 8, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 10000U}}},
+  {.msg = {{MSG_ESP_05, 0, 8, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 20000U}}},
+  {.msg = {{MSG_TSK_06, 0, 8, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 20000U}}},
+  {.msg = {{MSG_MOTOR_20, 0, 8, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 20000U}}},
 };
 const int VOLKSWAGEN_MQB_RX_CHECKS_LEN = sizeof(volkswagen_mqb_rx_checks) / sizeof(volkswagen_mqb_rx_checks[0]);
 
@@ -44,10 +44,10 @@ const CanMsg VOLKSWAGEN_PQ_TX_MSGS[] = {{MSG_HCA_1, 0, 5}, {MSG_GRA_NEU, 0, 4}, 
 const int VOLKSWAGEN_PQ_TX_MSGS_LEN = sizeof(VOLKSWAGEN_PQ_TX_MSGS) / sizeof(VOLKSWAGEN_PQ_TX_MSGS[0]);
 
 AddrCheckStruct volkswagen_pq_rx_checks[] = {
-  {.msg = {{MSG_LENKHILFE_3, 0, 6}}, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 10000U},
-  {.msg = {{MSG_MOTOR_2, 0, 8}}, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 20000U},
-  {.msg = {{MSG_MOTOR_3, 0, 8}}, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 10000U},
-  {.msg = {{MSG_BREMSE_3, 0, 8}}, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 10000U},
+  {.msg = {{MSG_LENKHILFE_3, 0, 6, .check_checksum = true,  .max_counter = 15U, .expected_timestep = 10000U}}},
+  {.msg = {{MSG_MOTOR_2, 0, 8, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 20000U}}},
+  {.msg = {{MSG_MOTOR_3, 0, 8, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 10000U}}},
+  {.msg = {{MSG_BREMSE_3, 0, 8, .check_checksum = false, .max_counter = 0U,  .expected_timestep = 10000U}}},
 };
 const int VOLKSWAGEN_PQ_RX_CHECKS_LEN = sizeof(volkswagen_pq_rx_checks) / sizeof(volkswagen_pq_rx_checks[0]);
 

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -20,14 +20,22 @@ typedef struct {
   int len;
 } CanMsg;
 
-// params and flags about checksum, counter and frequency checks for each monitored address
 typedef struct {
-  // const params
-  const CanMsg msg[3];               // check either messages (e.g. honda steer). Array MUST terminate with an empty struct to know its length.
+  const int addr;
+  const int bus;
+  const int len;
   const bool check_checksum;         // true is checksum check is performed
   const uint8_t max_counter;         // maximum value of the counter. 0 means that the counter check is skipped
   const uint32_t expected_timestep;  // expected time between message updates [us]
+} CanMsgCheck;
+
+// params and flags about checksum, counter and frequency checks for each monitored address
+typedef struct {
+  // const params
+  const CanMsgCheck msg[3];          // check either messages (e.g. honda steer). Array MUST terminate with an empty struct to know its length.
   // dynamic flags
+  bool msg_seen;
+  int index;                         // if multiple messages are allowed to be checked, this stores the index of the first one seen. only msg[msg_index] will be used
   bool valid_checksum;               // true if and only if checksum check is passed
   int wrong_counters;                // counter of wrong counters, saturated between 0 and MAX_WRONG_COUNTERS
   uint8_t last_counter;              // last counter value


### PR DESCRIPTION
Needed to cleanly add the gas signal to the RX checks for hyundai EVs, which doesn't have a counter

Changes:
* check_checksum, max_counter, and expected_timestep are now properties of the individual can message, not all the allowed messages for an RX check
* before when multiple msgs were allowed, either could update the RX check struct, however now it only uses the first one it sees for the subsequent checks