### PR TITLE
hyundai: TCS13 checksum

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -94,6 +94,9 @@ static uint8_t hyundai_compute_checksum(CAN_FIFOMailBox_TypeDef *to_push) {
   } else {
     // sum of nibbles
     for (int i = 0; i < 8; i++) {
+      if ((addr == 916) && (i == 7)) {
+        continue; // exclude
+      }
       uint8_t b = GET_BYTE(to_push, i);
       if (((addr == 608) && (i == 7)) || ((addr == 916) && (i == 6)) || ((addr == 1057) && (i == 7))) {
         b &= (addr == 1057) ? 0x0FU : 0xF0U; // remove checksum

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -41,6 +41,8 @@ def checksum(msg):
         b &= 0x0F if addr == 1057 else 0xF0
       elif addr == 916 and i == 6:
         b &= 0xF0
+      elif addr == 916 and i == 7:
+        continue
       chksum += sum(divmod(b, 16))
     chksum = (16 - chksum) % 16
     ret = bytearray(dat)


### PR DESCRIPTION
It was pure coincidence that this checksum ever worked.  Makes me wonder if there are any cars that openpilot doesn't work because of this bug.

This is stacked on top of https://github.com/commaai/panda/pull/622 (<- please merge first)

Good example of how adding up the bytes is a horrible checksum!