### PR TITLE
Subaru Global: use better brake pressed signal

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -88,7 +88,7 @@ static int subaru_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     }
 
     if (addr == 0x13c) {
-      brake_pressed = ((GET_BYTES_48(to_push) >> 30) & 1);
+      brake_pressed = ((GET_BYTE(to_push, 7) >> 6) & 1);
     }
 
     if (addr == 0x40) {

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -18,8 +18,8 @@ const int SUBARU_TX_MSGS_LEN = sizeof(SUBARU_TX_MSGS) / sizeof(SUBARU_TX_MSGS[0]
 AddrCheckStruct subaru_rx_checks[] = {
   {.msg = {{ 0x40, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U}, { 0 }, { 0 }}},
   {.msg = {{0x119, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
-  {.msg = {{0x139, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
   {.msg = {{0x13a, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
+  {.msg = {{0x13c, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
   {.msg = {{0x240, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 50000U}, { 0 }, { 0 }}},
 };
 const int SUBARU_RX_CHECK_LEN = sizeof(subaru_rx_checks) / sizeof(subaru_rx_checks[0]);
@@ -87,8 +87,8 @@ static int subaru_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       vehicle_moving = subaru_speed > SUBARU_STANDSTILL_THRSLD;
     }
 
-    if (addr == 0x139) {
-      brake_pressed = (GET_BYTES_48(to_push) & 0xFFF0) > 0;
+    if (addr == 0x13c) {
+      brake_pressed = ((GET_BYTES_48(to_push) >> 30) & 1);
     }
 
     if (addr == 0x40) {

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -54,9 +54,9 @@ class TestSubaruSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("Wheel_Speeds", 0, values)
 
   def _brake_msg(self, brake):
-    values = {"Brake_Pedal": brake, "Counter": self.cnt_brake % 4}
+    values = {"Brake": brake, "Counter": self.cnt_brake % 4}
     self.__class__.cnt_brake += 1
-    return self.packer.make_can_msg_panda("Brake_Pedal", 0, values)
+    return self.packer.make_can_msg_panda("Brake_Status", 0, values)
 
   def _torque_msg(self, torque):
     values = {"LKAS_Output": torque}


### PR DESCRIPTION
Use alternative Brake_Status Brake signal instead of Brake_Pedal Brake_Pedal signal. Fixes ACC disengage while braking issue for various newer models (https://github.com/martinl/openpilot/issues/27, https://github.com/commaai/openpilot/pull/20866)

Openpilot PR https://github.com/commaai/openpilot/pull/21012