### PR TITLE
expose debug flags and improve debug console output

### DIFF
--- a/board/SConscript
+++ b/board/SConscript
@@ -129,14 +129,6 @@ else:
 
 if os.getenv("DEBUG"):
   flags += ["-DDEBUG"]
-if os.getenv("DEBUG_UART"):
-  flags += ["-DDEBUG_UART"]
-if os.getenv("DEBUG_USB"):
-  flags += ["-DDEBUG_USB"]
-if os.getenv("DEBUG_SPI"):
-  flags += ["-DDEBUG_SPI"]
-if os.getenv("DEBUG_FAULTS"):
-  flags += ["-DDEBUG_FAULTS"]
 
 includes = [
   "stm32fx/inc",

--- a/board/SConscript
+++ b/board/SConscript
@@ -127,6 +127,17 @@ else:
   cert_fn = File("../certs/debug").srcnode().abspath
   flags += ["-DALLOW_DEBUG"]
 
+if os.getenv("DEBUG"):
+  flags += ["-DDEBUG"]
+if os.getenv("DEBUG_UART"):
+  flags += ["-DDEBUG_UART"]
+if os.getenv("DEBUG_USB"):
+  flags += ["-DDEBUG_USB"]
+if os.getenv("DEBUG_SPI"):
+  flags += ["-DDEBUG_SPI"]
+if os.getenv("DEBUG_FAULTS"):
+  flags += ["-DDEBUG_FAULTS"]
+
 includes = [
   "stm32fx/inc",
   "stm32h7/inc",

--- a/board/bootstub_declarations.h
+++ b/board/bootstub_declarations.h
@@ -2,6 +2,7 @@
 void puts(const char *a){ UNUSED(a); }
 void puth(uint8_t i){ UNUSED(i); }
 void puth2(uint8_t i){ UNUSED(i); }
+void puth4(uint8_t i){ UNUSED(i); }
 typedef struct board board;
 typedef struct harness_configuration harness_configuration;
 // No CAN support on bootloader

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -100,7 +100,21 @@ bool can_push(can_ring *q, CAN_FIFOMailBox_TypeDef *elem) {
   if (!ret) {
     can_overflow_cnt++;
     #ifdef DEBUG
-      puts("can_push failed!\n");
+      puts("can_push to ");
+      if (q == &can_rx_q) {
+        puts("can_rx_q");
+      } else if (q == &can_tx1_q) {
+        puts("can_tx1_q");
+      } else if (q == &can_tx2_q) {
+        puts("can_tx2_q");
+      } else if (q == &can_tx3_q) {
+        puts("can_tx3_q");
+      } else if (q == &can_txgmlan_q) {
+        puts("can_txgmlan_q");
+      } else {
+        puts("unknown");
+      }
+      puts(" failed!\n");
     #endif
   }
   return ret;

--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -181,9 +181,9 @@ void putui(uint32_t i) {
   puts(&str[idx + 1U]);
 }
 
-void puthx(unsigned int i, unsigned int len) {
+void puthx(uint32_t i, uint8_t len) {
   const char c[] = "0123456789abcdef";
-  for (int pos = (len * 4) - 4; pos > -4; pos -= 4) {
+  for (int pos = ((int)len * 4) - 4; pos > -4; pos -= 4) {
     putch(c[(i >> (unsigned int)(pos)) & 0xFU]);
   }
 }

--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -181,18 +181,23 @@ void putui(uint32_t i) {
   puts(&str[idx + 1U]);
 }
 
-void puth(unsigned int i) {
+void puthx(unsigned int i, unsigned int len) {
   const char c[] = "0123456789abcdef";
-  for (int pos = 28; pos != -4; pos -= 4) {
+  for (int pos = (len * 4) - 4; pos > -4; pos -= 4) {
     putch(c[(i >> (unsigned int)(pos)) & 0xFU]);
   }
 }
 
+void puth(unsigned int i) {
+  puthx(i, 8);
+}
+
 void puth2(unsigned int i) {
-  const char c[] = "0123456789abcdef";
-  for (int pos = 4; pos != -4; pos -= 4) {
-    putch(c[(i >> (unsigned int)(pos)) & 0xFU]);
-  }
+  puthx(i, 2);
+}
+
+void puth4(unsigned int i) {
+  puthx(i, 4);
 }
 
 void hexdump(const void *a, int l) {

--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -189,15 +189,15 @@ void puthx(unsigned int i, unsigned int len) {
 }
 
 void puth(unsigned int i) {
-  puthx(i, 8);
+  puthx(i, 8U);
 }
 
 void puth2(unsigned int i) {
-  puthx(i, 2);
+  puthx(i, 2U);
 }
 
 void puth4(unsigned int i) {
-  puthx(i, 4);
+  puthx(i, 4U);
 }
 
 void hexdump(const void *a, int l) {

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -823,9 +823,11 @@ void usb_irqhandler(void) {
       // USBx_OUTEP(3)->DOEPTSIZ = (1U << 19) | 0x40U;
       // USBx_OUTEP(3)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
     } else if ((USBx_OUTEP(3)->DOEPINT) != 0) {
-      puts("OUTEP3 error ");
-      puth(USBx_OUTEP(3)->DOEPINT);
-      puts("\n");
+      #ifdef DEBUG_USB
+        puts("OUTEP3 error ");
+        puth(USBx_OUTEP(3)->DOEPINT);
+        puts("\n");
+      #endif
     } else {
       // USBx_OUTEP(3)->DOEPINT is 0, ok to skip
     }

--- a/board/main.c
+++ b/board/main.c
@@ -679,9 +679,10 @@ void tick_handler(void) {
       }
       #ifdef DEBUG
         puts("** blink ");
-        puth(can_rx_q.r_ptr); puts(" "); puth(can_rx_q.w_ptr); puts("  ");
-        puth(can_tx1_q.r_ptr); puts(" "); puth(can_tx1_q.w_ptr); puts("  ");
-        puth(can_tx2_q.r_ptr); puts(" "); puth(can_tx2_q.w_ptr); puts("\n");
+        puts("rx:"); puth(can_rx_q.r_ptr); puts("/"); puth(can_rx_q.w_ptr); puts("  ");
+        puts("tx1:"); puth(can_tx1_q.r_ptr); puts("/"); puth(can_tx1_q.w_ptr); puts("  ");
+        puts("tx2:"); puth(can_tx2_q.r_ptr); puts("/"); puth(can_tx2_q.w_ptr); puts("  ");
+        puts("tx3:"); puth(can_tx3_q.r_ptr); puts("/"); puth(can_tx3_q.w_ptr); puts("\n");
       #endif
 
       // Tick drivers

--- a/board/main.c
+++ b/board/main.c
@@ -679,10 +679,10 @@ void tick_handler(void) {
       }
       #ifdef DEBUG
         puts("** blink ");
-        puts("rx:"); puth(can_rx_q.r_ptr); puts("/"); puth(can_rx_q.w_ptr); puts("  ");
-        puts("tx1:"); puth(can_tx1_q.r_ptr); puts("/"); puth(can_tx1_q.w_ptr); puts("  ");
-        puts("tx2:"); puth(can_tx2_q.r_ptr); puts("/"); puth(can_tx2_q.w_ptr); puts("  ");
-        puts("tx3:"); puth(can_tx3_q.r_ptr); puts("/"); puth(can_tx3_q.w_ptr); puts("\n");
+        puts("rx:"); puth4(can_rx_q.r_ptr); puts("-"); puth4(can_rx_q.w_ptr); puts("  ");
+        puts("tx1:"); puth4(can_tx1_q.r_ptr); puts("-"); puth4(can_tx1_q.w_ptr); puts("  ");
+        puts("tx2:"); puth4(can_tx2_q.r_ptr); puts("-"); puth4(can_tx2_q.w_ptr); puts("  ");
+        puts("tx3:"); puth4(can_tx3_q.r_ptr); puts("-"); puth4(can_tx3_q.w_ptr); puts("\n");
       #endif
 
       // Tick drivers

--- a/board/main_declarations.h
+++ b/board/main_declarations.h
@@ -2,6 +2,7 @@
 void puts(const char *a);
 void puth(unsigned int i);
 void puth2(unsigned int i);
+void puth4(unsigned int i);
 typedef struct board board;
 typedef struct harness_configuration harness_configuration;
 void can_flip_buses(uint8_t bus1, uint8_t bus2);

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -20,9 +20,6 @@
   void puth2(unsigned int i) {
     UNUSED(i);
   }
-  void puth4(unsigned int i) {
-    UNUSED(i);
-  }
 #endif
 
 #define ENTER_BOOTLOADER_MAGIC 0xdeadbeefU

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -20,6 +20,9 @@
   void puth2(unsigned int i) {
     UNUSED(i);
   }
+  void puth4(unsigned int i) {
+    UNUSED(i);
+  }
 #endif
 
 #define ENTER_BOOTLOADER_MAGIC 0xdeadbeefU

--- a/board/pedal/main_declarations.h
+++ b/board/pedal/main_declarations.h
@@ -2,6 +2,7 @@
 void puts(const char *a);
 void puth(unsigned int i);
 void puth2(unsigned int i);
+void puth4(unsigned int i);
 typedef struct board board;
 typedef struct harness_configuration harness_configuration;
 


### PR DESCRIPTION
support enabling debug flags when flashing
```sh
DEBUG=1 ./flash.sh
```

and improve debug console output
```
** blink rx:000009e5/00000a1d  tx1:000000ce/000000cb  tx2:00000000/00000000  tx3:00000000/00000000
** blink rx:00000983/00000a30  tx1:00000033/0000002f  tx2:00000000/00000000  tx3:00000000/00000000
** blink rx:00000a43/00000a53  tx1:000000a8/000000a7  tx2:00000000/00000000  tx3:00000000/00000000
** blink rx:000009e3/00000a74  tx1:0000001b/00000017  tx2:00000000/00000000  tx3:00000000/00000000
can_push to can_tx1_q failed!
can_push to can_tx1_q failed!
** blink rx:00000a80/00000a97  tx1:00000090/00000071  tx2:00000000/00000000  tx3:00000000/00000000
** blink rx:00000a3f/00000ab2  tx1:000000fd/000000f9  tx2:00000000/00000000  tx3:00000000/00000000
```