### PR TITLE
fix kernel 5.11 and above driver compilation

### DIFF
--- a/drivers/linux/panda.c
+++ b/drivers/linux/panda.c
@@ -283,7 +283,7 @@ static void panda_usb_process_can_rx(struct panda_dev_priv *priv_dev,
   //if (msg->dlc & MCBA_DLC_RTR_MASK)
   //  cf->can_id |= CAN_RTR_FLAG;
 
-  cf->can_dlc = get_can_dlc(msg->bus_dat_len & PANDA_DLC_MASK);
+  cf->can_dlc = (min_t(__u8, (msg->bus_dat_len & PANDA_DLC_MASK), 8));
 
   memcpy(cf->data, msg->data, cf->can_dlc);
 


### PR DESCRIPTION
Driver doesn't compile on kernel 5.11 and above, throws `error: implicit declaration of function ‘get_can_dlc’`