### PR TITLE
Panda Safety Improvement: Toyota BRAKE_MODULE2 

### DIFF
--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -115,19 +115,15 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       vehicle_moving = ABS(speed / 4) > TOYOTA_STANDSTILL_THRSLD;
     }
 
-    // capture brake press
-    if ((addr == 0x224) || (addr == 0x226) || (addr == 0x230)) {
-      switch (addr) {
-        case 0x224: // most vehicles
-          brake_pressed = ((GET_BYTE(to_push, 0) >> 5) & 1) != 0;
-          break;
-        case 0x226: // corolla and rav4
-          brake_pressed = ((GET_BYTE(to_push, 4) >> 5) & 1) != 0;
-          break;
-        case 0x230: // lexus esh 2018
-          brake_pressed = ((GET_BYTE(to_push, 3) >> 2) & 1) != 0;
-          break;
-      }
+    // most cars have brake_pressed on 0x226, corolla and rav4 on 0x224
+    if ((addr == 0x224) || (addr == 0x226)) {
+      int byte = (addr == 0x224) ? 0 : 4;
+      brake_pressed = ((GET_BYTE(to_push, byte) >> 5) & 1) != 0;
+    }
+
+    // capture brake_pressed signal from backup brake_module2 and OR with main
+    if (addr == 0x230) {
+      brake_pressed |= ((GET_BYTE(to_push, 3) >> 2) & 1) != 0;
     }
 
     // sample gas interceptor

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -121,7 +121,7 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed = ((GET_BYTE(to_push, byte) >> 5) & 1) != 0;
     }
 
-    // OR brake_pressed signal with backup brake_module2
+    // OR brake_pressed signal with backup signal from brake_module2
     if (addr == 0x230) {
       brake_pressed |= ((GET_BYTE(to_push, 3) >> 2) & 1) != 0;
     }

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -121,7 +121,7 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed = ((GET_BYTE(to_push, byte) >> 5) & 1) != 0;
     }
 
-    // capture brake_pressed signal from backup brake_module2 and OR with main
+    // OR brake_pressed signal with backup brake_module2
     if (addr == 0x230) {
       brake_pressed |= ((GET_BYTE(to_push, 3) >> 2) & 1) != 0;
     }

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -115,11 +115,19 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       vehicle_moving = ABS(speed / 4) > TOYOTA_STANDSTILL_THRSLD;
     }
 
-    // most cars have brake_pressed on 0x226, corolla and rav4 on 0x224, lexus esh 2018 on 0x230
+    // capture brake press
     if ((addr == 0x224) || (addr == 0x226) || (addr == 0x230)) {
-      bool brake2 = (addr == 0x230) ? (GET_BYTE(to_push, 3) & 0x04) != 0 : false;
-      int byte = (addr == 0x224) ? 0 : 4;
-      brake_pressed = ((GET_BYTE(to_push, byte) >> 5) & 1) != 0 || brake2;
+      switch (addr) {
+        case 0x224: // most vehicles
+          brake_pressed = ((GET_BYTE(to_push, 0) >> 5) & 1) != 0;
+          break;
+        case 0x226: // corolla and rav4
+          brake_pressed = ((GET_BYTE(to_push, 4) >> 5) & 1) != 0;
+          break;
+        case 0x230: // lexus esh 2018
+          brake_pressed = ((GET_BYTE(to_push, 3) >> 2) & 1) != 0;
+          break;
+      }
     }
 
     // sample gas interceptor

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -115,10 +115,11 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       vehicle_moving = ABS(speed / 4) > TOYOTA_STANDSTILL_THRSLD;
     }
 
-    // most cars have brake_pressed on 0x226, corolla and rav4 on 0x224
-    if ((addr == 0x224) || (addr == 0x226)) {
+    // most cars have brake_pressed on 0x226, corolla and rav4 on 0x224, lexus esh 2018 on 0x230
+    if ((addr == 0x224) || (addr == 0x226) || (addr == 0x230)) {
+      bool brake2 = (addr == 0x230) ? (GET_BYTE(to_push, 3) & 0x04) != 0 : false;
       int byte = (addr == 0x224) ? 0 : 4;
-      brake_pressed = ((GET_BYTE(to_push, byte) >> 5) & 1) != 0;
+      brake_pressed = ((GET_BYTE(to_push, byte) >> 5) & 1) != 0 || brake2;
     }
 
     // sample gas interceptor


### PR DESCRIPTION
This safety improvement is in conjunction with the following improvement to the openpilot repo: https://github.com/commaai/openpilot/pull/19638 

Adds detection of the brake_pressed signal in the backup brake_module2 message for an added layer of redundancy.

In-car testing required as of Jan 4, 2021