### PR TITLE
VW MQB and PQ: Fix controls entry conditions and tests

### DIFF
--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -231,7 +231,7 @@ static int volkswagen_pq_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     // Signal: Motor_2.GRA_Status
     if (addr == MSG_MOTOR_2) {
       int acc_status = (GET_BYTE(to_push, 2) & 0xC0) >> 6;
-      cruise_engaged = ((acc_status == 1) || (acc_status == 2)) ? 1 : 0;
+      int cruise_engaged = ((acc_status == 1) || (acc_status == 2)) ? 1 : 0;
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
       }

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -47,7 +47,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
     self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
     self.safety.init_tests()
 
-  # override these inherited tests from PandaSafetyTest
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
     self.safety.set_rt_torque_last(t)

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -48,9 +48,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
     self.safety.init_tests()
 
   # override these inherited tests from PandaSafetyTest
-  def test_cruise_engaged_prev(self):
-    pass
-
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
     self.safety.set_rt_torque_last(t)
@@ -98,16 +95,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
               "GRA_Tip_Wiederaufnahme": resume, "COUNTER": self.cnt_gra_acc_01 % 16}
     self.__class__.cnt_gra_acc_01 += 1
     return self.packer.make_can_msg_panda("GRA_ACC_01", 0, values)
-
-  def test_enable_control_allowed_from_cruise(self):
-    self.safety.set_controls_allowed(0)
-    self._rx(self._pcm_status_msg(True))
-    self.assertTrue(self.safety.get_controls_allowed())
-
-  def test_disable_control_allowed_from_cruise(self):
-    self.safety.set_controls_allowed(1)
-    self._rx(self._pcm_status_msg(False))
-    self.assertFalse(self.safety.get_controls_allowed())
 
   def test_steer_safety_check(self):
     for enabled in [0, 1]:

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -52,7 +52,6 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest):
     self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_PQ, 0)
     self.safety.init_tests()
 
-  # override these inherited tests from PandaSafetyTest
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
     self.safety.set_rt_torque_last(t)

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -53,9 +53,6 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest):
     self.safety.init_tests()
 
   # override these inherited tests from PandaSafetyTest
-  def test_cruise_engaged_prev(self):
-    pass
-
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
     self.safety.set_rt_torque_last(t)


### PR DESCRIPTION
Panda isn't currently handling `controls_allowed` for Volkswagen quite the same as other ports. We're only supposed to enter controls on rising edge of ACC engagement, but right now we're considering controls allowed whenever ACC is engaged. As far as I can tell, the real-world impact of this is pretty low, but this should be fixed anyway.

First commit will revert the overridden tests that allowed this to go undetected, reverting to the common inherited tests that look for this behavior. Second commit will fix the safety to pass the new tests.

Planning to hold this in draft for a short time, while I make sure this is working as-planned for community users.