### PR TITLE
Subaru SNG

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -275,8 +275,7 @@ static int subaru_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
   if (bus_num == 0) {
     // Global platform
     // 0x40 Throttle
-    // 0x139 Brake_Pedal
-    int block_msg = ((addr == 0x40) || (addr == 0x139));
+    int block_msg = (addr == 0x40);
     if (!block_msg) {
       bus_fwd = 2;  // Camera CAN
     }

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -24,11 +24,11 @@ class TestSubaruSafety(common.PandaSafetyTest):
   cnt_speed = 0
   cnt_brake = 0
 
-  TX_MSGS = [[0x122, 0], [0x221, 0], [0x322, 0]]
+  TX_MSGS = [[0x122, 0], [0x221, 0], [0x322, 0], [0x40, 2]]
   STANDSTILL_THRESHOLD = 20  # 1kph (see dbc file)
   RELAY_MALFUNCTION_ADDR = 0x122
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [0x122, 0x221, 0x322]}
+  FWD_BLACKLISTED_ADDRS = {0: [0x40], 2: [0x122, 0x221, 0x322]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -20,11 +20,11 @@ DRIVER_TORQUE_FACTOR = 10
 class TestSubaruLegacySafety(common.PandaSafetyTest):
   cnt_gas = 0
 
-  TX_MSGS = [[0x161, 0], [0x164, 0]]
+  TX_MSGS = [[0x161, 0], [0x164, 0], [0x140, 2]]
   STANDSTILL_THRESHOLD = 20  # 1kph (see dbc file)
   RELAY_MALFUNCTION_ADDR = 0x164
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [0x161, 0x164]}
+  FWD_BLACKLISTED_ADDRS = {0: [0x140], 2: [0x161, 0x164]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):


### PR DESCRIPTION
This PR is prerequisite for adding Subaru SNG support for both global and preglobal models.

Subaru stock ACC stops behind stopped cars but does not resume automatically. We send Throttle:Throttle_Pedal signal from openpilot to ACC when car in front starts moving to resume from ACC Hold state (mimicking stock ACC resume using gas press behaviour). 

We also tried to resume using ACC resume button signals but that did not work since ACC buttons are directly wired to Eyesight and not accepted as input from CAN.