### PR TITLE
Increase HKG Torque Limit

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -1,4 +1,4 @@
-const int HYUNDAI_MAX_STEER = 255;             // like stock
+const int HYUNDAI_MAX_STEER = 409;             // Max MDPS Will accept Prior to Dropping Request #LKA MAX IS 2NM #LFA MAX is 3.1953125NM
 const int HYUNDAI_MAX_RT_DELTA = 112;          // max delta torque allowed for real time checks
 const uint32_t HYUNDAI_RT_INTERVAL = 250000;   // 250ms between real time checks
 const int HYUNDAI_MAX_RATE_UP = 3;


### PR DESCRIPTION
This change is to address the OEM capability of the MDPS ECU in HKG vehicles capable of accepting steering torque request on ID 0x340 (LDW/LKA/LFA) up to a tested maximum of 409 (3.1953125NM) 



MDPS ECU's in HKG vehicles provisioned for just LKA or using a standard LKA profile (Older vehicles) will characteristically accept a torque request up to 255 (~2NM) but not greater than that. Requesting values greater than 2NM will request in frozen torque up to but not exceeding 2NM of torque and will result in the request not being accepted altogether if the request exceeds 409 (~3.20NM / MAX)

However, MDPS ECU's in HKG vehicles provisioned for LFA (or potentially using a standard LFA profile) will characteristically accept a torque request up to 409 (3.1953125NM) but not greater than that. Requesting a value greater than 3.1953125NM will result in the MDPS unit not accepting the request at all as that is it's theoretical limit currently for the current request profile.



This PR will lay the foundation to allow certain vehicles like the 2020 Sonata to take advantage of extra torque available to them once they are properly vetted/tested and an exception for a safe higher torque restriction for the specific model is written into the code under /Selfdrive/Car/Hyundai

Since the MDPS will fault / not accept requests above 406 for *ANY HKG* under the current known profiles for the LKA/LFA request message. 406 shall be set as the new absolute Panda safety limit to allow more breathing room for capable vehicles that can comfortably go higher than 255.

An Example of testing for the 2020 Sonata includes monitoring the higher limit in use during known phases of Openpilot operation and ensuring the MDPS does express any fault or incompatible states such as:

`CF_Mdps_ToiUnavail`
`CF_Mdps_ToiFlt`
`CF_Mdps_FailStat`
`CF_Mdps_SErr`

Testing must also include evaluation of the torque profile requested by Openpilot to ensure the tuning is adequate to support higher limits of actuation.

![firefox_U9H0FUyYht](https://user-images.githubusercontent.com/33460783/85923108-56222d00-b856-11ea-88ad-db5ee70ea929.png)
