### PR TITLE
Remove can_set_obd

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -213,9 +213,6 @@ void black_init(void) {
   if (car_harness_status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
   }
-
-  // init multiplexer
-  can_set_obd(car_harness_status, false);
 }
 
 const harness_configuration black_harness_config = {

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -204,9 +204,6 @@ void dos_init(void) {
     can_flip_buses(0, 2);
   }
 
-  // init multiplexer
-  can_set_obd(car_harness_status, false);
-
   // Init clock source as internal free running
   dos_set_clock_source_mode(CLOCK_SOURCE_MODE_FREE_RUNNING);
 }

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -250,9 +250,6 @@ void uno_init(void) {
     can_flip_buses(0, 2);
   }
 
-  // init multiplexer
-  can_set_obd(car_harness_status, false);
-
   // Switch to phone usb mode if harness connection is powered by less than 7V
   if(adc_get_voltage() < 7000U){
     uno_set_usb_switch(true);

--- a/board/bootstub_declarations.h
+++ b/board/bootstub_declarations.h
@@ -8,7 +8,6 @@ typedef struct harness_configuration harness_configuration;
 void can_flip_buses(uint8_t bus1, uint8_t bus2){UNUSED(bus1); UNUSED(bus2);}
 void pwm_init(TIM_TypeDef *TIM, uint8_t channel);
 void pwm_set(TIM_TypeDef *TIM, uint8_t channel, uint8_t percentage);
-void can_set_obd(uint8_t harness_orientation, bool obd){UNUSED(harness_orientation); UNUSED(obd);}
 
 // ********************* Globals **********************
 uint8_t hw_type = 0;

--- a/board/drivers/can.h
+++ b/board/drivers/can.h
@@ -235,34 +235,6 @@ void can_set_gmlan(uint8_t bus) {
   }
 }
 
-// TODO: remove
-void can_set_obd(uint8_t harness_orientation, bool obd){
-  if(obd){
-    puts("setting CAN2 to be OBD\n");
-  } else {
-    puts("setting CAN2 to be normal\n");
-  }
-  if(current_board->has_obd){
-    if(obd != (bool)(harness_orientation == HARNESS_STATUS_NORMAL)){
-        // B5,B6: disable normal mode
-        set_gpio_mode(GPIOB, 5, MODE_INPUT);
-        set_gpio_mode(GPIOB, 6, MODE_INPUT);
-        // B12,B13: CAN2 mode
-        set_gpio_alternate(GPIOB, 12, GPIO_AF9_CAN2);
-        set_gpio_alternate(GPIOB, 13, GPIO_AF9_CAN2);
-    } else {
-        // B5,B6: CAN2 mode
-        set_gpio_alternate(GPIOB, 5, GPIO_AF9_CAN2);
-        set_gpio_alternate(GPIOB, 6, GPIO_AF9_CAN2);
-        // B12,B13: disable normal mode
-        set_gpio_mode(GPIOB, 12, MODE_INPUT);
-        set_gpio_mode(GPIOB, 13, MODE_INPUT);
-    }
-  } else {
-    puts("OBD CAN not available on this board\n");
-  }
-}
-
 // CAN error
 void can_sce(CAN_TypeDef *CAN) {
   ENTER_CRITICAL();

--- a/board/main_declarations.h
+++ b/board/main_declarations.h
@@ -7,7 +7,6 @@ typedef struct harness_configuration harness_configuration;
 void can_flip_buses(uint8_t bus1, uint8_t bus2);
 void pwm_init(TIM_TypeDef *TIM, uint8_t channel);
 void pwm_set(TIM_TypeDef *TIM, uint8_t channel, uint8_t percentage);
-void can_set_obd(uint8_t harness_orientation, bool obd);
 
 // ********************* Globals **********************
 uint8_t hw_type = 0;


### PR DESCRIPTION
Remove can_set_obd() from can.h
It was replaced by local to boards set_can_mode()
It got called only when board gets initialized.