### PR TITLE
VW MQB: Longitudinal safety

### DIFF
--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -57,7 +57,7 @@ const int VOLKSWAGEN_PQ_RX_CHECKS_LEN = sizeof(volkswagen_pq_rx_checks) / sizeof
 
 const uint16_t VOLKSWAGEN_PARAM_LONG = 1;
 
-int volkswagen_longitudinal = false;
+bool volkswagen_longitudinal = false;
 int volkswagen_torque_msg = 0;
 int volkswagen_lane_msg = 0;
 int volkswagen_acc_accel_msg = 0;
@@ -184,10 +184,11 @@ static int volkswagen_mqb_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       // Signal: GRA_ACC_01.GRA_Abbrechen
       // Signal: GRA_ACC_01.GRA_Tip_Setzen
       // Signal: GRA_ACC_01.GRA_Tip_Wiederaufnahme
+      if ((GET_BYTE(to_push, 2) & 0x9) != 0) {
+        controls_allowed = 1;
+      }
       if ((GET_BYTE(to_push, 1) & 0x20) != 0) {
         controls_allowed = 0;
-      } else if ((GET_BYTE(to_push, 2) & 0x9) != 0) {
-        controls_allowed = 1;
       }
     } else if (addr == MSG_TSK_06) {
       // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
@@ -196,7 +197,8 @@ static int volkswagen_mqb_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       int cruise_engaged = ((acc_status == 3) || (acc_status == 4) || (acc_status == 5)) ? 1 : 0;
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
-      } else if (!cruise_engaged) {
+      }
+      if (!cruise_engaged) {
         controls_allowed = 0;
       }
       cruise_engaged_prev = cruise_engaged;

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -353,7 +353,7 @@ static int volkswagen_mqb_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
     int desired_accel = ((((GET_BYTE(to_send, 4) & 0x7) << 8) | GET_BYTE(to_send, 3)) * 5) - 7220;
 
     int acc_status = (GET_BYTE(to_send, 7) & 0x7) >> 4;
-    if (desired_accel == 3010 && !(acc_status == 3)) {
+    if ((desired_accel == 3010) && !(acc_status == 3)) {
       // VW send 3.01 m/s2 acceleration in place of zero while disengaged, treat it as such
       desired_accel = 0;
     }

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -352,6 +352,12 @@ static int volkswagen_mqb_tx_hook(CAN_FIFOMailBox_TypeDef *to_send) {
     bool violation = 0;
     int desired_accel = ((((GET_BYTE(to_send, 4) & 0x7) << 8) | GET_BYTE(to_send, 3)) * 5) - 7220;
 
+    int acc_status = (GET_BYTE(to_send, 7) & 0x7) >> 4;
+    if (desired_accel == 3010 && !(acc_status == 3)) {
+      // VW send 3.01 m/s2 acceleration in place of zero while disengaged, treat it as such
+      desired_accel = 0;
+    }
+
     if (!controls_allowed && (desired_accel != 0)) {
       violation = 1;
     }

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -151,6 +151,8 @@ class Panda(object):
   FLAG_HONDA_ALT_BRAKE = 1
   FLAG_HONDA_BOSCH_LONG = 2
 
+  FLAG_VOLKSWAGEN_LONGITUDINAL = 1
+
   def __init__(self, serial=None, claim=True):
     self._serial = serial
     self._handle = None

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -15,14 +15,20 @@ RT_INTERVAL = 250000
 DRIVER_TORQUE_ALLOWANCE = 80
 DRIVER_TORQUE_FACTOR = 3
 
+MAX_ACCEL = 2.0
+MIN_ACCEL = -3.5
+
 MSG_ESP_19 = 0xB2       # RX from ABS, for wheel speeds
 MSG_LH_EPS_03 = 0x9F    # RX from EPS, for driver steering torque
 MSG_ESP_05 = 0x106      # RX from ABS, for brake light state
 MSG_TSK_06 = 0x120      # RX from ECU, for ACC status from drivetrain coordinator
 MSG_MOTOR_20 = 0x121    # RX from ECU, for driver throttle input
+MSG_ACC_06 = 0x122      # TX by OP, ACC control instructions to the drivetrain coordinator
 MSG_HCA_01 = 0x126      # TX by OP, Heading Control Assist steering torque
 MSG_GRA_ACC_01 = 0x12B  # TX by OP, ACC control buttons for cancel/resume
+MSG_ACC_02 = 0x30C      # TX by OP, ACC HUD data to the instrument cluster
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
+
 
 class TestVolkswagenMqbSafety(common.PandaSafetyTest):
   cnt_lh_eps_03 = 0
@@ -32,24 +38,16 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
   cnt_hca_01 = 0
   cnt_gra_acc_01 = 0
 
-  # Transmit of GRA_ACC_01 is allowed on bus 0 and 2 to keep
-  # compatibility with gateway and camera integration
-  TX_MSGS = [[MSG_HCA_01, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2], [MSG_LDW_02, 0]]
   STANDSTILL_THRESHOLD = 1
   RELAY_MALFUNCTION_ADDR = MSG_HCA_01
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
-  FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
-  def setUp(self):
-    self.packer = CANPackerPanda("vw_mqb_2010")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
-    self.safety.init_tests()
-
-  # override these inherited tests from PandaSafetyTest
-  def test_cruise_engaged_prev(self):
-    pass
+  @classmethod
+  def setUpClass(cls):
+    if cls.__name__ == "TestVolkswagenMqbSafety":
+      cls.packer = None
+      cls.safety = None
+      raise unittest.SkipTest
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
@@ -99,16 +97,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
     self.__class__.cnt_gra_acc_01 += 1
     return self.packer.make_can_msg_panda("GRA_ACC_01", 0, values)
 
-  def test_enable_control_allowed_from_cruise(self):
-    self.safety.set_controls_allowed(0)
-    self._rx(self._pcm_status_msg(True))
-    self.assertTrue(self.safety.get_controls_allowed())
-
-  def test_disable_control_allowed_from_cruise(self):
-    self.safety.set_controls_allowed(1)
-    self._rx(self._pcm_status_msg(False))
-    self.assertFalse(self.safety.get_controls_allowed())
-
   def test_steer_safety_check(self):
     for enabled in [0, 1]:
       for t in range(-500, 500):
@@ -118,15 +106,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
           self.assertFalse(self._tx(self._hca_01_msg(t)))
         else:
           self.assertTrue(self._tx(self._hca_01_msg(t)))
-
-  def test_spam_cancel_safety_check(self):
-    self.safety.set_controls_allowed(0)
-    self.assertTrue(self._tx(self._gra_acc_01_msg(cancel=1)))
-    self.assertFalse(self._tx(self._gra_acc_01_msg(resume=1)))
-    self.assertFalse(self._tx(self._gra_acc_01_msg(_set=1)))
-    # do not block resume if we are engaged already
-    self.safety.set_controls_allowed(1)
-    self.assertTrue(self._tx(self._gra_acc_01_msg(resume=1)))
 
   def test_non_realtime_limit_up(self):
     self.safety.set_torque_driver(0, 0)
@@ -272,6 +251,79 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
       self._rx(self._gas_msg(0))
     self.assertTrue(self.safety.get_controls_allowed())
 
+
+class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
+  TX_MSGS = [[MSG_HCA_01, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2], [MSG_LDW_02, 0]]
+  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
+  FWD_BUS_LOOKUP = {0: 2, 2: 0}
+
+  def setUp(self):
+    self.packer = CANPackerPanda("vw_mqb_2010")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
+    self.safety.init_tests()
+
+  def test_spam_cancel_safety_check(self):
+    self.safety.set_controls_allowed(0)
+    self.assertTrue(self._tx(self._gra_acc_01_msg(cancel=1)))
+    self.assertFalse(self._tx(self._gra_acc_01_msg(resume=1)))
+    self.assertFalse(self._tx(self._gra_acc_01_msg(_set=1)))
+    # do not block resume if we are engaged already
+    self.safety.set_controls_allowed(1)
+    self.assertTrue(self._tx(self._gra_acc_01_msg(resume=1)))
+
+
+class TestVolkswagenMqbLongSafety(TestVolkswagenMqbSafety):
+  cnt_acc_06 = 0
+
+  TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_ACC_02, 0], [MSG_ACC_06, 0]]
+  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02, MSG_ACC_02, MSG_ACC_06]}
+  FWD_BUS_LOOKUP = {0: 2, 2: 0}
+
+  def setUp(self):
+    self.packer = CANPackerPanda("vw_mqb_2010")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, Panda.FLAG_VOLKSWAGEN_LONGITUDINAL)
+    self.safety.init_tests()
+
+  # Acceleration request to drivetrain coordinator
+  def _acc_06_msg(self, accel):
+    values = {"ACC_Sollbeschleunigung_02": accel, "COUNTER": self.cnt_acc_06 % 16}
+    self.__class__.cnt_acc_06 += 1
+    return self.packer.make_can_msg_panda("ACC_06", 0, values)
+
+  # stock cruise controls are entirely bypassed under openpilot longitudinal control
+  def test_disable_control_allowed_from_cruise(self):
+    pass
+
+  def test_enable_control_allowed_from_cruise(self):
+    pass
+
+  def test_cruise_engaged_prev(self):
+    pass
+
+  def test_resume_button(self):
+    self.safety.set_controls_allowed(0)
+    self._rx(self._gra_acc_01_msg(resume=1))
+    self.assertTrue(self.safety.get_controls_allowed())
+
+  def test_set_button(self):
+    self.safety.set_controls_allowed(0)
+    self._rx(self._gra_acc_01_msg(_set=1))
+    self.assertTrue(self.safety.get_controls_allowed())
+
+  def test_cancel_button(self):
+    self.safety.set_controls_allowed(1)
+    self._rx(self._gra_acc_01_msg(cancel=1))
+    self.assertFalse(self.safety.get_controls_allowed())
+
+  def test_accel_safety_check(self):
+    for controls_allowed in [True, False]:
+      for accel in np.arange(MIN_ACCEL - 1, MAX_ACCEL + 1, 0.01):
+        accel = round(accel, 2)  # floats might not hit exact boundary conditions without rounding
+        self.safety.set_controls_allowed(controls_allowed)
+        send = MIN_ACCEL <= accel <= MAX_ACCEL if controls_allowed else accel == 0
+        self.assertEqual(send, self._tx(self._acc_06_msg(accel)), (controls_allowed, accel))
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Work in progress, but runs and drives with full tests. It's broadly similar to the HKG long control scheme. The openpilot side has a ways to go before it's ready for a WIP draft PR.

There's no provision to pass-through a UDS diagnostic disable command, because at this time I've not found one that works on our radar, at least not without security access and switching diagnostic sessions. I haven't given up on finding a way, in fact I'm confident I can find something eventually, but it may be awhile. In the meantime, it works with gateway integrations, and when/if a way is found, safety should otherwise work the same for camera integrations.

While here, I discovered and fixed a bug where MQB stock long was re-entering controls whenever stock ACC was active, not just on the rising edge. Both the bug and the tests have been fixed. I can separate that into its own PR if desired.