### PR TITLE
UDS fingerprinting development tool updates

### DIFF
--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
   uds_data_ids = {}
   for std_id in DATA_IDENTIFIER_TYPE:
     uds_data_ids[std_id.value] = std_id.name
-  if(args.nonstandard):
+  if args.nonstandard:
     for uds_id in range(0xf100,0xf180):
       uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER"
     for uds_id in range(0xf1a0,0xf1f0):

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
       resp = {}
       for uds_data_id in sorted(uds_data_ids):
         try:
-          data = uds_client.read_data_by_identifier(uds_data_id)
+          data = uds_client.read_data_by_identifier(uds_data_id)  # type: ignore
           if data:
             resp[uds_data_id] = data
         except (NegativeResponseError, MessageTimeoutError):

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -33,8 +33,6 @@ if __name__ == "__main__":
   panda = Panda()
   panda.set_safety_mode(Panda.SAFETY_ELM327)
   panda.set_power_save(0)
-  panda.can_clear(0x1 if panda.has_obd() else 0x0)
-  panda.can_clear(0xffff)
   print("querying addresses ...")
   with tqdm(addrs) as t:
     for addr in t:

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -1,15 +1,40 @@
 #!/usr/bin/env python3
+import argparse
 from tqdm import tqdm
 from panda import Panda
 from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
 
 if __name__ == "__main__":
-  addrs = [0x700 + i for i in range(256)]
-  addrs += [0x18da0000 + (i << 8) + 0xf1 for i in range(256)]
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--rxoffset', default="0x8")
+  parser.add_argument('--nonstandard', action='store_true')
+  parser.add_argument('--debug', action='store_true')
+  parser.add_argument('--addr')
+  args = parser.parse_args()
+
+  if(args.addr):
+    addrs = [int(args.addr, base=16)]
+  else:
+    addrs = [0x700 + i for i in range(256)]
+    addrs += [0x18da0000 + (i << 8) + 0xf1 for i in range(256)]
   results = {}
+
+  uds_data_ids = {}
+  for std_id in DATA_IDENTIFIER_TYPE:
+    uds_data_ids[std_id.value] = std_id.name
+  if(args.nonstandard):
+    for uds_id in range(0xf100,0xf180):
+      uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER"
+    for uds_id in range(0xf1a0,0xf1f0):
+      uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC"
+    for uds_id in range(0xf1f0,0xf200):
+      uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_SYSTEM_SUPPLIER_SPECIFIC"
 
   panda = Panda()
   panda.set_safety_mode(Panda.SAFETY_ELM327)
+  panda.set_power_save(0)
+  panda.can_clear(0x1 if panda.has_obd() else 0x0)
+  panda.can_clear(0xffff)
   print("querying addresses ...")
   with tqdm(addrs) as t:
     for addr in t:
@@ -18,66 +43,40 @@ if __name__ == "__main__":
         continue
       t.set_description(hex(addr))
 
-      uds_client = UdsClient(panda, addr, bus=1 if panda.has_obd() else 0, timeout=0.1, debug=False)
+      uds_client = UdsClient(panda, addr, addr + int(args.rxoffset, base=16), bus=1 if panda.has_obd() else 0, timeout=0.2, debug=args.debug)
+      # Check for anything alive at this address, and switch to the highest
+      # available diagnostic session without security access
       try:
         uds_client.tester_present()
+        uds_client.diagnostic_session_control(SESSION_TYPE.DEFAULT)
         uds_client.diagnostic_session_control(SESSION_TYPE.EXTENDED_DIAGNOSTIC)
       except NegativeResponseError:
         pass
       except MessageTimeoutError:
         continue
 
+      # Run queries against all standard UDS data identifiers, plus selected
+      # non-standardized identifier ranges if requested
       resp = {}
+      for uds_data_id in sorted(uds_data_ids):
+        try:
+          data = uds_client.read_data_by_identifier(uds_data_id)
+          if data:
+            resp[uds_data_id] = data
+        except (NegativeResponseError, MessageTimeoutError):
+          pass
 
-      try:
-        data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.BOOT_SOFTWARE_IDENTIFICATION)
-        if data:
-          resp[DATA_IDENTIFIER_TYPE.BOOT_SOFTWARE_IDENTIFICATION] = data
-      except NegativeResponseError:
-        pass
-
-      try:
-        data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_SOFTWARE_IDENTIFICATION)
-        if data:
-          resp[DATA_IDENTIFIER_TYPE.APPLICATION_SOFTWARE_IDENTIFICATION] = data
-      except NegativeResponseError:
-        pass
-
-      try:
-        data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_DATA_IDENTIFICATION)
-        if data:
-          resp[DATA_IDENTIFIER_TYPE.APPLICATION_DATA_IDENTIFICATION] = data
-      except NegativeResponseError:
-        pass
-
-      try:
-        data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.BOOT_SOFTWARE_FINGERPRINT)
-        if data:
-          resp[DATA_IDENTIFIER_TYPE.BOOT_SOFTWARE_FINGERPRINT] = data
-      except NegativeResponseError:
-        pass
-
-      try:
-        data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_SOFTWARE_FINGERPRINT)
-        if data:
-          resp[DATA_IDENTIFIER_TYPE.APPLICATION_SOFTWARE_FINGERPRINT] = data
-      except NegativeResponseError:
-        pass
-
-      try:
-        data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.APPLICATION_DATA_FINGERPRINT)
-        if data:
-          resp[DATA_IDENTIFIER_TYPE.APPLICATION_DATA_FINGERPRINT] = data
-      except NegativeResponseError:
-        pass
 
       if resp.keys():
         results[addr] = resp
 
-    print("results:")
+      #if len(resp.keys()) > 1:
+      #  break
+
     if len(results.items()):
       for addr, resp in results.items():
+        print(f"\n\n*** Results for address 0x{addr:X} ***\n\n")
         for rid, dat in resp.items():
-          print(hex(addr), hex(rid), dat.decode())
+          print(f"0x{rid:02X} {uds_data_ids[rid]}: {dat}")
     else:
       print("no fw versions found!")

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
   parser.add_argument('--addr')
   args = parser.parse_args()
 
-  if(args.addr):
+  if args.addr:
     addrs = [int(args.addr, base=16)]
   else:
     addrs = [0x700 + i for i in range(256)]

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -66,12 +66,8 @@ if __name__ == "__main__":
         except (NegativeResponseError, MessageTimeoutError):
           pass
 
-
       if resp.keys():
         results[addr] = resp
-
-      #if len(resp.keys()) > 1:
-      #  break
 
     if len(results.items()):
       for addr, resp in results.items():


### PR DESCRIPTION
**Bug fixes:**

* Take Panda out of powersave mode so the OBD bus CAN transceiver actually works

**New features:**

* Support querying a single address instead of the entire address range
* Switch to best available diagnostic session without security access
* Support queries for all standard UDS data identifiers
* Support queries for nonstandard vehicle manufacturer/supplier reserved identifier ranges
* Support German Engineered™ ISO-TP receive offsets

**Known issues:**

* Timeout isn't long enough for certain *really* long ISO-TP replies, which ends up throwing an assert deep in the UDS library when the reply for a previous query is still arriving when we start the next. Timeout would have to be made absurdly longer, or the UDS library assert needs to become a handle-able exception, or the timeout timer needs to be reset every time we receive a new ISO-TP reply fragment. Probably a combination of the last two.

**Example output, all addresses, standard UDS queries only:**

[std_query_0x6a.txt](https://github.com/commaai/panda/files/6786485/std_query_0x6a.txt)

**Example output, single address, all queries:**

```
root@localhost:/data/openpilot/panda/examples$ ./query_fw_versions.py --nonstandard --addr=0x712 --rxoffset=0x6a

*** Results for address 0x712 ***


0xF15B IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF17B IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER: b'!\x06\x01'
0xF17C IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER: b'ZF0-00008.01.1802100308'
0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x0571A0JA15A1'
0xF186 ACTIVE_DIAGNOSTIC_SESSION: b'\x03'
0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'3Q0909144L '
0xF189 VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER: b'5081'
0xF190 VIN: b'00000000000007386'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'3Q0909144L '
0xF192 SYSTEM_SUPPLIER_ECU_HARDWARE_NUMBER: b'7805177577\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF197 SYSTEM_NAME_OR_ENGINE_TYPE: b'EPS_MQB_ZFLS '
0xF198 REPAIR_SHOP_CODE_OR_TESTER_SERIAL_NUMBER: b'\x00\x00\x00\x00\x00\x00'
0xF199 PROGRAMMING_DATE: b'\x00\x00\x00'
0xF19A CALIBRATION_REPAIR_SHOP_CODE_OR_CALIBRATION_EQUIPMENT_SERIAL_NUMBER: b'\x00\x00\x0bx!\x9f'
0xF19B CALIBRATION_DATE: b'\x18\x12\x17'
0xF19E ODX_FILE: b'EV_SteerAssisMQB\x00'
0xF1A0 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'V03935273GV'
0xF1A1 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'0001'
0xF1A2 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'015157'
0xF1A3 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'507'
0xF1A4 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
0xF1A5 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\x00\x00+x!\x9f'
0xF1A8 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\x00\x06@\x16\x05M'
0xF1A9 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\x18\x01\x12'
0xF1AA IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'J500 '
0xF1AB IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'032761600939'
0xF1AE IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\x05'
0xF1AF IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\x02\x00\x007\x02\x00\x02\x04\x00\x00\x1e\x01\x02b\x05\x00\x007\x02\x00\x01\x15\x00\x00 \x01\x02\x14\t\x00\x00\x01\x04\x01#'
0xF1DF IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'@'
0xF1E0 IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC: b'\x00'

```
