### PR TITLE
Change Subaru safety test to use generated dbc

### DIFF
--- a/Dockerfile.panda
+++ b/Dockerfile.panda
@@ -59,7 +59,7 @@ RUN cd /tmp && \
 RUN cd /tmp && \
     git clone https://github.com/commaai/openpilot.git tmppilot || true && \
     cd /tmp/tmppilot && \
-    git pull && git checkout fab939eebc7fcf67dbbb52f9352ba67c41598746 && \
+    git pull && git checkout a086f52881f4a1f0d20486e7fa089a843d5d8b34 && \
     git submodule update --init cereal opendbc && \
     mkdir /tmp/openpilot && \
     cp -pR SConstruct tools/ selfdrive/ common/ cereal/ opendbc/ /tmp/openpilot && \

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -32,7 +32,7 @@ class TestSubaruSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("subaru_global_2017")
+    self.packer = CANPackerPanda("subaru_global_2017_generated")
     self.safety = libpandasafety_py.libpandasafety
     self.safety.set_safety_hooks(Panda.SAFETY_SUBARU, 0)
     self.safety.init_tests()


### PR DESCRIPTION
Use generated Subaru global dbc in safety test, related to https://github.com/commaai/opendbc/pull/277