### PR TITLE
Enable CAN FD support

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -165,9 +165,9 @@ void can_clear(can_ring *q) {
 // Helpers
 // Panda:       Bus 0=CAN1   Bus 1=CAN2   Bus 2=CAN3
 bus_config_t bus_config[] = {
-  { .bus_lookup =0U, .can_num_lookup = 0U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
-  { .bus_lookup =1U, .can_num_lookup = 1U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
-  { .bus_lookup =2U, .can_num_lookup = 2U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 0U, .can_num_lookup = 0U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 1U, .can_num_lookup = 1U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 2U, .can_num_lookup = 2U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
   { .bus_lookup = 0xFFU, .can_num_lookup = 0xFFU, .can_speed = 333U, .can_data_speed = 333U, .canfd_enabled = false, .brs_enabled = false },
 };
 

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -10,6 +10,8 @@ typedef struct {
   uint8_t can_num_lookup;
   uint32_t can_speed;
   uint32_t can_data_speed;
+  bool canfd_enabled;
+  bool brs_enabled;
 } bus_config_t;
 
 #define CAN_BUS_NUM_MASK 0x3FU
@@ -163,10 +165,10 @@ void can_clear(can_ring *q) {
 // Helpers
 // Panda:       Bus 0=CAN1   Bus 1=CAN2   Bus 2=CAN3
 bus_config_t bus_config[] = {
-  { .bus_lookup = 0U, .can_num_lookup = 0U, .can_speed = 5000U, .can_data_speed = 5000U },
-  { .bus_lookup = 1U, .can_num_lookup = 1U, .can_speed = 5000U, .can_data_speed = 5000U },
-  { .bus_lookup = 2U, .can_num_lookup = 2U, .can_speed = 5000U, .can_data_speed = 5000U },
-  { .bus_lookup = 0xFFU, .can_num_lookup = 0xFFU, .can_speed = 333U, .can_data_speed = 333U },
+  { .bus_lookup =0U, .can_num_lookup = 0U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup =1U, .can_num_lookup = 1U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup =2U, .can_num_lookup = 2U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 0xFFU, .can_num_lookup = 0xFFU, .can_speed = 333U, .can_data_speed = 333U, .canfd_enabled = false, .brs_enabled = false },
 };
 
 #define CAN_MAX 3U

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -61,7 +61,7 @@ void process_can(uint8_t can_number) {
         fifo = (canfd_fifo *)(TxFIFOSA + (tx_index * FDCAN_TX_FIFO_EL_SIZE));
 
         fifo->header[0] = (to_send.extended << 30) | ((to_send.extended != 0) ? (to_send.addr) : (to_send.addr << 18));
-        fifo->header[1] = (to_send.data_len_code << 16); // | (1U << 21) | (1U << 20) to enable CAN FD , enable BRS
+        fifo->header[1] = (to_send.data_len_code << 16) | (bus_config[can_number].canfd_enabled << 21) | (bus_config[can_number].brs_enabled << 20);
 
         uint8_t data_len_w = (dlc_to_len[to_send.data_len_code] / 4U);
         data_len_w += ((dlc_to_len[to_send.data_len_code] % 4) > 0) ? 1U : 0U;

--- a/board/main.c
+++ b/board/main.c
@@ -600,8 +600,18 @@ int usb_cb_control_msg(USB_Setup_TypeDef *setup, uint8_t *resp, bool hardwired) 
       if (setup->b.wValue.w < CAN_MAX) {
         // TODO: add sanity check, ideally check if value is correct(from array of correct values)
         bus_config[setup->b.wValue.w].can_data_speed = setup->b.wIndex.w;
+        bus_config[setup->b.wValue.w].canfd_enabled = (setup->b.wIndex.w >= bus_config[setup->b.wValue.w].can_speed) ? true : false;
+        bus_config[setup->b.wValue.w].brs_enabled = (setup->b.wIndex.w > bus_config[setup->b.wValue.w].can_speed) ? true : false;
         bool ret = can_init(CAN_NUM_FROM_BUS_NUM(setup->b.wValue.w));
         UNUSED(ret);
+      }
+      break;
+    // **** 0xfa: check if CAN FD and BRS are enabled
+    case 0xfa:
+      if (setup->b.wValue.w < CAN_MAX) {
+        resp[0] =  bus_config[setup->b.wValue.w].canfd_enabled;
+        resp[1] = bus_config[setup->b.wValue.w].brs_enabled;
+        resp_len = 2;
       }
       break;
     default:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -584,6 +584,15 @@ class Panda(object):
   def set_can_data_speed_kbps(self, bus, speed):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xf9, bus, int(speed * 10), b'')
 
+    # CAN FD and BRS status
+  def get_canfd_status(self, bus):
+    dat = self._handle.controlRead(Panda.REQUEST_IN, 0xfa, bus, 0, 2)
+    if dat:
+      a = struct.unpack("BB", dat)
+      return (a[0], a[1])
+    else:
+      return (None, None)
+
   def set_uart_baud(self, uart, rate):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xe4, uart, int(rate / 300), b'')
 


### PR DESCRIPTION
Enable CAN FD support.
CAN FD enabled if can_data_speed is set. Also BRS enabled if can_data_speed is higher than can_speed.
can_data_speed must be set after can_speed (and that's seems logical)

P.S.: Based on #739 , testing.