### PR TITLE
Improve tests

### DIFF
--- a/tests/automated/1_program.py
+++ b/tests/automated/1_program.py
@@ -11,13 +11,13 @@ def aaaa_reset_before_tests():
 
 @test_all_pandas
 @panda_connect_and_init(clear_can=False)
-def test_recover(p):
+def test_a_recover(p):
   assert p.recover(timeout=30)
 
 
 @test_all_pandas
 @panda_connect_and_init(clear_can=False)
-def test_flash(p):
+def test_b_flash(p):
   p.flash()
 
 

--- a/tests/automated/3_usb_to_can.py
+++ b/tests/automated/3_usb_to_can.py
@@ -116,7 +116,7 @@ def test_throughput(p):
   # enable CAN loopback mode
   p.set_can_loopback(True)
 
-  for speed in [100, 250, 500, 750, 1000]:
+  for speed in [100, 250, 500, 1000]:
     # set bus 0 speed to speed
     p.set_can_speed_kbps(0, speed)
     time.sleep(0.05)

--- a/tests/automated/4_can_loopback.py
+++ b/tests/automated/4_can_loopback.py
@@ -26,7 +26,7 @@ def test_send_recv(p):
     busses = [0, 1, 2]
 
     for bus in busses:
-      for speed in [100, 250, 500, 750, 1000]:
+      for speed in [100, 250, 500, 1000]:
         p_send.set_can_speed_kbps(bus, speed)
         p_recv.set_can_speed_kbps(bus, speed)
         time.sleep(0.05)
@@ -79,7 +79,7 @@ def test_latency(p):
     busses = [0, 1, 2]
 
     for bus in busses:
-      for speed in [100, 250, 500, 750, 1000]:
+      for speed in [100, 250, 500, 1000]:
         p_send.set_can_speed_kbps(bus, speed)
         p_recv.set_can_speed_kbps(bus, speed)
         time.sleep(0.1)


### PR DESCRIPTION
Recover test must go before flash test for better stability(to flash main and bootstub firmwares first)
Also 750kbps speed is not used by CAN/CAN FD and prevents to reach both 2 and 5 Mbps with CAN FD because of time quanta.