### PR TITLE
Honda Bosch: Support extended LKAS_HUD IDs

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -61,7 +61,6 @@ static uint8_t honda_compute_checksum(CAN_FIFOMailBox_TypeDef *to_push) {
   int len = GET_LEN(to_push);
   uint8_t checksum = 0U;
   unsigned int addr = GET_ADDR(to_push);
-  bool extended = (addr > 0x7FFU);
   while (addr > 0U) {
     checksum += (addr & 0xFU); addr >>= 4;
   }
@@ -72,9 +71,7 @@ static uint8_t honda_compute_checksum(CAN_FIFOMailBox_TypeDef *to_push) {
       checksum -= (byte & 0xFU);  // remove checksum in message
     }
   }
-  checksum = (8U - checksum);
-  if (extended){ checksum += 3U; }
-  return checksum & 0xFU;
+  return (8U - checksum) & 0xFU;
 }
 
 static uint8_t honda_get_counter(CAN_FIFOMailBox_TypeDef *to_push) {

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -7,8 +7,8 @@
 //      brake rising edge
 //      brake > 0mph
 const CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5}, {0x194, 0, 4}, {0x1FA, 0, 8}, {0x200, 0, 6}, {0x30C, 0, 8}, {0x33D, 0, 5}};
-const CanMsg HONDA_BG_TX_MSGS[] = {{0xE4, 2, 5}, {0xE5, 2, 8}, {0x296, 0, 4}, {0x33D, 2, 5}};  // Bosch Giraffe
-const CanMsg HONDA_BH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}};  // Bosch Harness
+const CanMsg HONDA_BG_TX_MSGS[] = {{0xE4, 2, 5}, {0xE5, 2, 8}, {0x296, 0, 4}, {0x33D, 2, 5}, {0x33DA, 2, 5}, {0x33DB, 2, 8}};  // Bosch Giraffe
+const CanMsg HONDA_BH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}, {0x33DA, 0, 5}, {0x33DB, 0, 8}};  // Bosch Harness
 const CanMsg HONDA_BG_LONG_TX_MSGS[] = {{0xE4, 0, 5}, {0x1DF, 0, 8}, {0x1EF, 0, 8}, {0x1FA, 0, 8}, {0x30C, 0, 8}, {0x33D, 0, 5}, {0x39F, 0, 8}, {0x18DAB0F1, 0, 8}};  // Bosch Giraffe w/ gas and brakes
 const CanMsg HONDA_BH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 1, 8}, {0x1FA, 1, 8}, {0x30C, 1, 8}, {0x33D, 1, 5}, {0x39F, 1, 8}, {0x18DAB0F1, 1, 8}};  // Bosch Harness w/ gas and brakes
 
@@ -61,6 +61,7 @@ static uint8_t honda_compute_checksum(CAN_FIFOMailBox_TypeDef *to_push) {
   int len = GET_LEN(to_push);
   uint8_t checksum = 0U;
   unsigned int addr = GET_ADDR(to_push);
+  bool extended = (addr > 0x7FFU);
   while (addr > 0U) {
     checksum += (addr & 0xFU); addr >>= 4;
   }
@@ -71,7 +72,9 @@ static uint8_t honda_compute_checksum(CAN_FIFOMailBox_TypeDef *to_push) {
       checksum -= (byte & 0xFU);  // remove checksum in message
     }
   }
-  return (8U - checksum) & 0xFU;
+  checksum = (8U - checksum);
+  if (extended){ checksum += 3U; }
+  return checksum & 0xFU;
 }
 
 static uint8_t honda_get_counter(CAN_FIFOMailBox_TypeDef *to_push) {
@@ -274,7 +277,7 @@ static int honda_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
     }
   }
 
-    // Bosch supplemental control check
+  // Bosch supplemental control check
   if (addr == 0xE5) {
     if ((GET_BYTES_04(to_send) != 0x10800004) || ((GET_BYTES_48(to_send) & 0x00FFFFFF) != 0x0)) {
       tx = 0;
@@ -376,7 +379,7 @@ static int honda_bosch_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
     }
     if (bus_num == bus_rdr_cam)  {
       int addr = GET_ADDR(to_fwd);
-      int is_lkas_msg = (addr == 0xE4) || (addr == 0xE5) || (addr == 0x33D);
+      int is_lkas_msg = (addr == 0xE4) || (addr == 0xE5) || (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
       if (!is_lkas_msg) {
         bus_fwd = bus_rdr_car;
       }

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -297,7 +297,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
   def test_fwd_hook(self):
     # some safety modes don't forward anything, while others blacklist msgs
     for bus in range(0x0, 0x3):
-      for addr in range(0x1, 0x800):
+      for addr in range(0x1, 0x33DC):
         # assume len 8
         msg = make_msg(bus, addr, 8)
         fwd_bus = self.FWD_BUS_LOOKUP.get(bus, -1)
@@ -306,7 +306,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
         self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg))
 
   def test_spam_can_buses(self):
-    for addr in range(1, 0x800):
+    for addr in range(1, 0x33DC):
       for bus in range(0, 4):
         if all(addr != m[0] or bus != m[1] for m in self.TX_MSGS):
           self.assertFalse(self._tx(make_msg(bus, addr, 8)))
@@ -437,4 +437,3 @@ class PandaSafetyTest(PandaSafetyTestBase):
         msg = make_msg(addr, bus)
         self.safety.set_controls_allowed(1)
         self.assertFalse(self._tx(msg))
-

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -297,7 +297,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
   def test_fwd_hook(self):
     # some safety modes don't forward anything, while others blacklist msgs
     for bus in range(0x0, 0x3):
-      for addr in range(0x1, 0x33DC):
+      for addr in range(0x1, 0x40000):
         # assume len 8
         msg = make_msg(bus, addr, 8)
         fwd_bus = self.FWD_BUS_LOOKUP.get(bus, -1)
@@ -306,7 +306,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
         self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg))
 
   def test_spam_can_buses(self):
-    for addr in range(1, 0x33DC):
+    for addr in range(1, 0x40000):
       for bus in range(0, 4):
         if all(addr != m[0] or bus != m[1] for m in self.TX_MSGS):
           self.assertFalse(self._tx(make_msg(bus, addr, 8)))

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -306,9 +306,9 @@ class TestHondaBoschSafety(TestHondaSafety):
 
 
 class TestHondaBoschHarnessSafety(TestHondaBoschSafety):
-  TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0]]  # Bosch Harness
+  TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]  # Bosch Harness
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D]}
+  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   PT_BUS = 1
@@ -330,9 +330,9 @@ class TestHondaBoschHarnessSafety(TestHondaBoschSafety):
 
 
 class TestHondaBoschGiraffeSafety(TestHondaBoschHarnessSafety):
-  TX_MSGS = [[0xE4, 2], [0xE5, 2], [0x296, 0], [0x33D, 2]]  # Bosch Giraffe
+  TX_MSGS = [[0xE4, 2], [0xE5, 2], [0x296, 0], [0x33D, 2], [0x33DA, 2], [0x33DB, 2]]  # Bosch Giraffe
   RELAY_MALFUNCTION_BUS = 2
-  FWD_BLACKLISTED_ADDRS = {1: [0xE4, 0xE5, 0x33D]}
+  FWD_BLACKLISTED_ADDRS = {1: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
   FWD_BUS_LOOKUP = {1: 2, 2: 1}
 
   PT_BUS = 0
@@ -395,7 +395,7 @@ class TestHondaBoschLongSafety(TestHondaBoschSafety):
 class TestHondaBoschLongHarnessSafety(TestHondaBoschLongSafety):
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x39F, 1], [0x18DAB0F1, 1]]  # Bosch Harness w/ gas and brakes
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D]}
+  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   PT_BUS = 1
@@ -410,7 +410,7 @@ class TestHondaBoschLongHarnessSafety(TestHondaBoschLongSafety):
 class TestHondaBoschLongGiraffeSafety(TestHondaBoschLongSafety):
   TX_MSGS = [[0xE4, 0], [0x1DF, 0], [0x1EF, 0], [0x1FA, 0], [0x30C, 0], [0x33D, 0], [0x39F, 0], [0x18DAB0F1, 0]]  # Bosch Giraffe w/ gas and brakes
   RELAY_MALFUNCTION_BUS = 2
-  FWD_BLACKLISTED_ADDRS = {1: [0xE4, 0xE5, 0x33D]}
+  FWD_BLACKLISTED_ADDRS = {1: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
   FWD_BUS_LOOKUP = {1: 2, 2: 1}
 
   PT_BUS = 0

--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -12,7 +12,7 @@ def to_signed(d, bits):
 def is_steering_msg(mode, addr):
   ret = False
   if mode in [Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_BOSCH_GIRAFFE, Panda.SAFETY_HONDA_BOSCH_HARNESS]:
-    ret = (addr == 0xE4) or (addr == 0x194) or (addr == 0x33D)
+    ret = (addr == 0xE4) or (addr == 0x194) or (addr == 0x33D) or (addr == 0x33DA) or (addr == 0x33DB)
   elif mode == Panda.SAFETY_TOYOTA:
     ret = addr == 0x2E4
   elif mode == Panda.SAFETY_GM:


### PR DESCRIPTION
Honda has started using some extended IDs on 2021+ Bosch Hondas on the private CAN. They have also modified how the checksum is being calculated for the new messages (based on the two IDs that we're dealing with; 0x33DA and 0x33DB). The method is the same as before, but they do additional math if the ID is extended.

I know the extended IDs aren't being checked in panda, but it's there if needed. We run the same checksum changes in opendbc with success.

Some message examples:
```
- Original -
0x33d: 0000104000
0x33d: 000010401f
0x33d: 000010402e
0x33d: 000010403d

- Modified sum -
0x33da: 0000104009
0x33da: 0000104018
0x33da: 0000104027
0x33da: 0000104036

0x33db: 0000104000000008
0x33db: 0000104000000017
0x33db: 0000104000000026
0x33db: 0000104000000035
```