### PR TITLE
Deprecate bcdDevice and legacy mode from panda lib and tests

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -181,7 +181,6 @@ class Panda(object):
                 self._serial = this_serial
                 print("opening device", self._serial, hex(device.getProductID()))
                 self.bootstub = device.getProductID() == 0xddee
-                self.legacy = (device.getbcdDevice() != 0x2300)
                 self._handle = device.open()
                 if sys.platform not in ["win32", "cygwin", "msys", "darwin"]:
                   self._handle.setAutoDetachKernelDriver(True)

--- a/python/dfu.py
+++ b/python/dfu.py
@@ -22,7 +22,6 @@ class PandaDFU(object):
           continue
         if this_dfu_serial == dfu_serial or dfu_serial is None:
           self._handle = device.open()
-          self.legacy = "07*128Kg" in self._handle.getASCIIStringDescriptor(4)
           return
     raise Exception("failed to open " + dfu_serial if dfu_serial is not None else "DFU device")
 

--- a/tests/automated/3_usb_to_can.py
+++ b/tests/automated/3_usb_to_can.py
@@ -20,10 +20,7 @@ def test_can_loopback(p):
   # enable CAN loopback mode
   p.set_can_loopback(True)
 
-  if p.legacy:
-    busses = [0, 1]
-  else:
-    busses = [0, 1, 2]
+  busses = [0, 1, 2]
 
   for bus in busses:
     # set bus 0 speed to 250
@@ -135,9 +132,6 @@ def test_throughput(p):
 @panda_type_to_serial
 @panda_connect_and_init
 def test_gmlan(p):
-  if p.legacy:
-    return
-
   # Start heartbeat
   start_heartbeat_thread(p)
 
@@ -169,9 +163,6 @@ def test_gmlan(p):
 @panda_type_to_serial
 @panda_connect_and_init
 def test_gmlan_bad_toggle(p):
-  if p.legacy:
-    return
-
   # Start heartbeat
   start_heartbeat_thread(p)
 


### PR DESCRIPTION
legacy mode with bcdDevice 0x22 was used for NEO and STM32F2 (had only two CANs)