### PR TITLE
Debounce Brake signal for single frame errors.

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -208,10 +208,15 @@ void generic_rx_checks(bool stock_ecu_detected) {
   }
   gas_pressed_prev = gas_pressed;
 
-  // exit controls on rising edge of brake press
-  if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
+  // exit controls on rising edge while vehicle is not moving
+  if (brake_pressed && !brake_pressed_prev && !vehicle_moving) { 
     controls_allowed = 0;
-  }
+  } 
+  // exit controls while in motion if brake is pressed.
+  // debounce rising edge
+  if (brake_pressed && brake_pressed_prev && vehicle_moving) {
+	controls_allowed = 0;
+  } 
   brake_pressed_prev = brake_pressed;
 
   // check if stock ECU is on bus broken by car harness

--- a/board/safety.h
+++ b/board/safety.h
@@ -201,23 +201,28 @@ bool addr_safety_check(CAN_FIFOMailBox_TypeDef *to_push,
   return is_msg_valid(rx_checks, index);
 }
 
-void generic_rx_checks(bool stock_ecu_detected) {
-  // exit controls on rising edge of gas press
-  if (gas_pressed && !gas_pressed_prev && !(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
-    controls_allowed = 0;
-  }
-  gas_pressed_prev = gas_pressed;
+void generic_rx_checks(bool stock_ecu_detected, bool gas_update, bool brake_update) {
 
-  // exit controls on rising edge while vehicle is not moving
-  if (brake_pressed && !brake_pressed_prev && !vehicle_moving) { 
-    controls_allowed = 0;
-  } 
-  // exit controls while in motion if brake is pressed.
-  // debounce rising edge
-  if (brake_pressed && brake_pressed_prev && vehicle_moving) {
-	controls_allowed = 0;
-  } 
-  brake_pressed_prev = brake_pressed;
+  if (gas_update) {
+    // exit controls on rising edge of gas press
+    if (gas_pressed && !gas_pressed_prev && !(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
+      controls_allowed = 0;
+    }
+    gas_pressed_prev = gas_pressed;
+  }
+
+  if (brake_update) {
+    // exit controls on rising edge while vehicle is not moving
+    if (brake_pressed && !brake_pressed_prev && !vehicle_moving) { 
+      controls_allowed = 0;
+    } 
+    // exit controls while in motion if brake is pressed.
+    // debounce rising edge
+    if (brake_pressed && brake_pressed_prev && vehicle_moving) {
+      controls_allowed = 0;
+    } 
+    brake_pressed_prev = brake_pressed;
+  }
 
   // check if stock ECU is on bus broken by car harness
   if ((safety_mode_cnt > RELAY_TRNS_TIMEOUT) && stock_ecu_detected) {

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -111,7 +111,7 @@ static int chrysler_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed_prev = brake_pressed;
     }
 
-    generic_rx_checks((addr == 0x292));
+    generic_rx_checks(addr == 0x292, true, true);
   }
   return valid;
 }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -93,7 +93,7 @@ static int gm_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // on powertrain bus.
     // 384 = ASCMLKASteeringCmd
     // 715 = ASCMGasRegenCmd
-    generic_rx_checks(((addr == 384) || (addr == 715)));
+    generic_rx_checks((addr == 384) || (addr == 715), true, true);
   }
   return valid;
 }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -170,7 +170,7 @@ static int honda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
         stock_ecu_detected = true;
       }
     }
-    generic_rx_checks(stock_ecu_detected);
+    generic_rx_checks(stock_ecu_detected, true, true);
   }
   return valid;
 }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -165,7 +165,7 @@ static int hyundai_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed = (GET_BYTE(to_push, 6) >> 7) != 0;
     }
 
-    generic_rx_checks((addr == 832));
+    generic_rx_checks(addr == 832, true, true);
   }
   return valid;
 }

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -95,7 +95,7 @@ static int mazda_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed = (GET_BYTE(to_push, 0) & 0x10);
     }
 
-    generic_rx_checks((addr == MAZDA_LKAS));
+    generic_rx_checks(addr == MAZDA_LKAS, true, true);
   }
   return valid;
 }

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -93,7 +93,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       cruise_engaged_prev = cruise_engaged;
     }
 
-    generic_rx_checks((addr == 0x169) && (bus == 0));
+    generic_rx_checks((addr == 0x169) && (bus == 0), true, true);
   }
   return valid;
 }

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -95,7 +95,7 @@ static int subaru_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       gas_pressed = GET_BYTE(to_push, 4) != 0;
     }
 
-    generic_rx_checks((addr == 0x122));
+    generic_rx_checks(addr == 0x122, addr == 0x40, addr == 0x139);
   }
   return valid;
 }
@@ -142,7 +142,7 @@ static int subaru_legacy_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       gas_pressed = GET_BYTE(to_push, 0) != 0;
     }
 
-    generic_rx_checks((addr == 0x164));
+    generic_rx_checks(addr == 0x164, addr == 0x140, addr == 0xD1);
   }
   return valid;
 }

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -131,7 +131,7 @@ static int toyota_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       gas_interceptor_prev = gas_interceptor;
     }
 
-    generic_rx_checks((addr == 0x2E4));
+    generic_rx_checks(addr == 0x2E4, true, true);
   }
   return valid;
 }

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -184,7 +184,7 @@ static int volkswagen_mqb_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed = (GET_BYTE(to_push, 3) & 0x4) >> 2;
     }
 
-    generic_rx_checks((addr == MSG_HCA_01));
+    generic_rx_checks(addr == MSG_HCA_01, true, true);
   }
   return valid;
 }
@@ -237,7 +237,7 @@ static int volkswagen_pq_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       brake_pressed = (GET_BYTE(to_push, 2) & 0x1);
     }
 
-    generic_rx_checks((addr == MSG_HCA_1));
+    generic_rx_checks(addr == MSG_HCA_1, true, true);
   }
   return valid;
 }

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -69,7 +69,7 @@ bool addr_safety_check(CAN_FIFOMailBox_TypeDef *to_push,
                        uint8_t (*get_checksum)(CAN_FIFOMailBox_TypeDef *to_push),
                        uint8_t (*compute_checksum)(CAN_FIFOMailBox_TypeDef *to_push),
                        uint8_t (*get_counter)(CAN_FIFOMailBox_TypeDef *to_push));
-void generic_rx_checks(bool stock_ecu_detected);
+void generic_rx_checks(bool stock_ecu_detected, bool gas_update, bool brake_update);
 void relay_malfunction_set(void);
 void relay_malfunction_reset(void);
 


### PR DESCRIPTION
Single messages for user braking are appearing on Subaru vehicles causing unsafe ACC cancelation.
The vehicle cancels ACC and "coast" into/towards a vehicle that should be being braked for.
It seems to happen with moderate braking when a new lead is acquired.
It is also appearing more frequently with gas pedal enabled. 

My testing is only on subaru_global but change preserves the previous logic to ensure compatibility with all vehicles.
When vehicle is in motion this checks for 2 consecutive brake messages before exiting controls.
This prevents ACC from being canceled by itself if OP or stock ACC is actively braking. I do not know if this would be an issue with long vehicles but I imagine it would be similar behavior.

Openpilot PR https://github.com/commaai/openpilot/pull/20866
