### PR TITLE
Subaru legacy safety update

### DIFF
--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -1,6 +1,5 @@
 // more constants in board/safety/safety_subaru.h
-const int SUBARU_L_DRIVER_TORQUE_ALLOWANCE = 75;
-const int SUBARU_L_DRIVER_TORQUE_FACTOR = 10;
+const uint32_t SUBARU_L_BRAKE_THRSLD = 2; // filter sensor noise, max_brake is 400
 
 const CanMsg SUBARU_L_TX_MSGS[] = {
   {0x161, 0, 8},
@@ -50,7 +49,7 @@ static int subaru_legacy_rx_hook(CANPacket_t *to_push) {
     }
 
     if (addr == 0xD1) {
-      brake_pressed = ((GET_BYTES_04(to_push) >> 16) & 0xFFU) > 0U;
+      brake_pressed = GET_BYTE(to_push, 2) > SUBARU_L_BRAKE_THRSLD;
     }
 
     if (addr == 0x140) {
@@ -88,7 +87,7 @@ static int subaru_legacy_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed
       // *** torque rate limit check ***
       violation |= driver_limit_check(desired_torque, desired_torque_last, &torque_driver,
         SUBARU_MAX_STEER, SUBARU_MAX_RATE_UP, SUBARU_MAX_RATE_DOWN,
-        SUBARU_L_DRIVER_TORQUE_ALLOWANCE, SUBARU_L_DRIVER_TORQUE_FACTOR);
+        SUBARU_DRIVER_TORQUE_ALLOWANCE, SUBARU_DRIVER_TORQUE_FACTOR);
 
       // used next time
       desired_torque_last = desired_torque;

--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -16,6 +16,9 @@ AddrCheckStruct subaru_l_addr_checks[] = {
 #define SUBARU_L_ADDR_CHECK_LEN (sizeof(subaru_l_addr_checks) / sizeof(subaru_l_addr_checks[0]))
 addr_checks subaru_l_rx_checks = {subaru_l_addr_checks, SUBARU_L_ADDR_CHECK_LEN};
 
+const uint16_t SUBARU_L_PARAM_FLIP_DRIVER_TORQUE = 1;
+bool subaru_l_flip_driver_torque = false;
+
 static int subaru_legacy_rx_hook(CANPacket_t *to_push) {
 
   bool valid = addr_safety_check(to_push, &subaru_l_rx_checks, NULL, NULL, NULL);
@@ -26,6 +29,9 @@ static int subaru_legacy_rx_hook(CANPacket_t *to_push) {
       int torque_driver_new;
       torque_driver_new = (GET_BYTE(to_push, 3) >> 5) + (GET_BYTE(to_push, 4) << 3);
       torque_driver_new = to_signed(torque_driver_new, 11);
+      if (subaru_l_flip_driver_torque) {
+        torque_driver_new = -1 * torque_driver_new;
+      }
       update_sample(&torque_driver, torque_driver_new);
     }
 
@@ -145,7 +151,8 @@ static int subaru_legacy_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
 }
 
 static const addr_checks* subaru_legacy_init(uint16_t param) {
-  UNUSED(param);
+  // Checking for flip driver torque from safety parameter
+  subaru_l_flip_driver_torque = GET_FLAG(param, SUBARU_L_PARAM_FLIP_DRIVER_TORQUE);
   return &subaru_l_rx_checks;
 }
 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -204,6 +204,8 @@ class Panda:
 
   FLAG_SUBARU_GEN2 = 1
 
+  FLAG_SUBARU_L_FLIP_DRIVER_TORQUE = 1
+
   def __init__(self, serial: Optional[str] = None, claim: bool = True):
     self._serial = serial
     self._handle = None

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -571,6 +571,10 @@ class PandaSafetyTest(PandaSafetyTestBase):
             if attr.startswith('TestHonda'):
               # exceptions for common msgs across different hondas
               tx = list(filter(lambda m: m[0] not in [0x1FA, 0x30C, 0x33D], tx))
+            # TODO: Temporary, should be fixed in panda firmware, safety_subaru.h
+            if attr.startswith('TestSubaruLegacy'):
+              # exceptions for common msgs across different subarus
+              tx = list(filter(lambda m: m[0] not in [0x161, 0x164], tx))
             all_tx.append(list([m[0], m[1], attr[4:]] for m in tx))
 
     # make sure we got all the msgs

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -21,8 +21,8 @@ class TestSubaruLegacySafety(common.PandaSafetyTest, common.DriverTorqueSteering
   MAX_RT_DELTA = 940
   RT_INTERVAL = 250000
 
-  DRIVER_TORQUE_ALLOWANCE = 75
-  DRIVER_TORQUE_FACTOR = 10
+  DRIVER_TORQUE_ALLOWANCE = 60
+  DRIVER_TORQUE_FACTOR = 50
 
   def setUp(self):
     self.packer = CANPackerPanda("subaru_outback_2015_generated")

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -24,6 +24,8 @@ class TestSubaruLegacySafety(common.PandaSafetyTest, common.DriverTorqueSteering
   DRIVER_TORQUE_ALLOWANCE = 60
   DRIVER_TORQUE_FACTOR = 50
 
+  BRAKE_THRESHOLD = 2
+
   def setUp(self):
     self.packer = CANPackerPanda("subaru_outback_2015_generated")
     self.safety = libpandasafety_py.libpandasafety
@@ -45,6 +47,8 @@ class TestSubaruLegacySafety(common.PandaSafetyTest, common.DriverTorqueSteering
     return self.packer.make_can_msg_panda("Wheel_Speeds", 0, values)
 
   def _user_brake_msg(self, brake):
+    if brake > 0 and brake < self.BRAKE_THRESHOLD:
+      brake = self.BRAKE_THRESHOLD + 1
     values = {"Brake_Pedal": brake}
     return self.packer.make_can_msg_panda("Brake_Pedal", 0, values)
 

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -65,5 +65,14 @@ class TestSubaruLegacySafety(common.PandaSafetyTest, common.DriverTorqueSteering
     return self.packer.make_can_msg_panda("CruiseControl", 0, values)
 
 
+class TestSubaruLegacy2019Safety(TestSubaruLegacySafety):
+
+  def setUp(self):
+    self.packer = CANPackerPanda("subaru_outback_2019_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU_LEGACY, Panda.FLAG_SUBARU_L_FLIP_DRIVER_TORQUE)
+    self.safety.init_tests()
+
+
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Subaru legacy changes:
  - change driver torque to match global
  - brake threshold increased to 2, filter out sensor noise (https://github.com/martinl/openpilot/issues/27)
  - safety parameter for Outback 2018-2019 and Forester 2017-2018 flipped driver torque signal
  - safety tests covering each change

Matching changes on openpilot side are already upstreamed (dashcam only)