### PR TITLE
Make panda udev rules less likely to be overridden by another rules set

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And to send one on bus 0:
 ```
 Note that you may have to setup [udev rules](https://community.comma.ai/wiki/index.php/Panda#Linux_udev_rules) for Linux, such as
 ``` bash
-sudo tee /etc/udev/rules.d/11-panda.rules <<EOF
+sudo tee /etc/udev/rules.d/99-panda.rules <<EOF
 SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
 EOF


### PR DESCRIPTION
I spent about 3-4 hours diagnosing why Linux Mint 18.3 (based on Ubuntu 16.04) and panda wouldn't communicate properly on my new machine. Found that the rules list in `/lib/udev/rules.d/50-udev-defaults.rules` overrides the udev rules we add for panda in `/etc/udev/rules.d/11-panda.rules`. Defaults set the device mode to `0664`, while we want `0666`. If we set the order for our rules to be read later/last, we have less of a chance of them being overridden and causing libusb1 to not be able to gain device access.

This change also fixes cabana/webusb support for users with this issue.