### PR TITLE
updated: ruby homebrew installer deprecated.

### DIFF
--- a/board/get_sdk_mac.sh
+++ b/board/get_sdk_mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Need formula for gcc
 sudo easy_install pip
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew tap ArmMbed/homebrew-formulae
 brew install python dfu-util arm-none-eabi-gcc
 pip install --user libusb1 pycryptodome requests


### PR DESCRIPTION
updated script after following url https://raw.githubusercontent.com/Homebrew/install/master/install

that url returns the following indication:

  STDERR.print <<EOS
  Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
  Bash. Please migrate to the following command:
    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
  
  EOS
  
  Kernel.exec "/bin/bash", "-c", '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
