### PR TITLE
Fix assert error when flash release

### DIFF
--- a/python/flash_release.py
+++ b/python/flash_release.py
@@ -34,7 +34,7 @@ def flash_release(path=None, st_serial=None):
   zf = ZipFile(path)
   zf.printdir()
 
-  version = zf.read("version").decode()
+  version = zf.read("version").decode().strip()
   status("0. Preparing to flash " + str(version))
 
   code_bootstub = zf.read("bootstub.panda.bin")


### PR DESCRIPTION
The variable "version" extract from the zip file has a redundant new line, which causes assert error when flash release. It must be strip before assert.