### PR TITLE
Enable control over the fan on C3 while still in the bootloader

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -221,5 +221,6 @@ const board board_black = {
   .set_ir_power = unused_set_ir_power,
   .set_phone_power = unused_set_phone_power,
   .set_clock_source_mode = unused_set_clock_source_mode,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/boards/board_declarations.h
+++ b/board/boards/board_declarations.h
@@ -14,6 +14,7 @@ typedef void (*board_set_fan_power)(uint8_t percentage);
 typedef void (*board_set_phone_power)(bool enabled);
 typedef void (*board_set_clock_source_mode)(uint8_t mode);
 typedef void (*board_set_siren)(bool enabled);
+typedef bool (*board_read_som_gpio)(void);
 
 struct board {
   const char *board_type;
@@ -38,6 +39,7 @@ struct board {
   board_set_phone_power set_phone_power;
   board_set_clock_source_mode set_clock_source_mode;
   board_set_siren set_siren;
+  board_read_som_gpio read_som_gpio;
 };
 
 // ******************* Definitions ********************

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -231,5 +231,6 @@ const board board_dos = {
   .set_ir_power = dos_set_ir_power,
   .set_phone_power = unused_set_phone_power,
   .set_clock_source_mode = dos_set_clock_source_mode,
-  .set_siren = dos_set_siren
+  .set_siren = dos_set_siren,
+  .read_som_gpio = dos_read_som_gpio
 };

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -128,6 +128,10 @@ void dos_set_siren(bool enabled){
   set_gpio_output(GPIOC, 12, enabled);
 }
 
+bool dos_read_som_gpio (void){
+  return (get_gpio_input(GPIOC, 2) != 0);
+}
+
 void dos_init(void) {
   common_init_gpio();
 
@@ -151,6 +155,10 @@ void dos_init(void) {
 
   // C8: FAN PWM aka TIM3_CH3
   set_gpio_alternate(GPIOC, 8, GPIO_AF2_TIM3);
+
+  // C2: SOM GPIO used as input (fan control at boot)
+  set_gpio_mode(GPIOC, 2, MODE_INPUT);
+  set_gpio_pullup(GPIOC, 2, PULL_DOWN);
 
   // Initialize IR PWM and set to 0%
   set_gpio_alternate(GPIOB, 7, GPIO_AF2_TIM4);

--- a/board/boards/grey.h
+++ b/board/boards/grey.h
@@ -55,5 +55,6 @@ const board board_grey = {
   .set_ir_power = unused_set_ir_power,
   .set_phone_power = unused_set_phone_power,
   .set_clock_source_mode = unused_set_clock_source_mode,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/boards/pedal.h
+++ b/board/boards/pedal.h
@@ -98,5 +98,6 @@ const board board_pedal = {
   .set_ir_power = unused_set_ir_power,
   .set_phone_power = unused_set_phone_power,
   .set_clock_source_mode = unused_set_clock_source_mode,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/boards/red.h
+++ b/board/boards/red.h
@@ -198,5 +198,6 @@ const board board_red = {
   .set_ir_power = unused_set_ir_power,
   .set_phone_power = unused_set_phone_power,
   .set_clock_source_mode = unused_set_clock_source_mode,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -284,5 +284,6 @@ const board board_uno = {
   .set_ir_power = uno_set_ir_power,
   .set_phone_power = uno_set_phone_power,
   .set_clock_source_mode = unused_set_clock_source_mode,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/boards/unused_funcs.h
+++ b/board/boards/unused_funcs.h
@@ -29,3 +29,7 @@ void unused_set_siren(bool enabled) {
 uint32_t unused_read_current(void) {
   return 0U;
 }
+
+bool unused_read_som_gpio(void) {
+  return false;
+}

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -260,5 +260,6 @@ const board board_white = {
   .set_ir_power = unused_set_ir_power,
   .set_phone_power = unused_set_phone_power,
   .set_clock_source_mode = unused_set_clock_source_mode,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/main.c
+++ b/board/main.c
@@ -738,8 +738,9 @@ void tick_handler(void) {
           // Also disable IR when the heartbeat goes missing
           current_board->set_ir_power(0U);
 
-          // If enumerated but no heartbeat (phone up, boardd not running), turn the fan on to cool the device
-          if(usb_enumerated()){
+          // If enumerated but no heartbeat (phone up, boardd not running), or when the SOM GPIO is pulled high by the ABL,
+          // turn the fan on to cool the device
+          if(usb_enumerated() || current_board->read_som_gpio()){
             current_board->set_fan_power(50U);
           } else {
             current_board->set_fan_power(0U);


### PR DESCRIPTION
This uses a GPIO line which we can control from the SOM bootloader