### PR TITLE
Add passthrough safety mode

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -38,6 +38,7 @@
 #define SAFETY_SUBARU_LEGACY 22U
 #define SAFETY_HYUNDAI_LEGACY 23U
 #define SAFETY_HYUNDAI_COMMUNITY 24U
+#define SAFETY_PASSTHROUGH 25U
 
 uint16_t current_safety_mode = SAFETY_SILENT;
 int16_t current_safety_param = 0;
@@ -256,6 +257,7 @@ const safety_hook_config safety_hook_registry[] = {
   {SAFETY_VOLKSWAGEN_PQ, &volkswagen_pq_hooks},
   {SAFETY_ALLOUTPUT, &alloutput_hooks},
   {SAFETY_FORD, &ford_hooks},
+  {SAFETY_PASSTHROUGH, &passthrough_hooks},
 #endif
 };
 

--- a/board/safety.h
+++ b/board/safety.h
@@ -38,7 +38,7 @@
 #define SAFETY_SUBARU_LEGACY 22U
 #define SAFETY_HYUNDAI_LEGACY 23U
 #define SAFETY_HYUNDAI_COMMUNITY 24U
-#define SAFETY_PASSTHROUGH 25U
+#define SAFETY_STELLANTIS 25U
 
 uint16_t current_safety_mode = SAFETY_SILENT;
 int16_t current_safety_param = 0;
@@ -257,7 +257,6 @@ const safety_hook_config safety_hook_registry[] = {
   {SAFETY_VOLKSWAGEN_PQ, &volkswagen_pq_hooks},
   {SAFETY_ALLOUTPUT, &alloutput_hooks},
   {SAFETY_FORD, &ford_hooks},
-  {SAFETY_PASSTHROUGH, &passthrough_hooks},
 #endif
 };
 

--- a/board/safety/safety_defaults.h
+++ b/board/safety/safety_defaults.h
@@ -73,7 +73,7 @@ static int alloutput_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
   UNUSED(to_fwd);
   int bus_fwd = -1;
 
-  if (alloutput_passthrough == true) {
+  if (alloutput_passthrough) {
     if (bus_num == 0) {
       bus_fwd = 2;
     }

--- a/board/safety/safety_defaults.h
+++ b/board/safety/safety_defaults.h
@@ -71,3 +71,27 @@ const safety_hooks alloutput_hooks = {
   .tx_lin = alloutput_tx_lin_hook,
   .fwd = default_fwd_hook,
 };
+
+// *** passthrough safety mode ***
+
+static int passthrough_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
+  int bus_fwd = -1;
+  UNUSED(to_fwd);
+
+  if (bus_num == 0) {
+    bus_fwd = 2;
+  }
+  if (bus_num == 2) {
+    bus_fwd = 0;
+  }
+
+  return bus_fwd;
+}
+
+const safety_hooks passthrough_hooks = {
+  .init = alloutput_init,
+  .rx = default_rx_hook,
+  .tx = alloutput_tx_hook,
+  .tx_lin = alloutput_tx_lin_hook,
+  .fwd = passthrough_fwd_hook,
+};


### PR DESCRIPTION
This safety mode opens relay and forwards messages from bus 0 to 2 and from bus 2 to 0. That way we can know for sure which messages were sent by camera. 
It is only allowed when compiled with DEBUG set to true.