### PR TITLE
Subaru global: Enable Stock LKAS during disengagement.

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -208,7 +208,7 @@ void generic_rx_checks(bool stock_ecu_detected) {
   }
   gas_pressed_prev = gas_pressed;
 
-  // exit controls on rising edge of brake press
+  // exit controls on rising edge of brake press or if pressed while moving. 
   if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
     controls_allowed = 0;
   }

--- a/board/safety.h
+++ b/board/safety.h
@@ -208,11 +208,20 @@ void generic_rx_checks(bool stock_ecu_detected) {
   }
   gas_pressed_prev = gas_pressed;
 
-  // exit controls on rising edge of brake press or if pressed while moving. 
-  if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
+  // exit controls on rising edge while vehicle is not moving
+  if (brake_pressed && !brake_pressed_prev && !vehicle_moving) { 
+    controls_allowed = 0;
+	brake_pressed_prev = brake_pressed; // no debounce when not moving
+  } else {
+      if (!(brake_pressed == brake_pressed_prev)) { 
+        brake_pressed_prev = brake_pressed; // debounce rising edge 
+	    brake_pressed = false;
+      }
+  }
+  // exit controls repeatedly while in motion if brake is pressed.
+  if (brake_pressed && vehicle_moving) { 
     controls_allowed = 0;
   }
-  brake_pressed_prev = brake_pressed;
 
   // check if stock ECU is on bus broken by car harness
   if ((safety_mode_cnt > RELAY_TRNS_TIMEOUT) && stock_ecu_detected) {

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -289,7 +289,7 @@ static int subaru_fwd_hook(int bus_num, CAN_FIFOMailBox_TypeDef *to_fwd) {
       // 0x322 ES_LKAS_State
       int addr = GET_ADDR(to_fwd);
       int block_msg = ((addr == 0x122) || (addr == 0x221) || (addr == 0x322));
-      if (!block_msg) {
+      if (!block_msg || !controls_allowed) {
         bus_fwd = 0;  // Main CAN
       }
     }

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -151,6 +151,13 @@ static int subaru_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
   int tx = 1;
   int addr = GET_ADDR(to_send);
 
+  if (!controls_allowed) {
+    tx = 0;
+  }
+  if (addr == 0x221) {
+    tx = 1;
+  }
+  
   if (!msg_allowed(to_send, SUBARU_TX_MSGS, SUBARU_TX_MSGS_LEN)) {
     tx = 0;
   }

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -303,6 +303,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
         fwd_bus = self.FWD_BUS_LOOKUP.get(bus, -1)
         if bus in self.FWD_BLACKLISTED_ADDRS and addr in self.FWD_BLACKLISTED_ADDRS[bus]:
           fwd_bus = -1
+        self.safety.set_controls_allowed(1)
         self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg))
 
   def test_spam_can_buses(self):

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -78,11 +78,11 @@ class TestSubaruSafety(common.PandaSafetyTest):
     self._rx(self._torque_driver_msg(max_t))
 
   def test_steer_safety_check(self):
-    for enabled in [0, 1]:
+    for enabled in [0,1]:
       for t in range(-3000, 3000):
         self.safety.set_controls_allowed(enabled)
         self._set_prev_torque(t)
-        block = abs(t) > MAX_STEER or (not enabled and abs(t) > 0)
+        block = (abs(t) > MAX_STEER) or not enabled
         self.assertEqual(not block, self._tx(self._torque_msg(t)))
 
   def test_non_realtime_limit_up(self):


### PR DESCRIPTION
Subaru_Global specific update other than fwd_hook blacklist test. 

common safety test for blacklisting failed when allowing messages through during disengagement. 
This test may be better performed with "self.safety.set_controls_allowed(1)" to be asserting that the two systems are not active together. 

subaru safety test asserted that a torque request with "0" torque should be allowed within tx_hook when disengaged. 
I updated to allow blocking all torque messages when disengaged. To my knowledge, there should not be a reason to inject any messages when OP is disengaged. 

during disengagements the safety of the vehicle is being affected. It is less safe because OP is blocking LKAS and not replacing it.
Stock LKAS appears to be active but is disabled silently. additionally, it does not need to be. 

I updated the forwarding logic to only apply the blacklist when OP is engaged. 
I updated the tx_hook to only allow messages when OP is engaged. 

I had to whitelist the 0x221 message to preserve disengage_on_gas behavior. otherwise stock ACC remains active on subaru when OP disengages.

