### PR TITLE
honda: disable controls with main button

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -105,7 +105,8 @@ static int honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     if ((addr == 0x1A6) || (addr == 0x296)) {
       int button = (GET_BYTE(to_push, 0) & 0xE0) >> 5;
       switch (button) {
-        case 2:  // cancel
+        case 1:  // main
+        case 2:  // cancel 
           controls_allowed = 0;
           break;
         case 3:  // set


### PR DESCRIPTION
On honda, the cancel button only cancel's ACC and not LKAS.  The main button cancels both ACC and LKAS and is the real "main" control for these features.  Whenever the main button is pressed, the controls_allowed should be false regardless of the state the main switch is in.  This is an additional safety measure and matches stock functionality.