### PR TITLE
Fix Linux driver for canutils

### DIFF
--- a/drivers/linux/README.md
+++ b/drivers/linux/README.md
@@ -17,3 +17,12 @@ usage:
 
 You will need to bring it up using `sudo ifconfig can0 up` or
 `sudo ip link set dev can0 up`, depending on your platform.
+
+Note that you may have to setup udev rules for Linux
+``` bash
+sudo tee /etc/udev/rules.d/11-panda.rules <<EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
+EOF
+sudo udevadm control --reload-rules && sudo udevadm trigger`
+```

--- a/drivers/linux/panda.c
+++ b/drivers/linux/panda.c
@@ -81,8 +81,8 @@ static const struct usb_device_id panda_usb_table[] = {
 MODULE_DEVICE_TABLE(usb, panda_usb_table);
 
 
-// panda:       CAN1 = 0   CAN2 = 1   CAN3 = 4
-const int can_numbering[] = {0,1,4};
+// panda:       CAN1 = 0   CAN2 = 1   CAN3 = 2
+const int can_numbering[] = {0,1,2};
 
 struct panda_inf_priv *
 panda_get_inf_from_bus_id(struct panda_dev_priv *priv_dev, int bus_id){


### PR DESCRIPTION
Fixes the oldest panda repo issue #143 

Rebuilt driver on my machine with 

1. sudo rmmod panda
2. make uninstall
3. make link
4. make all

added Udev rules. Used debug board with EPS attached to CAN3 on panda and was able to see messages. 