### PR TITLE
VW MQB: Add UDS library support for variable response offsets

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -486,13 +486,14 @@ class IsoTpMessage():
 
 FUNCTIONAL_ADDRS = [0x7DF, 0x18DB33F1]
 
-def get_rx_addr_for_tx_addr(tx_addr):
+def get_rx_addr_for_tx_addr(tx_addr, rx_offset=0x8):
   if tx_addr in FUNCTIONAL_ADDRS:
     return None
 
   if tx_addr < 0xFFF8:
-    # standard 11 bit response addr (add 8)
-    return tx_addr + 8
+    # pseudo-standard 11 bit response addr (add 8) works for most manufacturers
+    # allow override; some manufacturers use other offsets for non-OBD2 access
+    return tx_addr + rx_offset
 
   if tx_addr > 0x10000000 and tx_addr < 0xFFFFFFFF:
     # standard 29 bit response addr (flip last two bytes)


### PR DESCRIPTION
**Prep for Volkswagen MQB FPv2**

Add support for UDS diagnostic queries to come back with non-standard response address offsets. For VW MQB, the engine and transmission respond at the conventional offset of 0x8, but most other controllers use 0x6A.

**Verification**

Worked in my old FPv2 mockup branch: https://github.com/commaai/openpilot/pull/1427