### PR TITLE
Bugfix: Fix harness error when starting car

### DIFF
--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -85,7 +85,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       cruise_engaged_prev = cruise_engaged;
     }
 
-    generic_rx_checks((addr == 0x169 && bus == 0));
+    generic_rx_checks((addr == 0x169) && (bus == 0));
   }
   return valid;
 }

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -85,7 +85,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       cruise_engaged_prev = cruise_engaged;
     }
 
-    generic_rx_checks((addr == 0x169));
+    generic_rx_checks((addr == 0x169 && bus == 0));
   }
   return valid;
 }


### PR DESCRIPTION
`generic_rx_checks()` was creating a harness error as `0x169` was being sent on bus 2 (from ADAS) and `(addr == 0x169)` would return true in this case