### PR TITLE
update gas pressed bit to TCS13 DriverOverride

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -128,7 +128,7 @@ static int hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       if (addr == 608) {
         gas_pressed = (GET_BYTE(to_push, 7) >> 6) != 0;
       } else {
-        gas_pressed = ((GET_BYTE(to_push, 5) >> 5) != 0) && ((GET_BYTE(to_push, 5) >> 6) == 0));
+        gas_pressed = (((GET_BYTE(to_push, 5) >> 5) != 0) && ((GET_BYTE(to_push, 5) >> 6) == 0));
       }
     }
 

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -124,11 +124,11 @@ static int hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       cruise_engaged_prev = cruise_engaged;
     }
 
-    if ((addr == 608) || (hyundai_legacy && (addr == 881))) {
+    if ((addr == 608) || (addr == 916)) { /* keep 608 for some manual transmission vehicles that do not have TCS13*/
       if (addr == 608) {
         gas_pressed = (GET_BYTE(to_push, 7) >> 6) != 0;
       } else {
-        gas_pressed = (((GET_BYTE(to_push, 4) & 0x7F) << 1) | GET_BYTE(to_push, 3) >> 7) != 0;
+        gas_pressed = ((GET_BYTE(to_push, 5) >> 5) != 0) && ((GET_BYTE(to_push, 5) >> 6) == 0));
       }
     }
 


### PR DESCRIPTION
It has been found that a common gas pressed bit is required to satisfy all three powertrains configuration on Hyundai.
TCS13 - DriverOverride signal shows driver gas pressed and it is available on ICE, HEV and EV.
EMS16 - CF_Ems_AclAct signals shows driver gas pressed on ICE manual transmission. TCS13 is unavailable on manual vehicles. Keeping this check here for future support for Manual trans Hyundai vehicles.