### PR TITLE
Fix C2 power draw

### DIFF
--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -56,7 +56,12 @@ void uno_set_gps_load_switch(bool enabled) {
 }
 
 void uno_set_bootkick(bool enabled){
-  set_gpio_output(GPIOB, 14, !enabled);
+  if(enabled){
+    set_gpio_output(GPIOB, 14, false);
+  } else {
+    // We want the pin to be floating, not forced high!
+    set_gpio_mode(GPIOB, 14, MODE_INPUT);
+  }
 }
 
 void uno_bootkick(void) {


### PR DESCRIPTION
Subtle bug, triggered by PR #611.
This should reduce the power draw of some comma twos by more than a watt when the phone is powered off.