### PR TITLE
Disable interrupts in early()

### DIFF
--- a/board/gpio.h
+++ b/board/gpio.h
@@ -21,13 +21,11 @@ void jump_to_bootloader(void) {
 
 void early(void) {
   // Reset global critical depth
+  disable_interrupts();
   global_critical_depth = 0;
 
   // Init register and interrupt tables
   init_registers();
-
-  // neccesary for DFU flashing on a non-power cycled white panda
-  enable_interrupts();
 
   // after it's been in the bootloader, things are initted differently, so we reset
   if ((enter_bootloader_mode != BOOT_NORMAL) &&

--- a/board/gpio.h
+++ b/board/gpio.h
@@ -12,6 +12,7 @@ void jump_to_bootloader(void) {
   void (*bootloader)(void) = (void (*)(void)) (*((uint32_t *)0x1fff0004));
 
   // jump to bootloader
+  enable_interrupts();
   bootloader();
 
   // reset on exit


### PR DESCRIPTION
This fixes #613 

The `early()` function runs twice, once before the bootstub and once between bootstub and application code. The bootstub configures and enables interrupts. The `early()` function then changes the ISR table base. After the `early()` call is done it goes back into the startup code which clears out the interrupt handler table in `interrupts.h`. This table is later initialized in application code, after which interrupts can be enable again. During all of this you don't want interrupts to be enabled or it can cause all kind of undefined behavior. On the first run this is not a problem since no actual interrupts are configured yet, but on the second run there is still leftover configuration from the bootstub.

I'm still not _exactly_ sure why this is only a problem when you remove both the `uart.h` and `usb.h` includes (leaving either one fixes it), but I think it causes the zeroing of the .bss section to take longer, which somehow alleviates the problem.

The comment suggests problems with "DFU flashing on a non-power cycled white panda", which does seem to be a problem. This is fixed by enabling interrupts again just before jumping into DFU mode.