### PR TITLE
Fix MISRA violations 10.1 and 10.4

### DIFF
--- a/board/can_definitions.h
+++ b/board/can_definitions.h
@@ -25,5 +25,5 @@ typedef struct {
 
 #define CANPACKET_HEAD_SIZE 5U
 
-#define WORD_TO_BYTE_ARRAY(dst8, src32) 0[dst8] = ((src32) & 0xFF); 1[dst8] = (((src32) >> 8) & 0xFF); 2[dst8] = (((src32) >> 16) & 0xFF); 3[dst8] = (((src32) >> 24) & 0xFF)
-#define BYTE_ARRAY_TO_WORD(dst32, src8) ((dst32) = 0[src8] | (1[src8] << 8) | (2[src8] << 16) | (3[src8] << 24))
+#define WORD_TO_BYTE_ARRAY(dst8, src32) 0[dst8] = ((src32) & 0xFFU); 1[dst8] = (((src32) >> 8U) & 0xFFU); 2[dst8] = (((src32) >> 16U) & 0xFFU); 3[dst8] = (((src32) >> 24U) & 0xFFU)
+#define BYTE_ARRAY_TO_WORD(dst32, src8) ((dst32) = 0[src8] | (1[src8] << 8U) | (2[src8] << 16U) | (3[src8] << 24U))

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -112,7 +112,7 @@ void process_can(uint8_t can_number) {
           to_push.returned = 1U;
           to_push.rejected = 0U;
           to_push.extended = (CAN->sTxMailBox[0].TIR >> 2) & 0x1U;
-          to_push.addr = (to_push.extended != 0) ? (CAN->sTxMailBox[0].TIR >> 3) : (CAN->sTxMailBox[0].TIR >> 21);
+          to_push.addr = (to_push.extended != 0U) ? (CAN->sTxMailBox[0].TIR >> 3) : (CAN->sTxMailBox[0].TIR >> 21);
           to_push.data_len_code = CAN->sTxMailBox[0].TDTR & 0xFU;
           to_push.bus = bus_number;
           WORD_TO_BYTE_ARRAY(&to_push.data[0], CAN->sTxMailBox[0].TDLR);
@@ -141,7 +141,7 @@ void process_can(uint8_t can_number) {
       if (can_pop(can_queues[bus_number], &to_send)) {
         can_tx_cnt += 1;
         // only send if we have received a packet
-        CAN->sTxMailBox[0].TIR = ((to_send.extended != 0) ? (to_send.addr << 3) : (to_send.addr << 21)) | (to_send.extended << 2);
+        CAN->sTxMailBox[0].TIR = ((to_send.extended != 0U) ? (to_send.addr << 3) : (to_send.addr << 21)) | (to_send.extended << 2);
         CAN->sTxMailBox[0].TDTR = to_send.data_len_code;
         BYTE_ARRAY_TO_WORD(CAN->sTxMailBox[0].TDLR, &to_send.data[0]);
         BYTE_ARRAY_TO_WORD(CAN->sTxMailBox[0].TDHR, &to_send.data[4]);
@@ -173,7 +173,7 @@ void can_rx(uint8_t can_number) {
     to_push.returned = 0U;
     to_push.rejected = 0U;
     to_push.extended = (CAN->sFIFOMailBox[0].RIR >> 2) & 0x1U;
-    to_push.addr = (to_push.extended != 0) ? (CAN->sFIFOMailBox[0].RIR >> 3) : (CAN->sFIFOMailBox[0].RIR >> 21);
+    to_push.addr = (to_push.extended != 0U) ? (CAN->sFIFOMailBox[0].RIR >> 3) : (CAN->sFIFOMailBox[0].RIR >> 21);
     to_push.data_len_code = CAN->sFIFOMailBox[0].RDTR & 0xFU;
     to_push.bus = bus_number;
     WORD_TO_BYTE_ARRAY(&to_push.data[0], CAN->sFIFOMailBox[0].RDLR);

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -206,18 +206,18 @@ void ignition_can_hook(CANPacket_t *to_push) {
     // since the 0x1F1 signal can briefly go low immediately after ignition
     if ((addr == 0x160) && (len == 5)) {
       // this message isn't all zeros when ignition is on
-      ignition_cadillac = GET_BYTES_04(to_push) != 0;
+      ignition_cadillac = GET_BYTES_04(to_push) != 0U;
     }
     if ((addr == 0x1F1) && (len == 8)) {
       // Bit 5 is ignition "on"
-      bool ignition_gm = ((GET_BYTE(to_push, 0) & 0x20) != 0);
+      bool ignition_gm = ((GET_BYTE(to_push, 0) & 0x20U) != 0U);
       ignition_can = ignition_gm || ignition_cadillac;
     }
 
     // Tesla exception
     if ((addr == 0x348) && (len == 8)) {
       // GTW_status
-      ignition_can = (GET_BYTE(to_push, 0) & 0x1) != 0;
+      ignition_can = (GET_BYTE(to_push, 0) & 0x1U) != 0U;
     }
 
     // Mazda exception

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -60,13 +60,13 @@ void process_can(uint8_t can_number) {
         canfd_fifo *fifo;
         fifo = (canfd_fifo *)(TxFIFOSA + (tx_index * FDCAN_TX_FIFO_EL_SIZE));
 
-        fifo->header[0] = (to_send.extended << 30) | ((to_send.extended != 0) ? (to_send.addr) : (to_send.addr << 18));
+        fifo->header[0] = (to_send.extended << 30) | ((to_send.extended != 0U) ? (to_send.addr) : (to_send.addr << 18));
         fifo->header[1] = (to_send.data_len_code << 16) | (bus_config[can_number].canfd_enabled << 21) | (bus_config[can_number].brs_enabled << 20);
 
         uint8_t data_len_w = (dlc_to_len[to_send.data_len_code] / 4U);
-        data_len_w += ((dlc_to_len[to_send.data_len_code] % 4) > 0) ? 1U : 0U;
+        data_len_w += ((dlc_to_len[to_send.data_len_code] % 4U) > 0U) ? 1U : 0U;
         for (unsigned int i = 0; i < data_len_w; i++) {
-          BYTE_ARRAY_TO_WORD(fifo->data_word[i], &to_send.data[i*4]);
+          BYTE_ARRAY_TO_WORD(fifo->data_word[i], &to_send.data[i*4U]);
         }
 
         CANx->TXBAR = (1UL << tx_index);
@@ -142,14 +142,14 @@ void can_rx(uint8_t can_number) {
       to_push.returned = 0U;
       to_push.rejected = 0U;
       to_push.extended = (fifo->header[0] >> 30) & 0x1U;
-      to_push.addr = ((to_push.extended != 0) ? (fifo->header[0] & 0x1FFFFFFFU) : ((fifo->header[0] >> 18) & 0x7FFU));
+      to_push.addr = ((to_push.extended != 0U) ? (fifo->header[0] & 0x1FFFFFFFU) : ((fifo->header[0] >> 18) & 0x7FFU));
       to_push.bus = bus_number;
       to_push.data_len_code = ((fifo->header[1] >> 16) & 0xFU);
 
       uint8_t data_len_w = (dlc_to_len[to_push.data_len_code] / 4U);
-      data_len_w += ((dlc_to_len[to_push.data_len_code] % 4) > 0) ? 1U : 0U;
+      data_len_w += ((dlc_to_len[to_push.data_len_code] % 4U) > 0U) ? 1U : 0U;
       for (unsigned int i = 0; i < data_len_w; i++) {
-        WORD_TO_BYTE_ARRAY(&to_push.data[i*4], fifo->data_word[i]);
+        WORD_TO_BYTE_ARRAY(&to_push.data[i*4U], fifo->data_word[i]);
       }
 
       // forwarding (panda only)

--- a/board/drivers/gmlan_alt.h
+++ b/board/drivers/gmlan_alt.h
@@ -91,7 +91,7 @@ int get_bit_message(char *out, CANPacket_t *to_bang) {
   int dlc_len = GET_LEN(to_bang);
   len = append_int(pkt, len, 0, 1);    // Start-of-frame
 
-  if (to_bang->extended != 0) {
+  if (to_bang->extended != 0U) {
     // extended identifier
     len = append_int(pkt, len, GET_ADDR(to_bang) >> 18, 11);  // Identifier
     len = append_int(pkt, len, 3, 2);    // SRR+IDE

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -80,7 +80,7 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
 
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == 500) {
-      int cruise_engaged = ((GET_BYTE(to_push, 2) & 0x38) >> 3) == 7;
+      int cruise_engaged = ((GET_BYTE(to_push, 2) & 0x38U) >> 3) == 7;
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
       }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -19,7 +19,7 @@ AddrCheckStruct chrysler_addr_checks[] = {
 addr_checks chrysler_rx_checks = {chrysler_addr_checks, CHRYSLER_ADDR_CHECK_LEN};
 
 static uint8_t chrysler_get_checksum(CANPacket_t *to_push) {
-  int checksum_byte = GET_LEN(to_push) - 1;
+  int checksum_byte = GET_LEN(to_push) - 1U;
   return (uint8_t)(GET_BYTE(to_push, checksum_byte));
 }
 
@@ -67,7 +67,7 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
                                  chrysler_get_checksum, chrysler_compute_checksum,
                                  chrysler_get_counter);
 
-  if (valid && (GET_BUS(to_push) == 0)) {
+  if (valid && (GET_BUS(to_push) == 0U)) {
     int addr = GET_ADDR(to_push);
 
     // Measured eps torque
@@ -80,7 +80,7 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
 
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == 500) {
-      int cruise_engaged = ((GET_BYTE(to_push, 2) & 0x38U) >> 3) == 7;
+      int cruise_engaged = ((GET_BYTE(to_push, 2) & 0x38U) >> 3) == 7U;
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
       }
@@ -100,12 +100,12 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
 
     // exit controls on rising edge of gas press
     if (addr == 308) {
-      gas_pressed = ((GET_BYTE(to_push, 5) & 0x7F) != 0) && ((int)vehicle_speed > CHRYSLER_GAS_THRSLD);
+      gas_pressed = ((GET_BYTE(to_push, 5) & 0x7FU) != 0U) && ((int)vehicle_speed > CHRYSLER_GAS_THRSLD);
     }
 
     // exit controls on rising edge of brake press
     if (addr == 320) {
-      brake_pressed = (GET_BYTE(to_push, 0) & 0x7) == 5;
+      brake_pressed = (GET_BYTE(to_push, 0) & 0x7U) == 5U;
       if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
         controls_allowed = 0;
       }
@@ -174,7 +174,7 @@ static int chrysler_tx_hook(CANPacket_t *to_send) {
 
   // FORCE CANCEL: only the cancel button press is allowed
   if (addr == 571) {
-    if ((GET_BYTE(to_send, 0) != 1) || ((GET_BYTE(to_send, 1) & 1) == 1)) {
+    if ((GET_BYTE(to_send, 0) != 1U) || ((GET_BYTE(to_send, 1) & 1U) == 1U)) {
       tx = 0;
     }
   }

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -24,8 +24,8 @@ static int ford_rx_hook(CANPacket_t *to_push) {
 
   // state machine to enter and exit controls
   if (addr == 0x83) {
-    bool cancel = GET_BYTE(to_push, 1) & 0x1;
-    bool set_or_resume = GET_BYTE(to_push, 3) & 0x30;
+    bool cancel = GET_BYTE(to_push, 1) & 0x1U;
+    bool set_or_resume = GET_BYTE(to_push, 3) & 0x30U;
     if (cancel) {
       controls_allowed = 0;
     }
@@ -37,7 +37,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
   // exit controls on rising edge of brake press or on brake press when
   // speed > 0
   if (addr == 0x165) {
-    brake_pressed = GET_BYTE(to_push, 0) & 0x20;
+    brake_pressed = GET_BYTE(to_push, 0) & 0x20U;
     if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
       controls_allowed = 0;
     }
@@ -46,7 +46,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
 
   // exit controls on rising edge of gas press
   if (addr == 0x204) {
-    gas_pressed = ((GET_BYTE(to_push, 0) & 0x03) | GET_BYTE(to_push, 1)) != 0;
+    gas_pressed = ((GET_BYTE(to_push, 0) & 0x03U) | GET_BYTE(to_push, 1)) != 0U;
     if (!unsafe_allow_gas && gas_pressed && !gas_pressed_prev) {
       controls_allowed = 0;
     }
@@ -83,7 +83,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
   if (addr == 0x3CA) {
     if (!current_controls_allowed) {
       // bits 7-4 need to be 0xF to disallow lkas commands
-      if ((GET_BYTE(to_send, 0) & 0xF0) != 0xF0) {
+      if ((GET_BYTE(to_send, 0) & 0xF0U) != 0xF0U) {
         tx = 0;
       }
     }
@@ -92,7 +92,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
   // FORCE CANCEL: safety check only relevant when spamming the cancel button
   // ensuring that set and resume aren't sent
   if (addr == 0x83) {
-    if ((GET_BYTE(to_send, 3) & 0x30) != 0) {
+    if ((GET_BYTE(to_send, 3) & 0x30U) != 0U) {
       tx = 0;
     }
   }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -42,7 +42,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
     int addr = GET_ADDR(to_push);
 
     if (addr == 388) {
-      int torque_driver_new = ((GET_BYTE(to_push, 6) & 0x7) << 8) | GET_BYTE(to_push, 7);
+      int torque_driver_new = ((GET_BYTE(to_push, 6) & 0x7U) << 8) | GET_BYTE(to_push, 7);
       torque_driver_new = to_signed(torque_driver_new, 11);
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
@@ -56,7 +56,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 
     // ACC steering wheel buttons
     if (addr == 481) {
-      int button = (GET_BYTE(to_push, 5) & 0x70) >> 4;
+      int button = (GET_BYTE(to_push, 5) & 0x70U) >> 4;
       switch (button) {
         case 2:  // resume
         case 3:  // set

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -38,7 +38,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 
   bool valid = addr_safety_check(to_push, &gm_rx_checks, NULL, NULL, NULL);
 
-  if (valid && (GET_BUS(to_push) == 0)) {
+  if (valid && (GET_BUS(to_push) == 0U)) {
     int addr = GET_ADDR(to_push);
 
     if (addr == 388) {
@@ -74,16 +74,16 @@ static int gm_rx_hook(CANPacket_t *to_push) {
     if (addr == 241) {
       // Brake pedal's potentiometer returns near-zero reading
       // even when pedal is not pressed
-      brake_pressed = GET_BYTE(to_push, 1) >= 10;
+      brake_pressed = GET_BYTE(to_push, 1) >= 10U;
     }
 
     if (addr == 417) {
-      gas_pressed = GET_BYTE(to_push, 6) != 0;
+      gas_pressed = GET_BYTE(to_push, 6) != 0U;
     }
 
     // exit controls on regen paddle
     if (addr == 189) {
-      bool regen = GET_BYTE(to_push, 0) & 0x20;
+      bool regen = GET_BYTE(to_push, 0) & 0x20U;
       if (regen) {
         controls_allowed = 0;
       }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -109,7 +109,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // check ACC main state
     // 0x326 for all Bosch and some Nidec, 0x1A6 for some Nidec
     if ((addr == 0x326) || (addr == 0x1A6)) {
-      acc_main_on = GET_BIT(to_push, (addr == 0x326) ? 28 : 47);
+      acc_main_on = GET_BIT(to_push, ((addr == 0x326) ? 28 : 47));
       if (!acc_main_on) {
         controls_allowed = 0;
       }
@@ -119,7 +119,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // 0x1A6 for the ILX, 0x296 for the Civic Touring
     if ((addr == 0x1A6) || (addr == 0x296)) {
       // check for button presses
-      int button = (GET_BYTE(to_push, 0) & 0xE0) >> 5;
+      int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
       switch (button) {
         case 1:  // main
         case 2:  // cancel

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -17,7 +17,7 @@ const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 
 // assuming that 2*(gain_dbc1*gas1) == (gain_dbc2*gas2)
 // In this safety: ((gas1 + (gas2/2))/2) > THRESHOLD
 const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 344;
-#define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + ((GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2 ) / 2) // avg between 2 tracks
+#define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + ((GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2U ) / 2U) // avg between 2 tracks
 const int HONDA_BOSCH_NO_GAS_VALUE = -30000; // value sent when not requesting gas
 const int HONDA_BOSCH_GAS_MAX = 2000;
 const int HONDA_BOSCH_ACCEL_MIN = -350; // max braking == -3.5m/s2
@@ -64,7 +64,7 @@ addr_checks honda_rx_checks = {honda_nidec_addr_checks, HONDA_NIDEC_ADDR_CHECKS_
 
 
 static uint8_t honda_get_checksum(CANPacket_t *to_push) {
-  int checksum_byte = GET_LEN(to_push) - 1;
+  int checksum_byte = GET_LEN(to_push) - 1U;
   return (uint8_t)(GET_BYTE(to_push, checksum_byte)) & 0xFU;
 }
 
@@ -86,7 +86,7 @@ static uint8_t honda_compute_checksum(CANPacket_t *to_push) {
 }
 
 static uint8_t honda_get_counter(CANPacket_t *to_push) {
-  int counter_byte = GET_LEN(to_push) - 1;
+  int counter_byte = GET_LEN(to_push) - 1U;
   return ((uint8_t)(GET_BYTE(to_push, counter_byte)) >> 4U) & 0x3U;
 }
 
@@ -109,7 +109,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // check ACC main state
     // 0x326 for all Bosch and some Nidec, 0x1A6 for some Nidec
     if ((addr == 0x326) || (addr == 0x1A6)) {
-      acc_main_on = GET_BIT(to_push, ((addr == 0x326) ? 28 : 47));
+      acc_main_on = GET_BIT(to_push, ((addr == 0x326) ? 28U : 47U));
       if (!acc_main_on) {
         controls_allowed = 0;
       }
@@ -144,7 +144,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // accord, crv: 0x1BE bit 4
     bool is_user_brake_msg = honda_alt_brake_msg ? ((addr) == 0x1BE) : ((addr) == 0x17C);
     if (is_user_brake_msg) {
-      brake_pressed = honda_alt_brake_msg ? (GET_BYTE((to_push), 0) & 0x10) : (GET_BYTE((to_push), 6) & 0x20);
+      brake_pressed = honda_alt_brake_msg ? (GET_BYTE((to_push), 0) & 0x10U) : (GET_BYTE((to_push), 6) & 0x20U);
     }
 
     // length check because bosch hardware also uses this id (0x201 w/ len = 8)
@@ -157,15 +157,15 @@ static int honda_rx_hook(CANPacket_t *to_push) {
 
     if (!gas_interceptor_detected) {
       if (addr == 0x17C) {
-        gas_pressed = GET_BYTE(to_push, 0) != 0;
+        gas_pressed = GET_BYTE(to_push, 0) != 0U;
       }
     }
 
     // disable stock Honda AEB in unsafe mode
     if ( !(unsafe_mode & UNSAFE_DISABLE_STOCK_AEB) ) {
       if ((bus == 2) && (addr == 0x1FA)) {
-        bool honda_stock_aeb = GET_BYTE(to_push, 3) & 0x20;
-        int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) + ((GET_BYTE(to_push, 1) >> 6) & 0x3);
+        bool honda_stock_aeb = GET_BYTE(to_push, 3) & 0x20U;
+        int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) + ((GET_BYTE(to_push, 1) >> 6) & 0x3U);
 
         // Forward AEB when stock braking is higher than openpilot braking
         // only stop forwarding when AEB event is over
@@ -235,7 +235,7 @@ static int honda_tx_hook(CANPacket_t *to_send) {
 
   // BRAKE: safety check (nidec)
   if ((addr == 0x1FA) && (bus == bus_pt)) {
-    honda_brake = (GET_BYTE(to_send, 0) << 2) + ((GET_BYTE(to_send, 1) >> 6) & 0x3);
+    honda_brake = (GET_BYTE(to_send, 0) << 2) + ((GET_BYTE(to_send, 1) >> 6) & 0x3U);
     if (!current_controls_allowed) {
       if (honda_brake != 0) {
         tx = 0;
@@ -251,7 +251,7 @@ static int honda_tx_hook(CANPacket_t *to_send) {
 
   // BRAKE/GAS: safety check (bosch)
   if ((addr == 0x1DF) && (bus == bus_pt)) {
-    int accel = (GET_BYTE(to_send, 3) << 3) | ((GET_BYTE(to_send, 4) >> 5) & 0x7);
+    int accel = (GET_BYTE(to_send, 3) << 3) | ((GET_BYTE(to_send, 4) >> 5) & 0x7U);
     accel = to_signed(accel, 11);
     if (!current_controls_allowed) {
       if (accel != 0) {
@@ -286,7 +286,7 @@ static int honda_tx_hook(CANPacket_t *to_send) {
 
     // Bosch supplemental control check
   if (addr == 0xE5) {
-    if ((GET_BYTES_04(to_send) != 0x10800004) || ((GET_BYTES_48(to_send) & 0x00FFFFFF) != 0x0)) {
+    if ((GET_BYTES_04(to_send) != 0x10800004U) || ((GET_BYTES_48(to_send) & 0x00FFFFFFU) != 0x0U)) {
       tx = 0;
     }
   }
@@ -304,14 +304,14 @@ static int honda_tx_hook(CANPacket_t *to_send) {
   // ensuring that only the cancel button press is sent (VAL 2) when controls are off.
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == 0x296) && !current_controls_allowed && (bus == bus_pt)) {
-    if (((GET_BYTE(to_send, 0) >> 5) & 0x7) != 2) {
+    if (((GET_BYTE(to_send, 0) >> 5) & 0x7U) != 2U) {
       tx = 0;
     }
   }
 
   // Only tester present ("\x02\x3E\x80\x00\x00\x00\x00\x00") allowed on diagnostics address
   if (addr == 0x18DAB0F1) {
-    if ((GET_BYTES_04(to_send) != 0x00803E02) || (GET_BYTES_48(to_send) != 0x0)) {
+    if ((GET_BYTES_04(to_send) != 0x00803E02U) || (GET_BYTES_48(to_send) != 0x0U)) {
       tx = 0;
     }
   }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -191,7 +191,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
     // read gas pressed signal
     if ((addr == 881) && hyundai_ev_gas_signal) {
-      gas_pressed = (((GET_BYTE(to_push, 4) & 0x7F) << 1) | GET_BYTE(to_push, 3) >> 7) != 0;
+      gas_pressed = (((GET_BYTE(to_push, 4) & 0x7FU) << 1) | GET_BYTE(to_push, 3) >> 7) != 0;
     } else if ((addr == 881) && hyundai_hybrid_gas_signal) {
       gas_pressed = GET_BYTE(to_push, 7) != 0;
     } else if (addr == 608) {  // ICE
@@ -247,7 +247,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
 
   // ACCEL: safety check
   if (addr == 1057) {
-    int desired_accel_raw = (((GET_BYTE(to_send, 4) & 0x7) << 8) | GET_BYTE(to_send, 3)) - 1023;
+    int desired_accel_raw = (((GET_BYTE(to_send, 4) & 0x7U) << 8) | GET_BYTE(to_send, 3)) - 1023;
     int desired_accel_val = ((GET_BYTE(to_send, 5) << 3) | (GET_BYTE(to_send, 4) >> 5)) - 1023;
 
     int aeb_decel_cmd = GET_BYTE(to_send, 2);

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -74,15 +74,15 @@ static uint8_t hyundai_get_counter(CANPacket_t *to_push) {
 
   uint8_t cnt;
   if (addr == 608) {
-    cnt = (GET_BYTE(to_push, 7) >> 4) & 0x3;
+    cnt = (GET_BYTE(to_push, 7) >> 4) & 0x3U;
   } else if (addr == 902) {
     cnt = ((GET_BYTE(to_push, 3) >> 6) << 2) | (GET_BYTE(to_push, 1) >> 6);
   } else if (addr == 916) {
-    cnt = (GET_BYTE(to_push, 1) >> 5) & 0x7;
+    cnt = (GET_BYTE(to_push, 1) >> 5) & 0x7U;
   } else if (addr == 1057) {
-    cnt = GET_BYTE(to_push, 7) & 0xF;
+    cnt = GET_BYTE(to_push, 7) & 0xFU;
   } else if (addr == 1265) {
-    cnt = (GET_BYTE(to_push, 3) >> 4) & 0xF;
+    cnt = (GET_BYTE(to_push, 3) >> 4) & 0xFU;
   } else {
     cnt = 0;
   }
@@ -94,11 +94,11 @@ static uint8_t hyundai_get_checksum(CANPacket_t *to_push) {
 
   uint8_t chksum;
   if (addr == 608) {
-    chksum = GET_BYTE(to_push, 7) & 0xF;
+    chksum = GET_BYTE(to_push, 7) & 0xFU;
   } else if (addr == 902) {
     chksum = ((GET_BYTE(to_push, 7) >> 6) << 2) | (GET_BYTE(to_push, 5) >> 6);
   } else if (addr == 916) {
-    chksum = GET_BYTE(to_push, 6) & 0xF;
+    chksum = GET_BYTE(to_push, 6) & 0xFU;
   } else if (addr == 1057) {
     chksum = GET_BYTE(to_push, 7) >> 4;
   } else {
@@ -149,11 +149,11 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
                                  hyundai_get_checksum, hyundai_compute_checksum,
                                  hyundai_get_counter);
 
-  if (valid && (GET_BUS(to_push) == 0)) {
+  if (valid && (GET_BUS(to_push) == 0U)) {
     int addr = GET_ADDR(to_push);
 
     if (addr == 593) {
-      int torque_driver_new = ((GET_BYTES_04(to_push) & 0x7ff) * 0.79) - 808; // scale down new driver torque signal to match previous one
+      int torque_driver_new = ((GET_BYTES_04(to_push) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }
@@ -161,7 +161,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
     if (hyundai_longitudinal) {
       // ACC steering wheel buttons
       if (addr == 1265) {
-        int button = GET_BYTE(to_push, 0) & 0x7;
+        int button = GET_BYTE(to_push, 0) & 0x7U;
         switch (button) {
           case 1:  // resume
           case 2:  // set
@@ -178,7 +178,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
       // enter controls on rising edge of ACC, exit controls on ACC off
       if (addr == 1057) {
         // 2 bits: 13-14
-        int cruise_engaged = (GET_BYTES_04(to_push) >> 13) & 0x3;
+        int cruise_engaged = (GET_BYTES_04(to_push) >> 13) & 0x3U;
         if (cruise_engaged && !cruise_engaged_prev) {
           controls_allowed = 1;
         }
@@ -191,24 +191,23 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
     // read gas pressed signal
     if ((addr == 881) && hyundai_ev_gas_signal) {
-      gas_pressed = (((GET_BYTE(to_push, 4) & 0x7FU) << 1) | GET_BYTE(to_push, 3) >> 7) != 0;
+      gas_pressed = (((GET_BYTE(to_push, 4) & 0x7FU) << 1) | GET_BYTE(to_push, 3) >> 7) != 0U;
     } else if ((addr == 881) && hyundai_hybrid_gas_signal) {
-      gas_pressed = GET_BYTE(to_push, 7) != 0;
+      gas_pressed = GET_BYTE(to_push, 7) != 0U;
     } else if (addr == 608) {  // ICE
-      gas_pressed = (GET_BYTE(to_push, 7) >> 6) != 0;
+      gas_pressed = (GET_BYTE(to_push, 7) >> 6) != 0U;
     } else {
     }
 
     // sample wheel speed, averaging opposite corners
     if (addr == 902) {
-      int hyundai_speed = GET_BYTES_04(to_push) & 0x3FFF;  // FL
-      hyundai_speed += (GET_BYTES_48(to_push) >> 16) & 0x3FFF;  // RL
+      int hyundai_speed = (GET_BYTES_04(to_push) & 0x3FFFU) + ((GET_BYTES_48(to_push) >> 16) & 0x3FFFU);  // FL + RR
       hyundai_speed /= 2;
       vehicle_moving = hyundai_speed > HYUNDAI_STANDSTILL_THRSLD;
     }
 
     if (addr == 916) {
-      brake_pressed = (GET_BYTE(to_push, 6) >> 7) != 0;
+      brake_pressed = (GET_BYTE(to_push, 6) >> 7) != 0U;
     }
 
     bool stock_ecu_detected = (addr == 832);
@@ -237,8 +236,8 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
   // FCA11: Block any potential actuation
   if (addr == 909) {
     int CR_VSM_DecCmd = GET_BYTE(to_send, 1);
-    int FCA_CmdAct = (GET_BYTE(to_send, 2) >> 5) & 1;
-    int CF_VSM_DecCmdAct = (GET_BYTE(to_send, 3) >> 7) & 1;
+    int FCA_CmdAct = (GET_BYTE(to_send, 2) >> 5) & 1U;
+    int CF_VSM_DecCmdAct = (GET_BYTE(to_send, 3) >> 7) & 1U;
 
     if ((CR_VSM_DecCmd != 0) || (FCA_CmdAct != 0) || (CF_VSM_DecCmdAct != 0)) {
       tx = 0;
@@ -247,11 +246,11 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
 
   // ACCEL: safety check
   if (addr == 1057) {
-    int desired_accel_raw = (((GET_BYTE(to_send, 4) & 0x7U) << 8) | GET_BYTE(to_send, 3)) - 1023;
-    int desired_accel_val = ((GET_BYTE(to_send, 5) << 3) | (GET_BYTE(to_send, 4) >> 5)) - 1023;
+    int desired_accel_raw = (((GET_BYTE(to_send, 4) & 0x7U) << 8) | GET_BYTE(to_send, 3)) - 1023U;
+    int desired_accel_val = ((GET_BYTE(to_send, 5) << 3) | (GET_BYTE(to_send, 4) >> 5)) - 1023U;
 
     int aeb_decel_cmd = GET_BYTE(to_send, 2);
-    int aeb_req = (GET_BYTE(to_send, 6) >> 6) & 1;
+    int aeb_req = (GET_BYTE(to_send, 6) >> 6) & 1U;
 
     bool violation = 0;
 
@@ -273,7 +272,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
 
   // LKA STEER: safety check
   if (addr == 832) {
-    int desired_torque = ((GET_BYTES_04(to_send) >> 16) & 0x7ff) - 1024;
+    int desired_torque = ((GET_BYTES_04(to_send) >> 16) & 0x7ffU) - 1024U;
     uint32_t ts = microsecond_timer_get();
     bool violation = 0;
 
@@ -320,7 +319,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
 
   // UDS: Only tester present ("\x02\x3E\x80\x00\x00\x00\x00\x00") allowed on diagnostics address
   if (addr == 2000) {
-    if ((GET_BYTES_04(to_send) != 0x00803E02) || (GET_BYTES_48(to_send) != 0x0)) {
+    if ((GET_BYTES_04(to_send) != 0x00803E02U) || (GET_BYTES_48(to_send) != 0x0U)) {
       tx = 0;
     }
   }
@@ -329,7 +328,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
   // ensuring that only the cancel button press is sent (VAL 4) when controls are off.
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == 1265) && !controls_allowed) {
-    if ((GET_BYTES_04(to_send) & 0x7) != 4) {
+    if ((GET_BYTES_04(to_send) & 0x7U) != 4U) {
       tx = 0;
     }
   }

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -94,7 +94,7 @@ static int mazda_tx_hook(CANPacket_t *to_send) {
 
     // steer cmd checks
     if (addr == MAZDA_LKAS) {
-      int desired_torque = (((GET_BYTE(to_send, 0) & 0x0f) << 8) | GET_BYTE(to_send, 1)) - MAZDA_MAX_STEER;
+      int desired_torque = (((GET_BYTE(to_send, 0) & 0x0FU) << 8) | GET_BYTE(to_send, 1)) - MAZDA_MAX_STEER;
       bool violation = 0;
       uint32_t ts = microsecond_timer_get();
 

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -9,10 +9,10 @@
 
 // CAN bus numbers
 #define MAZDA_MAIN 0
-#define MAZDA_AUX 1
-#define MAZDA_CAM 2
+#define MAZDA_AUX  1
+#define MAZDA_CAM  2
 
-#define MAZDA_MAX_STEER 2048
+#define MAZDA_MAX_STEER 2048U
 
 // max delta torque allowed for real time checks
 #define MAZDA_MAX_RT_DELTA 940
@@ -39,7 +39,7 @@ addr_checks mazda_rx_checks = {mazda_addr_checks, MAZDA_ADDR_CHECKS_LEN};
 // track msgs coming from OP so that we know what CAM msgs to drop and what to forward
 static int mazda_rx_hook(CANPacket_t *to_push) {
   bool valid = addr_safety_check(to_push, &mazda_rx_checks, NULL, NULL, NULL);
-  if (valid && (GET_BUS(to_push) == MAZDA_MAIN)) {
+  if (valid && ((int)GET_BUS(to_push) == MAZDA_MAIN)) {
     int addr = GET_ADDR(to_push);
 
     if (addr == MAZDA_ENGINE_DATA) {
@@ -49,14 +49,14 @@ static int mazda_rx_hook(CANPacket_t *to_push) {
     }
 
     if (addr == MAZDA_STEER_TORQUE) {
-      int torque_driver_new = GET_BYTE(to_push, 0) - 127;
+      int torque_driver_new = GET_BYTE(to_push, 0) - 127U;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }
 
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == MAZDA_CRZ_CTRL) {
-      bool cruise_engaged = GET_BYTE(to_push, 0) & 8;
+      bool cruise_engaged = GET_BYTE(to_push, 0) & 0x8U;
       if (cruise_engaged) {
         if (!cruise_engaged_prev) {
           controls_allowed = 1;
@@ -68,11 +68,11 @@ static int mazda_rx_hook(CANPacket_t *to_push) {
     }
 
     if (addr == MAZDA_ENGINE_DATA) {
-      gas_pressed = (GET_BYTE(to_push, 4) || (GET_BYTE(to_push, 5) & 0xF0));
+      gas_pressed = (GET_BYTE(to_push, 4) || (GET_BYTE(to_push, 5) & 0xF0U));
     }
 
     if (addr == MAZDA_PEDALS) {
-      brake_pressed = (GET_BYTE(to_push, 0) & 0x10);
+      brake_pressed = (GET_BYTE(to_push, 0) & 0x10U);
     }
 
     generic_rx_checks((addr == MAZDA_LKAS));

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -53,7 +53,7 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
       if (addr == 0x2) {
         // Current steering angle
         // Factor -0.1, little endian
-        int angle_meas_new = (GET_BYTES_04(to_push) & 0xFFFF);
+        int angle_meas_new = (GET_BYTES_04(to_push) & 0xFFFFU);
         // Need to multiply by 10 here as LKAS and Steering wheel are different base unit
         angle_meas_new = to_signed(angle_meas_new, 16) * 10;
 
@@ -71,9 +71,9 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
       // X-Trail 0x15c, Leaf 0x239
       if ((addr == 0x15c) || (addr == 0x239)) {
         if (addr == 0x15c){
-          gas_pressed = ((GET_BYTE(to_push, 5) << 2) | ((GET_BYTE(to_push, 6) >> 6) & 0x3)) > 3;
+          gas_pressed = ((GET_BYTE(to_push, 5) << 2) | ((GET_BYTE(to_push, 6) >> 6) & 0x3U)) > 3U;
         } else {
-          gas_pressed = GET_BYTE(to_push, 0) > 3;
+          gas_pressed = GET_BYTE(to_push, 0) > 3U;
         }
       }
     }
@@ -81,15 +81,15 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
     // X-trail 0x454, Leaf  0x239
     if ((addr == 0x454) || (addr == 0x239)) {
       if (addr == 0x454){
-        brake_pressed = (GET_BYTE(to_push, 2) & 0x80) != 0;
+        brake_pressed = (GET_BYTE(to_push, 2) & 0x80U) != 0U;
       } else {
-        brake_pressed = ((GET_BYTE(to_push, 4) >> 5) & 1) != 0;
+        brake_pressed = ((GET_BYTE(to_push, 4) >> 5) & 1U) != 0U;
       }
     }
 
     // Handle cruise enabled
     if ((addr == 0x30f) && (((bus == 2) && (!nissan_alt_eps)) || ((bus == 1) && (nissan_alt_eps)))) {
-      bool cruise_engaged = (GET_BYTE(to_push, 0) >> 3) & 1;
+      bool cruise_engaged = (GET_BYTE(to_push, 0) >> 3) & 1U;
 
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
@@ -117,8 +117,8 @@ static int nissan_tx_hook(CANPacket_t *to_send) {
 
   // steer cmd checks
   if (addr == 0x169) {
-    int desired_angle = ((GET_BYTE(to_send, 0) << 10) | (GET_BYTE(to_send, 1) << 2) | ((GET_BYTE(to_send, 2) >> 6) & 0x3));
-    bool lka_active = (GET_BYTE(to_send, 6) >> 4) & 1;
+    int desired_angle = ((GET_BYTE(to_send, 0) << 10) | (GET_BYTE(to_send, 1) << 2) | ((GET_BYTE(to_send, 2) >> 6) & 0x3U));
+    bool lka_active = (GET_BYTE(to_send, 6) >> 4) & 1U;
 
     // offeset 1310 * NISSAN_DEG_TO_CAN
     desired_angle =  desired_angle - 131000;
@@ -154,7 +154,7 @@ static int nissan_tx_hook(CANPacket_t *to_send) {
   // acc button check, only allow cancel button to be sent
   if (addr == 0x20b) {
     // Violation of any button other than cancel is pressed
-    violation |= ((GET_BYTE(to_send, 1) & 0x3d) > 0);
+    violation |= ((GET_BYTE(to_send, 1) & 0x3dU) > 0U);
   }
 
   if (violation) {

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -62,7 +62,7 @@ static int tesla_rx_hook(CANPacket_t *to_push) {
         if(addr == 0x370) {
           // Steering angle: (0.1 * val) - 819.2 in deg.
           // Store it 1/10 deg to match steering request
-          int angle_meas_new = (((GET_BYTE(to_push, 4) & 0x3FU) << 8) | GET_BYTE(to_push, 5)) - 8192;
+          int angle_meas_new = (((GET_BYTE(to_push, 4) & 0x3FU) << 8) | GET_BYTE(to_push, 5)) - 8192U;
           update_sample(&angle_meas, angle_meas_new);
         }
       }
@@ -75,12 +75,12 @@ static int tesla_rx_hook(CANPacket_t *to_push) {
 
       if(addr == (tesla_powertrain ? 0x106 : 0x108)) {
         // Gas pressed
-        gas_pressed = (GET_BYTE(to_push, 6) != 0);
+        gas_pressed = (GET_BYTE(to_push, 6) != 0U);
       }
 
       if(addr == (tesla_powertrain ? 0x1f8 : 0x20a)) {
         // Brake pressed
-        brake_pressed = (((GET_BYTE(to_push, 0) & 0x0CU) >> 2) != 1);
+        brake_pressed = (((GET_BYTE(to_push, 0) & 0x0CU) >> 2) != 1U);
       }
 
       if(addr == (tesla_powertrain ? 0x256 : 0x368)) {

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -62,14 +62,14 @@ static int tesla_rx_hook(CANPacket_t *to_push) {
         if(addr == 0x370) {
           // Steering angle: (0.1 * val) - 819.2 in deg.
           // Store it 1/10 deg to match steering request
-          int angle_meas_new = (((GET_BYTE(to_push, 4) & 0x3F) << 8) | GET_BYTE(to_push, 5)) - 8192;
+          int angle_meas_new = (((GET_BYTE(to_push, 4) & 0x3FU) << 8) | GET_BYTE(to_push, 5)) - 8192;
           update_sample(&angle_meas, angle_meas_new);
         }
       }
 
       if(addr == (tesla_powertrain ? 0x116 : 0x118)) {
         // Vehicle speed: ((0.05 * val) - 25) * MPH_TO_MPS
-        vehicle_speed = (((((GET_BYTE(to_push, 3) & 0x0F) << 8) | (GET_BYTE(to_push, 2))) * 0.05) - 25) * 0.447;
+        vehicle_speed = (((((GET_BYTE(to_push, 3) & 0x0FU) << 8) | (GET_BYTE(to_push, 2))) * 0.05) - 25) * 0.447;
         vehicle_moving = ABS(vehicle_speed) > 0.1;
       }
 
@@ -80,7 +80,7 @@ static int tesla_rx_hook(CANPacket_t *to_push) {
 
       if(addr == (tesla_powertrain ? 0x1f8 : 0x20a)) {
         // Brake pressed
-        brake_pressed = (((GET_BYTE(to_push, 0) & 0x0C) >> 2) != 1);
+        brake_pressed = (((GET_BYTE(to_push, 0) & 0x0CU) >> 2) != 1);
       }
 
       if(addr == (tesla_powertrain ? 0x256 : 0x368)) {
@@ -129,7 +129,7 @@ static int tesla_tx_hook(CANPacket_t *to_send) {
   if(!tesla_powertrain && (addr == 0x488)) {
     // Steering control: (0.1 * val) - 1638.35 in deg.
     // We use 1/10 deg as a unit here
-    int raw_angle_can = (((GET_BYTE(to_send, 0) & 0x7F) << 8) | GET_BYTE(to_send, 1));
+    int raw_angle_can = (((GET_BYTE(to_send, 0) & 0x7FU) << 8) | GET_BYTE(to_send, 1));
     int desired_angle = raw_angle_can - 16384;
     int steer_control_type = GET_BYTE(to_send, 2) >> 6;
     bool steer_control_enabled = (steer_control_type != 0) &&  // NONE
@@ -164,7 +164,7 @@ static int tesla_tx_hook(CANPacket_t *to_send) {
 
   if(!tesla_powertrain && (addr == 0x45)) {
     // No button other than cancel can be sent by us
-    int control_lever_status = (GET_BYTE(to_send, 0) & 0x3F);
+    int control_lever_status = (GET_BYTE(to_send, 0) & 0x3FU);
     if((control_lever_status != 0) && (control_lever_status != 1)) {
       violation = true;
     }
@@ -174,14 +174,14 @@ static int tesla_tx_hook(CANPacket_t *to_send) {
     // DAS_control: longitudinal control message
     if (tesla_longitudinal) {
       // No AEB events may be sent by openpilot
-      int aeb_event = GET_BYTE(to_send, 2) & 0x03;
+      int aeb_event = GET_BYTE(to_send, 2) & 0x03U;
       if (aeb_event != 0) {
         violation = true;
       }
 
       // Don't allow any acceleration limits above the safety limits
-      int raw_accel_max = ((GET_BYTE(to_send, 6) & 0x1F) << 4) | (GET_BYTE(to_send, 5) >> 4);
-      int raw_accel_min = ((GET_BYTE(to_send, 5) & 0x0F) << 5) | (GET_BYTE(to_send, 4) >> 3);
+      int raw_accel_max = ((GET_BYTE(to_send, 6) & 0x1FU) << 4) | (GET_BYTE(to_send, 5) >> 4);
+      int raw_accel_min = ((GET_BYTE(to_send, 5) & 0x0FU) << 5) | (GET_BYTE(to_send, 4) >> 3);
       float accel_max = (0.04 * raw_accel_max) - 15;
       float accel_min = (0.04 * raw_accel_min) - 15;
 

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -163,8 +163,8 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
     // Signal: LH_EPS_03.EPS_Lenkmoment (absolute torque)
     // Signal: LH_EPS_03.EPS_VZ_Lenkmoment (direction)
     if (addr == MSG_LH_EPS_03) {
-      int torque_driver_new = GET_BYTE(to_push, 5) | ((GET_BYTE(to_push, 6) & 0x1F) << 8);
-      int sign = (GET_BYTE(to_push, 6) & 0x80) >> 7;
+      int torque_driver_new = GET_BYTE(to_push, 5) | ((GET_BYTE(to_push, 6) & 0x1FU) << 8);
+      int sign = (GET_BYTE(to_push, 6) & 0x80U) >> 7;
       if (sign == 1) {
         torque_driver_new *= -1;
       }
@@ -174,7 +174,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
     // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
     // Signal: TSK_06.TSK_Status
     if (addr == MSG_TSK_06) {
-      int acc_status = (GET_BYTE(to_push, 3) & 0x7);
+      int acc_status = (GET_BYTE(to_push, 3) & 0x7U);
       int cruise_engaged = ((acc_status == 3) || (acc_status == 4) || (acc_status == 5)) ? 1 : 0;
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
@@ -187,12 +187,12 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
 
     // Signal: Motor_20.MO_Fahrpedalrohwert_01
     if (addr == MSG_MOTOR_20) {
-      gas_pressed = ((GET_BYTES_04(to_push) >> 12) & 0xFF) != 0;
+      gas_pressed = ((GET_BYTES_04(to_push) >> 12) & 0xFFU) != 0;
     }
 
     // Signal: ESP_05.ESP_Fahrer_bremst
     if (addr == MSG_ESP_05) {
-      brake_pressed = (GET_BYTE(to_push, 3) & 0x4) >> 2;
+      brake_pressed = (GET_BYTE(to_push, 3) & 0x4U) >> 2;
     }
 
     generic_rx_checks((addr == MSG_HCA_01));
@@ -211,7 +211,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
     // Update in-motion state from speed value.
     // Signal: Bremse_1.Geschwindigkeit_neu__Bremse_1_
     if (addr == MSG_BREMSE_1) {
-      int speed = ((GET_BYTE(to_push, 2) & 0xFE) >> 1) | (GET_BYTE(to_push, 3) << 7);
+      int speed = ((GET_BYTE(to_push, 2) & 0xFEU) >> 1) | (GET_BYTE(to_push, 3) << 7);
       // DBC speed scale 0.01: 0.3m/s = 108.
       vehicle_moving = speed > 108;
     }
@@ -220,8 +220,8 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
     // Signal: Lenkhilfe_3.LH3_LM (absolute torque)
     // Signal: Lenkhilfe_3.LH3_LMSign (direction)
     if (addr == MSG_LENKHILFE_3) {
-      int torque_driver_new = GET_BYTE(to_push, 2) | ((GET_BYTE(to_push, 3) & 0x3) << 8);
-      int sign = (GET_BYTE(to_push, 3) & 0x4) >> 2;
+      int torque_driver_new = GET_BYTE(to_push, 2) | ((GET_BYTE(to_push, 3) & 0x3U) << 8);
+      int sign = (GET_BYTE(to_push, 3) & 0x4U) >> 2;
       if (sign == 1) {
         torque_driver_new *= -1;
       }
@@ -231,7 +231,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
     // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
     // Signal: Motor_2.GRA_Status
     if (addr == MSG_MOTOR_2) {
-      int acc_status = (GET_BYTE(to_push, 2) & 0xC0) >> 6;
+      int acc_status = (GET_BYTE(to_push, 2) & 0xC0U) >> 6;
       int cruise_engaged = ((acc_status == 1) || (acc_status == 2)) ? 1 : 0;
       if (cruise_engaged && !cruise_engaged_prev) {
         controls_allowed = 1;
@@ -249,7 +249,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
 
     // Signal: Motor_2.Bremslichtschalter
     if (addr == MSG_MOTOR_2) {
-      brake_pressed = (GET_BYTE(to_push, 2) & 0x1);
+      brake_pressed = (GET_BYTE(to_push, 2) & 0x1U);
     }
 
     generic_rx_checks((addr == MSG_HCA_1));
@@ -309,8 +309,8 @@ static int volkswagen_mqb_tx_hook(CANPacket_t *to_send) {
   // Signal: HCA_01.Assist_Torque (absolute torque)
   // Signal: HCA_01.Assist_VZ (direction)
   if (addr == MSG_HCA_01) {
-    int desired_torque = GET_BYTE(to_send, 2) | ((GET_BYTE(to_send, 3) & 0x3F) << 8);
-    int sign = (GET_BYTE(to_send, 3) & 0x80) >> 7;
+    int desired_torque = GET_BYTE(to_send, 2) | ((GET_BYTE(to_send, 3) & 0x3FU) << 8);
+    int sign = (GET_BYTE(to_send, 3) & 0x80U) >> 7;
     if (sign == 1) {
       desired_torque *= -1;
     }
@@ -324,7 +324,7 @@ static int volkswagen_mqb_tx_hook(CANPacket_t *to_send) {
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == MSG_GRA_ACC_01) && !controls_allowed) {
     // disallow resume and set: bits 16 and 19
-    if ((GET_BYTE(to_send, 2) & 0x9) != 0) {
+    if ((GET_BYTE(to_send, 2) & 0x9U) != 0) {
       tx = 0;
     }
   }
@@ -345,9 +345,9 @@ static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
   // Signal: HCA_1.LM_Offset (absolute torque)
   // Signal: HCA_1.LM_Offsign (direction)
   if (addr == MSG_HCA_1) {
-    int desired_torque = GET_BYTE(to_send, 2) | ((GET_BYTE(to_send, 3) & 0x7F) << 8);
+    int desired_torque = GET_BYTE(to_send, 2) | ((GET_BYTE(to_send, 3) & 0x7FU) << 8);
     desired_torque = desired_torque / 32;  // DBC scale from PQ network to centi-Nm
-    int sign = (GET_BYTE(to_send, 3) & 0x80) >> 7;
+    int sign = (GET_BYTE(to_send, 3) & 0x80U) >> 7;
     if (sign == 1) {
       desired_torque *= -1;
     }
@@ -361,7 +361,7 @@ static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == MSG_GRA_NEU) && !controls_allowed) {
     // disallow resume and set: bits 16 and 17
-    if ((GET_BYTE(to_send, 2) & 0x3) != 0) {
+    if ((GET_BYTE(to_send, 2) & 0x3U) != 0) {
       tx = 0;
     }
   }

--- a/board/safety/safety_volkswagen.h
+++ b/board/safety/safety_volkswagen.h
@@ -145,7 +145,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
   bool valid = addr_safety_check(to_push, &volkswagen_mqb_rx_checks,
                                  volkswagen_get_checksum, volkswagen_mqb_compute_crc, volkswagen_mqb_get_counter);
 
-  if (valid && (GET_BUS(to_push) == 0)) {
+  if (valid && (GET_BUS(to_push) == 0U)) {
     int addr = GET_ADDR(to_push);
 
     // Update in-motion state by sampling front wheel speeds
@@ -187,7 +187,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
 
     // Signal: Motor_20.MO_Fahrpedalrohwert_01
     if (addr == MSG_MOTOR_20) {
-      gas_pressed = ((GET_BYTES_04(to_push) >> 12) & 0xFFU) != 0;
+      gas_pressed = ((GET_BYTES_04(to_push) >> 12) & 0xFFU) != 0U;
     }
 
     // Signal: ESP_05.ESP_Fahrer_bremst
@@ -205,7 +205,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
   bool valid = addr_safety_check(to_push, &volkswagen_pq_rx_checks,
                                 volkswagen_get_checksum, volkswagen_pq_compute_checksum, volkswagen_pq_get_counter);
 
-  if (valid && (GET_BUS(to_push) == 0)) {
+  if (valid && (GET_BUS(to_push) == 0U)) {
     int addr = GET_ADDR(to_push);
 
     // Update in-motion state from speed value.
@@ -324,7 +324,7 @@ static int volkswagen_mqb_tx_hook(CANPacket_t *to_send) {
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == MSG_GRA_ACC_01) && !controls_allowed) {
     // disallow resume and set: bits 16 and 19
-    if ((GET_BYTE(to_send, 2) & 0x9U) != 0) {
+    if ((GET_BYTE(to_send, 2) & 0x9U) != 0U) {
       tx = 0;
     }
   }
@@ -361,7 +361,7 @@ static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
   // This avoids unintended engagements while still allowing resume spam
   if ((addr == MSG_GRA_NEU) && !controls_allowed) {
     // disallow resume and set: bits 16 and 17
-    if ((GET_BYTE(to_send, 2) & 0x3U) != 0) {
+    if ((GET_BYTE(to_send, 2) & 0x3U) != 0U) {
       tx = 0;
     }
   }

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -1,7 +1,7 @@
-#define GET_BIT(msg, b) (((msg)->data[(int)((b) / 8)] >> ((b) % 8)) & 0x1)
+#define GET_BIT(msg, b) (((msg)->data[(int)((b) / 8)] >> ((b) % 8U)) & 0x1U)
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
-#define GET_BYTES_04(msg) ((msg)->data[0] | ((msg)->data[1] << 8) | ((msg)->data[2] << 16) | ((msg)->data[3] << 24))
-#define GET_BYTES_48(msg) ((msg)->data[4] | ((msg)->data[5] << 8) | ((msg)->data[6] << 16) | ((msg)->data[7] << 24))
+#define GET_BYTES_04(msg) ((msg)->data[0] | ((msg)->data[1] << 8U) | ((msg)->data[2] << 16U) | ((msg)->data[3] << 24U))
+#define GET_BYTES_48(msg) ((msg)->data[4] | ((msg)->data[5] << 8U) | ((msg)->data[6] << 16U) | ((msg)->data[7] << 24U))
 #define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask))
 
 const int MAX_WRONG_COUNTERS = 5;

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -1,4 +1,4 @@
-#define GET_BIT(msg, b) (((msg)->data[(uint8_t)((b) / 8U)] >> ((b) % 8U)) & 0x1U)
+#define GET_BIT(msg, b) (((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U)
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
 #define GET_BYTES_04(msg) ((msg)->data[0] | ((msg)->data[1] << 8U) | ((msg)->data[2] << 16U) | ((msg)->data[3] << 24U))
 #define GET_BYTES_48(msg) ((msg)->data[4] | ((msg)->data[5] << 8U) | ((msg)->data[6] << 16U) | ((msg)->data[7] << 24U))

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -1,4 +1,4 @@
-#define GET_BIT(msg, b) (((msg)->data[(int)((b) / 8)] >> ((b) % 8U)) & 0x1U)
+#define GET_BIT(msg, b) (((msg)->data[(uint8_t)((b) / 8U)] >> ((b) % 8U)) & 0x1U)
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
 #define GET_BYTES_04(msg) ((msg)->data[0] | ((msg)->data[1] << 8U) | ((msg)->data[2] << 16U) | ((msg)->data[3] << 24U))
 #define GET_BYTES_48(msg) ((msg)->data[4] | ((msg)->data[5] << 8U) | ((msg)->data[6] << 16U) | ((msg)->data[7] << 24U))

--- a/board/usb_protocol.h
+++ b/board/usb_protocol.h
@@ -1,39 +1,39 @@
 typedef struct {
-  uint8_t ptr;
-  uint8_t tail_size;
+  int ptr;
+  int tail_size;
   uint8_t data[72];
   uint8_t counter;
 } usb_asm_buffer;
 
 usb_asm_buffer ep1_buffer = {.ptr = 0, .tail_size = 0, .counter = 0};
-uint32_t total_rx_size = 0;
+int total_rx_size = 0;
 
 int usb_cb_ep1_in(void *usbdata, int len, bool hardwired) {
   UNUSED(hardwired);
-  uint8_t pos = 1;
+  int pos = 1;
   uint8_t *usbdata8 = (uint8_t *)usbdata;
   usbdata8[0] = ep1_buffer.counter;
   // Send tail of previous message if it is in buffer
   if (ep1_buffer.ptr > 0) {
-    if (ep1_buffer.ptr <= 63U) {
+    if (ep1_buffer.ptr <= 63) {
       (void)memcpy(&usbdata8[pos], ep1_buffer.data, ep1_buffer.ptr);
       pos += ep1_buffer.ptr;
       ep1_buffer.ptr = 0;
     } else {
-      (void)memcpy(&usbdata8[pos], ep1_buffer.data, 63U);
-      ep1_buffer.ptr = ep1_buffer.ptr - 63U;
-      (void)memcpy(ep1_buffer.data, &ep1_buffer.data[63U], ep1_buffer.ptr);
-      pos += 63U;
+      (void)memcpy(&usbdata8[pos], ep1_buffer.data, 63);
+      ep1_buffer.ptr = ep1_buffer.ptr - 63;
+      (void)memcpy(ep1_buffer.data, &ep1_buffer.data[63], ep1_buffer.ptr);
+      pos += 63;
     }
   }
 
   if (total_rx_size > MAX_EP1_CHUNK_PER_BULK_TRANSFER) {
     total_rx_size = 0;
-    ep1_buffer.counter = 0;
+    ep1_buffer.counter = 0U;
   } else {
     CANPacket_t can_packet;
     while ((pos < len) && can_pop(&can_rx_q, &can_packet)) {
-      uint8_t pckt_len = CANPACKET_HEAD_SIZE + dlc_to_len[can_packet.data_len_code];
+      int pckt_len = CANPACKET_HEAD_SIZE + dlc_to_len[can_packet.data_len_code];
       if ((pos + pckt_len) <= len) {
         (void)memcpy(&usbdata8[pos], &can_packet, pckt_len);
         pos += pckt_len;
@@ -50,7 +50,7 @@ int usb_cb_ep1_in(void *usbdata, int len, bool hardwired) {
     total_rx_size += pos;
   }
   if (pos != len) {
-    ep1_buffer.counter = 0;
+    ep1_buffer.counter = 0U;
     total_rx_size = 0;
   }
   if (pos <= 1) { pos = 0; }
@@ -64,17 +64,17 @@ void usb_cb_ep3_out(void *usbdata, int len, bool hardwired) {
   UNUSED(hardwired);
   uint8_t *usbdata8 = (uint8_t *)usbdata;
   // Got first packet from a stream, resetting buffer and counter
-  if (usbdata8[0] == 0) {
-    ep3_buffer.counter = 0;
+  if (usbdata8[0] == 0U) {
+    ep3_buffer.counter = 0U;
     ep3_buffer.ptr = 0;
     ep3_buffer.tail_size = 0;
   }
   // Assembling can message with data from buffer
   if (usbdata8[0] == ep3_buffer.counter) {
-    uint8_t pos = 1;
+    int pos = 1;
     ep3_buffer.counter++;
     if (ep3_buffer.ptr != 0) {
-      if (ep3_buffer.tail_size <= 63U) {
+      if (ep3_buffer.tail_size <= 63) {
         CANPacket_t to_push;
         (void)memcpy(&ep3_buffer.data[ep3_buffer.ptr], &usbdata8[pos], ep3_buffer.tail_size);
         (void)memcpy(&to_push, ep3_buffer.data, ep3_buffer.ptr + ep3_buffer.tail_size);
@@ -84,15 +84,15 @@ void usb_cb_ep3_out(void *usbdata, int len, bool hardwired) {
         ep3_buffer.tail_size = 0;
       } else {
         (void)memcpy(&ep3_buffer.data[ep3_buffer.ptr], &usbdata8[pos], len - pos);
-        ep3_buffer.tail_size -= 63U;
-        ep3_buffer.ptr += 63U;
-        pos += 63U;
+        ep3_buffer.tail_size -= 63;
+        ep3_buffer.ptr += 63;
+        pos += 63;
       }
     }
 
     while (pos < len) {
-      uint8_t pckt_len = CANPACKET_HEAD_SIZE + dlc_to_len[(usbdata8[pos] >> 4U)];
-      if ((pos + pckt_len) <= (uint8_t)len) {
+      int pckt_len = CANPACKET_HEAD_SIZE + dlc_to_len[(usbdata8[pos] >> 4U)];
+      if ((pos + pckt_len) <= len) {
         CANPacket_t to_push;
         (void)memcpy(&to_push, &usbdata8[pos], pckt_len);
         can_send(&to_push, to_push.bus, false);

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -10,5 +10,3 @@ misra-c2012-19.2
 misra-c2012-20.10
 # Required: it's ok re-defining potentially reserved Macro names. Not likely to cause confusion
 misra-c2012-21.1
-# MUST BE FIXED, mostly in the safety code
-misra-c2012-10.4

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -12,5 +12,3 @@ misra-c2012-20.10
 misra-c2012-21.1
 # MUST BE FIXED, mostly in the safety code
 misra-c2012-10.4
-# MUST BE FIXED, mostly in the safety code
-misra-c2012-10.1


### PR DESCRIPTION
Fix MISRA violations 10.1 and 10.4 that were suppressed before. Total 200+ violations, most of them were in safety code. I am still not happy with code cleanliness, will continue in following PRs. (All bitwise and shift operations should have unsigned operands only)