### PR TITLE
Nissan: use cleaner Leaf brake pressed signal

### DIFF
--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -71,7 +71,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       }
     }
 
-    // X-trail 0x454, Leaf  0x1cc
+    // X-trail 0x454, Leaf  0x25e
     if ((addr == 0x454) || (addr == 0x25e)) {
       if (addr == 0x454){
         brake_pressed = (GET_BYTE(to_push, 2) & 0x80) != 0;

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -25,8 +25,7 @@ AddrCheckStruct nissan_addr_checks[] = {
            {0x15c, 1, 8, .expected_timestep = 20000U},
            {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
   {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
-           {0x454, 1, 8, .expected_timestep = 100000U},
-           {0x239, 0, 8, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+           {0x454, 1, 8, .expected_timestep = 100000U}, { 0 }}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 #define NISSAN_ADDR_CHECK_LEN (sizeof(nissan_addr_checks) / sizeof(nissan_addr_checks[0]))
 addr_checks nissan_rx_checks = {nissan_addr_checks, NISSAN_ADDR_CHECK_LEN};

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -26,7 +26,7 @@ AddrCheckStruct nissan_addr_checks[] = {
            {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
   {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
            {0x454, 1, 8, .expected_timestep = 100000U},
-           {0x25e, 0, 1, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+           {0x239, 0, 8, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 #define NISSAN_ADDR_CHECK_LEN (sizeof(nissan_addr_checks) / sizeof(nissan_addr_checks[0]))
 addr_checks nissan_rx_checks = {nissan_addr_checks, NISSAN_ADDR_CHECK_LEN};
@@ -71,12 +71,12 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       }
     }
 
-    // X-trail 0x454, Leaf  0x25e
-    if ((addr == 0x454) || (addr == 0x25e)) {
+    // X-trail 0x454, Leaf  0x239
+    if ((addr == 0x454) || (addr == 0x239)) {
       if (addr == 0x454){
         brake_pressed = (GET_BYTE(to_push, 2) & 0x80) != 0;
       } else {
-        brake_pressed = GET_BYTE(to_push, 0) != 0;
+        brake_pressed = (GET_BYTE(to_push, 4) & 0x20) != 0;
       }
     }
 

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -25,7 +25,8 @@ AddrCheckStruct nissan_addr_checks[] = {
            {0x15c, 1, 8, .expected_timestep = 20000U},
            {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
   {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
-           {0x454, 1, 8, .expected_timestep = 100000U}, { 0 }}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+           {0x454, 1, 8, .expected_timestep = 100000U},
+           {0x1cc, 0, 4, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 #define NISSAN_ADDR_CHECK_LEN (sizeof(nissan_addr_checks) / sizeof(nissan_addr_checks[0]))
 addr_checks nissan_rx_checks = {nissan_addr_checks, NISSAN_ADDR_CHECK_LEN};

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -26,7 +26,7 @@ AddrCheckStruct nissan_addr_checks[] = {
            {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
   {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
            {0x454, 1, 8, .expected_timestep = 100000U},
-           {0x1cc, 0, 4, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+           {0x25e, 0, 1, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 #define NISSAN_ADDR_CHECK_LEN (sizeof(nissan_addr_checks) / sizeof(nissan_addr_checks[0]))
 addr_checks nissan_rx_checks = {nissan_addr_checks, NISSAN_ADDR_CHECK_LEN};
@@ -76,7 +76,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
       if (addr == 0x454){
         brake_pressed = (GET_BYTE(to_push, 2) & 0x80) != 0;
       } else {
-        brake_pressed = GET_BYTE(to_push, 0) > 3;
+        brake_pressed = GET_BYTE(to_push, 0) != 0;
       }
     }
 

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -26,7 +26,7 @@ AddrCheckStruct nissan_addr_checks[] = {
            {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
   {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
            {0x454, 1, 8, .expected_timestep = 100000U},
-           {0x25e, 0, 1, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+           {0x, 0, 1, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 #define NISSAN_ADDR_CHECK_LEN (sizeof(nissan_addr_checks) / sizeof(nissan_addr_checks[0]))
 addr_checks nissan_rx_checks = {nissan_addr_checks, NISSAN_ADDR_CHECK_LEN};
@@ -72,7 +72,7 @@ static int nissan_rx_hook(CAN_FIFOMailBox_TypeDef *to_push) {
     }
 
     // X-trail 0x454, Leaf  0x1cc
-    if ((addr == 0x454) || (addr == 0x1cc)) {
+    if ((addr == 0x454) || (addr == 0x25e)) {
       if (addr == 0x454){
         brake_pressed = (GET_BYTE(to_push, 2) & 0x80) != 0;
       } else {

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -26,7 +26,7 @@ AddrCheckStruct nissan_addr_checks[] = {
            {0x239, 0, 8, .expected_timestep = 20000U}}}, // GAS_PEDAL (100Hz / 50Hz)
   {.msg = {{0x454, 0, 8, .expected_timestep = 100000U},
            {0x454, 1, 8, .expected_timestep = 100000U},
-           {0x, 0, 1, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
+           {0x25e, 0, 1, .expected_timestep = 10000U}}}, // DOORS_LIGHTS (10Hz) / BRAKE (100Hz)
 };
 #define NISSAN_ADDR_CHECK_LEN (sizeof(nissan_addr_checks) / sizeof(nissan_addr_checks[0]))
 addr_checks nissan_rx_checks = {nissan_addr_checks, NISSAN_ADDR_CHECK_LEN};


### PR DESCRIPTION
Refer to openpilot issue 19631, this is necessary to change the detection from the braking from how the brakes report to the actual brake pedal being used

Updated brake CAN address to 0x25e and brake pressed to byte logic
