### PR TITLE
GM Safety: Switch to AcceleratorPedal2 message for pressed detection

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -18,7 +18,7 @@ const int GM_DRIVER_TORQUE_FACTOR = 4;
 const int GM_MAX_GAS = 3072;
 const int GM_MAX_REGEN = 1404;
 const int GM_MAX_BRAKE = 350;
-const CanMsg GM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8}, {880, 0, 6}, {789, 0, 5}, {800, 0, 6},   // pt bus
+const CanMsg GM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8}, {880, 0, 6},  // pt bus
                              {161, 1, 7}, {774, 1, 8}, {776, 1, 7}, {784, 1, 2},   // obs bus
                              {789, 2, 5},  // ch bus
                              {0x104c006c, 3, 3}, {0x10400060, 3, 5}};  // gmlan

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -18,7 +18,7 @@ const int GM_DRIVER_TORQUE_FACTOR = 4;
 const int GM_MAX_GAS = 3072;
 const int GM_MAX_REGEN = 1404;
 const int GM_MAX_BRAKE = 350;
-const CanMsg GM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8}, {880, 0, 6},  // pt bus
+const CanMsg GM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8}, {880, 0, 6}, {789, 0, 5}, {800, 0, 6},   // pt bus
                              {161, 1, 7}, {774, 1, 8}, {776, 1, 7}, {784, 1, 2},   // obs bus
                              {789, 2, 5},  // ch bus
                              {0x104c006c, 3, 3}, {0x10400060, 3, 5}};  // gmlan
@@ -29,7 +29,7 @@ AddrCheckStruct gm_addr_checks[] = {
   {.msg = {{842, 0, 5, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{481, 0, 7, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{241, 0, 6, .expected_timestep = 100000U}, { 0 }, { 0 }}},
-  {.msg = {{417, 0, 7, .expected_timestep = 100000U}, { 0 }, { 0 }}},
+  {.msg = {{452, 0, 7, .expected_timestep = 100000U}, { 0 }, { 0 }}},
 };
 #define GM_RX_CHECK_LEN (sizeof(gm_addr_checks) / sizeof(gm_addr_checks[0]))
 addr_checks gm_rx_checks = {gm_addr_checks, GM_RX_CHECK_LEN};
@@ -77,7 +77,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
       brake_pressed = GET_BYTE(to_push, 1) >= 10U;
     }
 
-    if (addr == 417) {
+    if (addr == 452) {
       gas_pressed = GET_BYTE(to_push, 6) != 0U;
     }
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -21,7 +21,7 @@ DRIVER_TORQUE_ALLOWANCE = 50
 DRIVER_TORQUE_FACTOR = 4
 
 class TestGmSafety(common.PandaSafetyTest):
-  TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0], [789, 0], [800, 0],  # pt bus
+  TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0],  # pt bus
              [161, 1], [774, 1], [776, 1], [784, 1],  # obs bus
              [789, 2],  # ch bus
              [0x104c006c, 3], [0x10400060, 3]]  # gmlan

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -21,7 +21,7 @@ DRIVER_TORQUE_ALLOWANCE = 50
 DRIVER_TORQUE_FACTOR = 4
 
 class TestGmSafety(common.PandaSafetyTest):
-  TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0],  # pt bus
+  TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0], [789, 0], [800, 0],  # pt bus
              [161, 1], [774, 1], [776, 1], [784, 1],  # obs bus
              [789, 2],  # ch bus
              [0x104c006c, 3], [0x10400060, 3]]  # gmlan
@@ -65,8 +65,8 @@ class TestGmSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("EBCMBrakePedalPosition", 0, values)
 
   def _gas_msg(self, gas):
-    values = {"AcceleratorPedal": 1 if gas else 0}
-    return self.packer.make_can_msg_panda("AcceleratorPedal", 0, values)
+    values = {"AcceleratorPedal2": 1 if gas else 0}
+    return self.packer.make_can_msg_panda("AcceleratorPedal2", 0, values)
 
   def _send_brake_msg(self, brake):
     values = {"FrictionBrakeCmd": -brake}


### PR DESCRIPTION
### Update pedal-pressed detection message

(Prep for Silverado / Stock VOACC)

* Switch to the AcceleratorPedal2 (452) message for pedal pressed detection, from 417.
  * The messages are redundant (452 contains an extra field).
  * Both were required in OP but 417 is not present on the 2020 Silverado.
  * Since both were required, it should be safe to assume AcceleratorPedal2 is present on all currently functional vehicles
  * While some sort of conditional may be possible, I see no reason to require both if they both have the same value