### PR TITLE
Timeouts in fw versions query example scan

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -355,7 +355,7 @@ class CanClient():
         self._recv_buffer()
 
 class IsoTpMessage():
-  def __init__(self, can_client: CanClient, timeout: float = 1, debug: bool = False, max_len: int = 8, response_pending_timeout: float = 5):
+  def __init__(self, can_client: CanClient, timeout: float = 1, debug: bool = False, max_len: int = 8, response_pending_timeout: float = 6):
     self._can_client = can_client
     self.timeout = timeout
     self.debug = debug
@@ -509,7 +509,7 @@ def get_rx_addr_for_tx_addr(tx_addr, rx_offset=0x8):
 
 
 class UdsClient():
-  def __init__(self, panda, tx_addr: int, rx_addr: int = None, bus: int = 0, timeout: float = 1, debug: bool = False, response_pending_timeout: float = 5):
+  def __init__(self, panda, tx_addr: int, rx_addr: int = None, bus: int = 0, timeout: float = 1, debug: bool = False, response_pending_timeout: float = 6):
     self.bus = bus
     self.tx_addr = tx_addr
     self.rx_addr = rx_addr if rx_addr is not None else get_rx_addr_for_tx_addr(tx_addr)


### PR DESCRIPTION
Fixes following traceback (caused by one specific infotainment ecu), allowing the fw query scan to finish and show results
```
./panda/examples/query_fw_versions.py
opening device 37003a001651383432363133 0xddcc
connected
querying addresses ...
0x7d0:  41%|██████████████████████████████████████████████████████▊                                                                                | 208/512 [00:47<01:10,  4.34it/s]
Traceback (most recent call last):
  File "./panda/examples/query_fw_versions.py", line 61, in <module>
    data = uds_client.read_data_by_identifier(uds_data_id)  # type: ignore
  File "/data/pythonpath/panda/python/uds.py", line 654, in read_data_by_identifier
    resp = self._uds_request(SERVICE_TYPE.READ_DATA_BY_IDENTIFIER, subfunction=None, data=data)
  File "/data/pythonpath/panda/python/uds.py", line 526, in _uds_request
    resp = isotp_msg.recv()
  File "/data/pythonpath/panda/python/uds.py", line 401, in recv
    self._isotp_rx_next(msg)
  File "/data/pythonpath/panda/python/uds.py", line 443, in _isotp_rx_next
    assert self.rx_idx & 0xF == rx_data[0] & 0xF, "isotp - rx: invalid consecutive frame index"
AssertionError: isotp - rx: invalid consecutive frame index
```
