### PR TITLE
Fix bulk transfer dropping messages sometimes

### DIFF
--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -23,8 +23,6 @@ typedef union _USB_Setup {
 }
 USB_Setup_TypeDef;
 
-#define MAX_CAN_MSGS_PER_BULK_TRANSFER 16U
-
 bool usb_eopf_detected = false;
 
 void usb_init(void);
@@ -363,6 +361,8 @@ uint8_t usbdata[0x100];
 uint8_t* ep0_txdata = NULL;
 uint16_t ep0_txlen = 0;
 bool outep3_processing = false;
+
+#define MAX_CAN_MSGS_PER_BULK_TRANSFER (uint32_t)(sizeof(usbdata) / sizeof(CAN_FIFOMailBox_TypeDef))
 
 // Store the current interface alt setting.
 int current_int0_alt_setting = 0;

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -23,6 +23,8 @@ typedef union _USB_Setup {
 }
 USB_Setup_TypeDef;
 
+#define MAX_CAN_MSGS_PER_BULK_TRANSFER 4U
+
 bool usb_eopf_detected = false;
 
 void usb_init(void);
@@ -361,8 +363,6 @@ uint8_t usbdata[0x100];
 uint8_t* ep0_txdata = NULL;
 uint16_t ep0_txlen = 0;
 bool outep3_processing = false;
-
-#define MAX_CAN_MSGS_PER_BULK_TRANSFER (uint32_t)(sizeof(usbdata) / sizeof(CAN_FIFOMailBox_TypeDef))
 
 // Store the current interface alt setting.
 int current_int0_alt_setting = 0;

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -23,7 +23,7 @@ typedef union _USB_Setup {
 }
 USB_Setup_TypeDef;
 
-#define MAX_CAN_MSGS_PER_BULK_TRANSFER 4U
+#define MAX_CAN_MSGS_PER_BULK_TRANSFER 16U
 
 bool usb_eopf_detected = false;
 

--- a/board/main.c
+++ b/board/main.c
@@ -236,7 +236,8 @@ void usb_cb_ep3_out(void *usbdata, int len, bool hardwired) {
 }
 
 void usb_cb_ep3_out_complete(void) {
-  if (can_tx_check_min_slots_free(MAX_CAN_MSGS_PER_BULK_TRANSFER)) {
+  // TODO: how does a second USB packet sneek in? (why multiply by 2)
+  if (can_tx_check_min_slots_free(MAX_CAN_MSGS_PER_BULK_TRANSFER * 2U)) {
     usb_outep3_resume_if_paused();
   }
 }

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -533,7 +533,13 @@ class Panda(object):
           for s in snds:
             self._handle.bulkWrite(3, s)
         else:
-          self._handle.bulkWrite(3, b''.join(snds), timeout=timeout)
+          dat = b''.join(snds)
+          while True:
+            bs = self._handle.bulkWrite(3, dat, timeout=timeout)
+            dat = dat[bs:]
+            if len(dat) == 0:
+              break
+            print("CAN: PARTIAL SEND MANY, RETRYING")
         break
       except (usb1.USBErrorIO, usb1.USBErrorOverflow):
         print("CAN: BAD SEND MANY, RETRYING")

--- a/tests/automated/4_can_loopback.py
+++ b/tests/automated/4_can_loopback.py
@@ -214,8 +214,12 @@ def test_bulk_write(p):
 
   def flood_tx(panda):
     print('Sending!')
-    msg = b"\xaa" * 4
-    packet = [[0xaa, None, msg, 0], [0xaa, None, msg, 1], [0xaa, None, msg, 2]] * NUM_MESSAGES_PER_BUS
+    msg = b"\xaa" * 8
+    packet = []
+    # start with many messages on a single bus (higher contention for single TX ring buffer)
+    packet += [[0xaa, None, msg, 0]] * NUM_MESSAGES_PER_BUS
+    # end with many messages on multiple buses
+    packet += [[0xaa, None, msg, 0], [0xaa, None, msg, 1], [0xaa, None, msg, 2]] * NUM_MESSAGES_PER_BUS
 
     # Disable timeout
     panda.can_send_many(packet, timeout=0)
@@ -241,7 +245,7 @@ def test_bulk_write(p):
   print(f"Received {len(rx)} messages")
 
   # All messages should have been received
-  if len(rx) != 3 * NUM_MESSAGES_PER_BUS:
+  if len(rx) != 4 * NUM_MESSAGES_PER_BUS:
     Exception("Did not receive all messages!")
 
   # Set back to silent mode


### PR DESCRIPTION
I noticed TX messages getting dropped when sending large amounts of CAN messages really fast with a timeout specified (and USB NAKs are needed).  I am sure I have the max number of messages per USB packet correct, so somehow it seems like a second packet sneaks in when we want to start NAKing but I am failing to see how.  I tried adding `ENTER_CRITICAL()` and `EXIT_CRITICAL()` around `usb_irqhandler` but it doesn't help, so I am not sure how this happens.  Since I don't understand what is going on, I am worried that maybe more than one extra USB packets could somehow sneak in and this isn't a real fix.