### PR TITLE
board/get_sdk.sh: add dfu-util and python3-pip

### DIFF
--- a/board/get_sdk.sh
+++ b/board/get_sdk.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo apt-get install -y dfu-util gcc-arm-none-eabi python3-pip
+sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip
 sudo pip install libusb1 pycryptodome requests

--- a/board/get_sdk.sh
+++ b/board/get_sdk.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-sudo apt-get install gcc-arm-none-eabi python-pip
+sudo apt-get install -y dfu-util gcc-arm-none-eabi python3-pip
 sudo pip install libusb1 pycryptodome requests


### PR DESCRIPTION
dfu-util package missing from get_sdk.sh. Flash and recover tasks fail without it.
Package already included in the mac version of the script, and is also included in the dockerfile

Also updated python-pip to python3-pip and added the '-y' flag to apt-get.