### PR TITLE
USB enumeration detection fix

### DIFF
--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -243,11 +243,11 @@ void uno_init(void) {
   can_set_obd(car_harness_status, false);
 
   // Switch to phone usb mode if harness connection is powered by less than 7V
-  /*if(adc_get_voltage() < 7000U){
+  if(adc_get_voltage() < 7000U){
     uno_set_usb_switch(true);
-  } else {*/
+  } else {
     uno_set_usb_switch(false);
-  //}
+  }
 
   // Bootkick phone
   uno_bootkick();

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -243,11 +243,11 @@ void uno_init(void) {
   can_set_obd(car_harness_status, false);
 
   // Switch to phone usb mode if harness connection is powered by less than 7V
-  if(adc_get_voltage() < 7000U){
+  /*if(adc_get_voltage() < 7000U){
     uno_set_usb_switch(true);
-  } else {
+  } else {*/
     uno_set_usb_switch(false);
-  }
+  //}
 
   // Bootkick phone
   uno_bootkick();

--- a/board/main.c
+++ b/board/main.c
@@ -1,4 +1,4 @@
-#define EON
+//#define EON
 //#define PANDA
 
 // ********************* Includes *********************

--- a/board/main.c
+++ b/board/main.c
@@ -707,10 +707,9 @@ void TIM1_BRK_TIM9_IRQ_Handler(void) {
 
     // Tick drivers
     fan_tick();
-    usb_tick();
 
     // set green LED to be controls allowed
-    //current_board->set_led(LED_GREEN, controls_allowed);
+    current_board->set_led(LED_GREEN, controls_allowed);
 
     // turn off the blue LED, turned on by CAN
     // unless we are in power saving mode
@@ -741,10 +740,8 @@ void TIM1_BRK_TIM9_IRQ_Handler(void) {
       // If enumerated but no heartbeat (phone up, boardd not running), turn the fan on to cool the device
       if(usb_enumerated()){
         current_board->set_fan_power(50U);
-        current_board->set_led(LED_GREEN, true);
       } else {
         current_board->set_fan_power(0U);
-        current_board->set_led(LED_GREEN, false);
       }
     }
 

--- a/board/main.c
+++ b/board/main.c
@@ -1,4 +1,4 @@
-//#define EON
+#define EON
 //#define PANDA
 
 // ********************* Includes *********************
@@ -705,11 +705,12 @@ void TIM1_BRK_TIM9_IRQ_Handler(void) {
       puth(can_tx2_q.r_ptr); puts(" "); puth(can_tx2_q.w_ptr); puts("\n");
     #endif
 
-    // Tick fan driver
+    // Tick drivers
     fan_tick();
+    usb_tick();
 
     // set green LED to be controls allowed
-    current_board->set_led(LED_GREEN, controls_allowed);
+    //current_board->set_led(LED_GREEN, controls_allowed);
 
     // turn off the blue LED, turned on by CAN
     // unless we are in power saving mode
@@ -740,8 +741,10 @@ void TIM1_BRK_TIM9_IRQ_Handler(void) {
       // If enumerated but no heartbeat (phone up, boardd not running), turn the fan on to cool the device
       if(usb_enumerated()){
         current_board->set_fan_power(50U);
+        current_board->set_led(LED_GREEN, true);
       } else {
         current_board->set_fan_power(0U);
+        current_board->set_led(LED_GREEN, false);
       }
     }
 


### PR DESCRIPTION
On some devices, the suspend condition sometimes false-triggers as enumerated when the host is not connected due to noise on the USB lines. Trying to fix by checking if we actually rx the SOF packets (1/ms)