### PR TITLE
Try resuming outep3 on can buffer clear

### DIFF
--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -141,9 +141,7 @@ void process_can(uint8_t can_number) {
         CAN->sTxMailBox[0].TDTR = to_send.RDTR;
         CAN->sTxMailBox[0].TIR = to_send.RIR;
 
-        if (can_tx_check_min_slots_free(MAX_CAN_MSGS_PER_BULK_TRANSFER)) {
-          usb_outep3_resume_if_paused();
-        }
+        usb_cb_ep3_out_complete();
       }
     }
 

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -40,6 +40,7 @@ int can_silent = ALL_CAN_SILENT;
 // ******************* functions prototypes *********************
 bool can_init(uint8_t can_number);
 void process_can(uint8_t can_number);
+bool can_tx_check_min_slots_free(uint32_t min);
 
 // ********************* instantiate queues *********************
 #define can_buffer(x, size) \
@@ -125,6 +126,10 @@ void can_clear(can_ring *q) {
   q->w_ptr = 0;
   q->r_ptr = 0;
   EXIT_CRITICAL();
+
+  if (can_tx_check_min_slots_free(MAX_CAN_MSGS_PER_BULK_TRANSFER)) {
+    usb_outep3_resume_if_paused();
+  }
 }
 
 // assign CAN numbering

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -40,7 +40,6 @@ int can_silent = ALL_CAN_SILENT;
 // ******************* functions prototypes *********************
 bool can_init(uint8_t can_number);
 void process_can(uint8_t can_number);
-bool can_tx_check_min_slots_free(uint32_t min);
 
 // ********************* instantiate queues *********************
 #define can_buffer(x, size) \
@@ -126,10 +125,8 @@ void can_clear(can_ring *q) {
   q->w_ptr = 0;
   q->r_ptr = 0;
   EXIT_CRITICAL();
-
-  if (can_tx_check_min_slots_free(MAX_CAN_MSGS_PER_BULK_TRANSFER)) {
-    usb_outep3_resume_if_paused();
-  }
+  // handle TX buffer full with zero ECUs awake on the bus
+  usb_cb_ep3_out_complete();
 }
 
 // assign CAN numbering

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -74,9 +74,7 @@ void process_can(uint8_t can_number) {
         to_push.RDHR = to_send.RDHR;
         can_send_errs += can_push(&can_rx_q, &to_push) ? 0U : 1U;
 
-        if (can_tx_check_min_slots_free(MAX_CAN_MSGS_PER_BULK_TRANSFER)) {
-          usb_outep3_resume_if_paused();
-        }
+        usb_cb_ep3_out_complete();
       }
     }
 


### PR DESCRIPTION
In the can TX interrupt it is checked if there is enough space in the buffers to allow more USB packets to come in. However, when the car is shutting down it's possible a bunch of messages that have to be sent to the camera are never ACKed and fill up the buffer. All further USB transfers would be blocked since the buffers are full, and the TX interrupt will never fire again.

If on following car startup you try to send messages from ELM or ALL_OUTPUT mode they would fail to send due the USB stack still thinking the buffers are full. As soon as you switch to a car safety mode with a fwd hook the CAN TX interrupt starts firing again solving the issue.

This PR adds the same check as in the CAN TX interrupt to the can buffer clear function (which get's called on safety mode switch) to solve this issue.