### PR TITLE
VW MQB: Prep for longitudinal safety

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -299,7 +299,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
         fwd_bus = self.FWD_BUS_LOOKUP.get(bus, -1)
         if bus in self.FWD_BLACKLISTED_ADDRS and addr in self.FWD_BLACKLISTED_ADDRS[bus]:
           fwd_bus = -1
-        self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg))
+        self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg), f"{addr=:#x} from {bus=} to {fwd_bus=} got through")
 
   def test_spam_can_buses(self):
     for addr in range(1, 0x800):
@@ -426,16 +426,16 @@ class PandaSafetyTest(PandaSafetyTestBase):
             # TODO: Temporary, should be fixed in panda firmware, safety_honda.h
             if attr in ['TestHondaBoschLongGiraffeSafety', 'TestHondaNidecSafety']:
               tx = list(filter(lambda m: m[0] not in [0x1FA, 0x30C], tx))
-            all_tx.append(tx)
+            all_tx.append(list([m[0], m[1], attr[4:]] for m in tx))
 
     # make sure we got all the msgs
     self.assertTrue(len(all_tx) >= len(test_files)-1)
 
     for tx_msgs in all_tx:
-      for addr, bus in tx_msgs:
+      for addr, bus, test_name in tx_msgs:
         msg = make_msg(bus, addr)
         self.safety.set_controls_allowed(1)
         # TODO: this should be blocked
         if current_test in ["TestNissanSafety", "TestNissanLeafSafety"] and [addr, bus] in self.TX_MSGS:
           continue
-        self.assertFalse(self._tx(msg), f"{addr=} {bus=} got through")
+        self.assertFalse(self._tx(msg), f"transmit of {addr=:#x} {bus=} from {test_name} was allowed")

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -299,7 +299,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
         fwd_bus = self.FWD_BUS_LOOKUP.get(bus, -1)
         if bus in self.FWD_BLACKLISTED_ADDRS and addr in self.FWD_BLACKLISTED_ADDRS[bus]:
           fwd_bus = -1
-        self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg), f"{addr=:#x} from {bus=} to {fwd_bus=} got through")
+        self.assertEqual(fwd_bus, self.safety.safety_fwd_hook(bus, msg), f"{addr=:#x} from {bus=} to {fwd_bus=}")
 
   def test_spam_can_buses(self):
     for addr in range(1, 0x800):

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -24,6 +24,7 @@ MSG_HCA_01 = 0x126      # TX by OP, Heading Control Assist steering torque
 MSG_GRA_ACC_01 = 0x12B  # TX by OP, ACC control buttons for cancel/resume
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
+
 class TestVolkswagenMqbSafety(common.PandaSafetyTest):
   cnt_lh_eps_03 = 0
   cnt_esp_05 = 0
@@ -32,20 +33,16 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
   cnt_hca_01 = 0
   cnt_gra_acc_01 = 0
 
-  # Transmit of GRA_ACC_01 is allowed on bus 0 and 2 to keep
-  # compatibility with gateway and camera integration
-  TX_MSGS = [[MSG_HCA_01, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2], [MSG_LDW_02, 0]]
   STANDSTILL_THRESHOLD = 1
   RELAY_MALFUNCTION_ADDR = MSG_HCA_01
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
-  FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
-  def setUp(self):
-    self.packer = CANPackerPanda("vw_mqb_2010")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
-    self.safety.init_tests()
+  @classmethod
+  def setUpClass(cls):
+    if cls.__name__ == "TestVolkswagenMqbSafety":
+      cls.packer = None
+      cls.safety = None
+      raise unittest.SkipTest
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
@@ -104,15 +101,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
           self.assertFalse(self._tx(self._hca_01_msg(t)))
         else:
           self.assertTrue(self._tx(self._hca_01_msg(t)))
-
-  def test_spam_cancel_safety_check(self):
-    self.safety.set_controls_allowed(0)
-    self.assertTrue(self._tx(self._gra_acc_01_msg(cancel=1)))
-    self.assertFalse(self._tx(self._gra_acc_01_msg(resume=1)))
-    self.assertFalse(self._tx(self._gra_acc_01_msg(_set=1)))
-    # do not block resume if we are engaged already
-    self.safety.set_controls_allowed(1)
-    self.assertTrue(self._tx(self._gra_acc_01_msg(resume=1)))
 
   def test_non_realtime_limit_up(self):
     self.safety.set_torque_driver(0, 0)
@@ -257,6 +245,27 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
       self._rx(self._pcm_status_msg(True))
       self._rx(self._gas_msg(0))
     self.assertTrue(self.safety.get_controls_allowed())
+
+
+class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
+  TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2]]
+  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
+  FWD_BUS_LOOKUP = {0: 2, 2: 0}
+
+  def setUp(self):
+    self.packer = CANPackerPanda("vw_mqb_2010")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
+    self.safety.init_tests()
+
+  def test_spam_cancel_safety_check(self):
+    self.safety.set_controls_allowed(0)
+    self.assertTrue(self._tx(self._gra_acc_01_msg(cancel=1)))
+    self.assertFalse(self._tx(self._gra_acc_01_msg(resume=1)))
+    self.assertFalse(self._tx(self._gra_acc_01_msg(_set=1)))
+    # do not block resume if we are engaged already
+    self.safety.set_controls_allowed(1)
+    self.assertTrue(self._tx(self._gra_acc_01_msg(resume=1)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In preparation for adding openpilot longitudinal control tests, null-effect refactor the MQB safety tests into a common base class and layer stock longitudinal on top. While here, add some helpful instrumentation to the common tests.

The full OP long PR will come right behind this, but there are problems with `test_tx_hook_on_wrong_safety_mode()` yet to solve, and I thought it best to do so in smaller pieces.