### PR TITLE
Ford safety for LCA vehicles

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -8,7 +8,7 @@ const struct lookup_t FORD_LOOKUP_ANGLE_RATE_DOWN = {
 
 #define DEG_TO_RAD (3.14159265358979 / 180.0)
 #define RAD_TO_DEG (180.0 / 3.14159265358979)
-#define KPH_TO_MS (0.01 / 3.6)
+#define KPH_TO_MS (1 / 3.6)
 
 // Signal: LatCtlPath_An_Actl
 // Factor: 0.0005
@@ -75,10 +75,9 @@ static int ford_rx_hook(CANPacket_t *to_push) {
     // Update in motion state from speed value
     if (addr == MSG_ENG_VEHICLE_SP_THROTTLE2) {
       // Speed in km/h, convert to m/s
-      // Speed: (0.01 * val) in km/h
+      // Speed: (0.01 * val) * KPH_TO_MS
       // Signal: Veh_V_ActlEng
-      int raw_can_speed = ((GET_BYTE(to_push, 6) << 8) | GET_BYTE(to_push, 7)) * 0.01;
-      vehicle_speed = raw_can_speed * KPH_TO_MS;
+      vehicle_speed = (((GET_BYTE(to_push, 6) << 8) | GET_BYTE(to_push, 7)) * 0.01) * KPH_TO_MS;
       vehicle_moving = vehicle_speed > 0.3;
     }
 

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -189,13 +189,6 @@ static int ford_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     }
     desired_angle_last = desired_angle;
 
-    // TODO: this is broken because we can't send the current angle most of the time -
-    // the signal only supports angles in range [-0.5, 0.5] radians
-    // // Angle should be the same as current angle while not steering
-    // if (!controls_allowed && ((desired_angle < (angle_meas.min - 1)) || (desired_angle > (angle_meas.max + 1)))) {
-    //   tx = 0;
-    // }
-
     // No steer control allowed when controls are not allowed
     if (!controls_allowed && steer_control_enabled) {
       tx = 0;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -96,7 +96,8 @@ static int ford_rx_hook(CANPacket_t *to_push) {
       brake_pressed = ((GET_BYTE(to_push, 0) & 0x30U) >> 4) == 2U;
 
       // Signal: CcStat_D_Actl
-      bool cruise_engaged = (GET_BYTE(to_push, 1) & 0x07U) == 5U;
+      unsigned int cruise_state = GET_BYTE(to_push, 1) & 0x07U;
+      bool cruise_engaged = cruise_state == 4U || cruise_state == 5U;
 
       // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
       if (cruise_engaged && !cruise_engaged_prev) {

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -223,7 +223,8 @@ static int ford_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
     }
     case FORD_CAM: {
       // Block stock LKAS messages
-      bool is_lkas_msg = (addr == MSG_LANE_ASSIST_DATA1)
+      bool is_lkas_msg = (addr == MSG_ACC_DATA_3)
+                      || (addr == MSG_LANE_ASSIST_DATA1)
                       || (addr == MSG_LATERAL_MOTION_CONTROL)
                       || (addr == MSG_IPMA_DATA);
       if (!is_lkas_msg) {

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -179,7 +179,7 @@ static int ford_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     //   tx = 0;
     // }
 
-    // No angle control allowed when controls are not allowed
+    // No steer control allowed when controls are not allowed
     if (!controls_allowed && steer_control_enabled) {
       tx = 0;
     }

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -38,7 +38,8 @@ def clamp(n, low, high):
 
 
 class TestFordSafety(common.PandaSafetyTest):
-  STANDSTILL_THRESHOLD = 0.3
+  STANDSTILL_THRESHOLD = 1
+  GAS_PRESSED_THRESHOLD = 3
   RELAY_MALFUNCTION_BUS = 0
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -48,7 +48,7 @@ class TestFordSafety(common.PandaSafetyTest):
     raise unittest.SkipTest
 
   # Driver brake pedal
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     # brake pedal and cruise state share same message, so we have to send
     # the other signal too (use prev value)
     enable = self.safety.get_controls_allowed()
@@ -64,7 +64,7 @@ class TestFordSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("EngVehicleSpThrottle2", 0, values)
 
   # Drive throttle input
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"ApedPos_Pc_ActlArb": gas}
     return self.packer.make_can_msg_panda("EngVehicleSpThrottle", 0, values)
 
@@ -158,11 +158,6 @@ class TestFordSteeringSafety(TestFordSafety):
 
         # Down
         self.assertEqual(False, self._tx(self._lkas_control_msg(a - sign(a) * (max_delta_down + 1.1), 1)))
-
-        # TODO: ford safety doesn't check for this yet
-        # # Check desired steer should be the same as steer angle when controls are off
-        # self.safety.set_controls_allowed(0)
-        # self.assertEqual(True, self._tx(self._lkas_control_msg(a, 0)))
 
   def test_steer_when_disabled(self):
     self.safety.set_controls_allowed(0)

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -172,14 +172,9 @@ class TestFordSteeringSafety(TestFordSafety):
     self.assertFalse(self.safety.get_controls_allowed())
 
   def test_spam_cancel_safety_check(self):
-    self.safety.set_controls_allowed(1)
-    self._tx(self._acc_button_msg(cancel=1))
-    self.assertTrue(self.safety.get_controls_allowed())
-    self._tx(self._acc_button_msg(resume=1))
-    self.assertFalse(self.safety.get_controls_allowed())
-    self.safety.set_controls_allowed(1)
-    self._tx(self._acc_button_msg(_set=1))
-    self.assertFalse(self.safety.get_controls_allowed())
+    self.assertTrue(self._tx(self._acc_button_msg(cancel=1)))
+    self.assertFalse(self._tx(self._acc_button_msg(resume=1)))
+    self.assertFalse(self._tx(self._acc_button_msg(_set=1)))
 
   def test_rx_hook(self):
     # TODO: test_rx_hook

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -139,37 +139,30 @@ class TestFordSteeringSafety(TestFordSafety):
         # Stay within limits
         # Don't change
         self.assertTrue(self._tx(self._lkas_control_msg(a, 1)))
-        self.assertTrue(self.safety.get_controls_allowed())
 
         # Up
         self.assertTrue(self._tx(self._lkas_control_msg(a + sign(a) * max_delta_up, 1)))
-        self.assertTrue(self.safety.get_controls_allowed())
 
         # Down
         self._set_prev_angle(a)
         self.assertTrue(self._tx(self._lkas_control_msg(a - sign(a) * max_delta_down, 1)))
-        self.assertTrue(self.safety.get_controls_allowed())
 
         # Inject too high rates
         # Up
         self._set_prev_angle(a)
         self.assertFalse(self._tx(self._lkas_control_msg(a + sign(a) * (max_delta_up + 1.1), 1)))
-        self.assertFalse(self.safety.get_controls_allowed())
 
         # Don't change
-        self.safety.set_controls_allowed(1)
         self._set_prev_angle(a)
-        self.assertTrue(self.safety.get_controls_allowed())
         self.assertEqual(True, self._tx(self._lkas_control_msg(a, 1)))
-        self.assertTrue(self.safety.get_controls_allowed())
 
         # Down
         self.assertEqual(False, self._tx(self._lkas_control_msg(a - sign(a) * (max_delta_down + 1.1), 1)))
-        self.assertFalse(self.safety.get_controls_allowed())
 
-        # Check desired steer should be the same as steer angle when controls are off
-        self.safety.set_controls_allowed(0)
-        self.assertEqual(True, self._tx(self._lkas_control_msg(a, 0)))
+        # TODO: ford safety doesn't check for this yet
+        # # Check desired steer should be the same as steer angle when controls are off
+        # self.safety.set_controls_allowed(0)
+        # self.assertEqual(True, self._tx(self._lkas_control_msg(a, 0)))
 
   def test_steer_when_disabled(self):
     self.safety.set_controls_allowed(0)

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -50,8 +50,8 @@ class TestFordSafety(common.PandaSafetyTest):
   # Driver brake pedal
   def _brake_msg(self, brake):
     # brake pedal and cruise state share same message, so we have to send
-    # the cruise state signal too
-    enable = self.safety.get_cruise_engaged_prev()
+    # the other signal too (use prev value)
+    enable = self.safety.get_controls_allowed()
     values = {
       "BpedDrvAppl_D_Actl": 2 if brake else 1,
       "CcStat_D_Actl": 5 if enable else 0,
@@ -70,7 +70,11 @@ class TestFordSafety(common.PandaSafetyTest):
 
   # Cruise status
   def _pcm_status_msg(self, enable):
+    # brake pedal and cruise state share same message, so we have to send
+    # the other signal too (use prev value)
+    brake = self.safety.get_brake_pressed_prev()
     values = {
+      "BpedDrvAppl_D_Actl": 2 if brake else 1,
       "CcStat_D_Actl": 5 if enable else 0,
     }
     return self.packer.make_can_msg_panda("EngBrakeData", 0, values)

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+import unittest
+import numpy as np
+
+import panda.tests.safety.common as common
+
+from panda import Panda
+from panda.tests.safety import libpandasafety_py
+from panda.tests.safety.common import CANPackerPanda
+
+ANGLE_DELTA_BP = [0., 5., 15.]
+ANGLE_DELTA_V = [5., .8, .15]     # windup limit
+ANGLE_DELTA_VU = [5., 3.5, 0.4]   # unwind limit
+
+MSG_STEERING_PINION_DATA = 0x07E      # RX from PSCM, for steering pinion angle
+MSG_ENG_BRAKE_DATA = 0x165            # RX from PCM, for driver brake pedal and cruise state
+MSG_ENG_VEHICLE_SP_THROTTLE2 = 0x202  # RX from PCM, for vehicle speed
+MSG_ENG_VEHICLE_SP_THROTTLE = 0x204   # RX from PCM, for driver throttle input
+MSG_STEERING_DATA_FD1 = 0x083         # TX by OP, ACC control buttons for cancel
+MSG_LANE_ASSIST_DATA1 = 0x3CA         # TX by OP, Lane Keeping Assist
+MSG_LATERAL_MOTION_CONTROL = 0x3D3    # TX by OP, Lane Centering Assist
+MSG_IPMA_DATA = 0x3D8                 # TX by OP, IPMA HUD user interface
+
+
+def sign(a):
+  return 1 if a > 0 else -1
+
+
+class TestFordSafety(common.PandaSafetyTest):
+  STANDSTILL_THRESHOLD = 0.3
+  GAS_PRESSED_THRESHOLD = 3
+  RELAY_MALFUNCTION_BUS = 0
+  FWD_BUS_LOOKUP = {0: 2, 2: 0}
+
+  def setUp(self):
+      self.packer = None
+      raise unittest.SkipTest
+
+  # Driver brake pedal
+  def _brake_msg(self, brake):
+    # TODO: combine with pcm_status_msg since they share a CAN message
+    values = {
+      "BpedDrvAppl_D_Actl": 2 if brake else 1,
+      "CcStat_D_Actl": 5 if self.safety.get_controls_allowed() else 0,  # what to do
+    }
+    return self.packer.make_can_msg_panda("EngBrakeData", 0, values)
+
+  # Vehicle speed
+  def _speed_msg(self, speed):
+    values = {"Veh_V_ActlEng": speed}
+    return self.packer.make_can_msg_panda("EngVehicleSpThrottle2", 0, values)
+
+  # Drive throttle input
+  def _gas_msg(self, gas):
+    values = {"ApedPos_Pc_ActlArb": gas}
+    return self.packer.make_can_msg_panda("EngVehicleSpThrottle", 0, values)
+
+  # Cruise status
+  def _pcm_status_msg(self, enable):
+    # TODO: combine with _brake_msg since they share a CAN message
+    values = {
+      "CcStat_D_Actl": 5 if enable else 0,
+      "BpedDrvAppl_D_Actl": 1,  # what to do
+    }
+    return self.packer.make_can_msg_panda("EngBrakeData", 0, values)
+
+  # Steering wheel angle
+  def _angle_meas_msg(self, angle):
+    values = {"StePinComp_An_Est": angle}
+    return self.packer.make_can_msg_panda("SteeringPinion_Data", 0, values)
+
+  def _set_prev_angle(self, t):
+    self.safety.set_desired_angle_last(t)
+
+  def _angle_meas_msg_array(self, angle):
+    for _ in range(6):
+      self._rx(self._angle_meas_msg(angle))
+
+  # Lane Centering Assist command
+  def _steer_msg(self, angle, enabled):
+    values = {
+      "LatCtl_D_Rq": 1 if enabled else 0,
+      "LatCtlPath_An_Actl": angle,
+    }
+    return self.packer.make_can_msg_panda("LateralMotionControl", 0, values)
+
+
+class TestFordSteeringSafety(TestFordSafety):
+  TX_MSGS = [[MSG_STEERING_DATA_FD1, 0], [MSG_LANE_ASSIST_DATA1, 0], [MSG_LATERAL_MOTION_CONTROL, 0], [MSG_IPMA_DATA, 0]]
+  RELAY_MALFUNCTION_ADDR = MSG_LANE_ASSIST_DATA1
+  FWD_BLACKLISTED_ADDRS = {2: [MSG_LANE_ASSIST_DATA1, MSG_LATERAL_MOTION_CONTROL, MSG_IPMA_DATA]}
+
+  def setUp(self):
+    self.packer = CANPackerPanda("ford_lincoln_base_pt")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_FORD, 0)
+    self.safety.init_tests()
+
+  def test_steer_when_enabled(self):
+    # when controls are allowed, angle cmd rate limit is enforced
+    speeds = [0., 1., 5., 10., 15., 50.]
+    angles = [-300, -100, -10, 0, 10, 100, 300]
+    for a in angles:
+      for s in speeds:
+        max_delta_up = np.interp(s, ANGLE_DELTA_BP, ANGLE_DELTA_V)
+        max_delta_down = np.interp(s, ANGLE_DELTA_BP, ANGLE_DELTA_VU)
+
+        # first test against false positives
+        self._angle_meas_msg_array(a)
+        self._rx(self._speed_msg(s))
+
+        self._set_prev_angle(a)
+        self.safety.set_controls_allowed(1)
+
+        # Stay within limits
+        # Up
+        self.assertEqual(True, self._tx(self._steer_msg(a + sign(a) * max_delta_up, 1)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Don't change
+        self.assertEqual(True, self._tx(self._steer_msg(a, 1)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Down
+        self.assertEqual(True, self._tx(self._steer_msg(a - sign(a) * max_delta_down, 1)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Inject too high rates
+        # Up
+        self.assertEqual(False, self._tx(self._steer_msg(a + sign(a) * (max_delta_up + 1.1), 1)))
+        self.assertFalse(self.safety.get_controls_allowed())
+
+        # Don't change
+        self.safety.set_controls_allowed(1)
+        self._set_prev_angle(a)
+        self.assertTrue(self.safety.get_controls_allowed())
+        self.assertEqual(True, self._tx(self._steer_msg(a, 1)))
+        self.assertTrue(self.safety.get_controls_allowed())
+
+        # Down
+        self.assertEqual(False, self._tx(self._steer_msg(a - sign(a) * (max_delta_down + 1.1), 1)))
+        self.assertFalse(self.safety.get_controls_allowed())
+
+        # Check desired steer should be the same as steer angle when controls are off
+        self.safety.set_controls_allowed(0)
+        self.assertEqual(True, self._tx(self._steer_msg(a, 0)))
+
+  def test_steer_when_disabled(self):
+    self.safety.set_controls_allowed(0)
+
+    self._set_prev_angle(0)
+    self.assertFalse(self._tx(self._steer_msg(0, 1)))
+    self.assertFalse(self.safety.get_controls_allowed())
+
+  def test_spam_cancel_safety_check(self):
+    # TODO: test_spam_cancel_safety_check
+    pass
+
+  def test_rx_hook(self):
+    # TODO: test_rx_hook
+    pass

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -49,10 +49,12 @@ class TestFordSafety(common.PandaSafetyTest):
 
   # Driver brake pedal
   def _brake_msg(self, brake):
-    # TODO: combine with pcm_status_msg since they share a CAN message
+    # brake pedal and cruise state share same message, so we have to send
+    # the cruise state signal too
+    enable = self.safety.get_cruise_engaged_prev()
     values = {
       "BpedDrvAppl_D_Actl": 2 if brake else 1,
-      "CcStat_D_Actl": 5 if self.safety.get_controls_allowed() else 0,  # what to do
+      "CcStat_D_Actl": 5 if enable else 0,
     }
     return self.packer.make_can_msg_panda("EngBrakeData", 0, values)
 
@@ -68,10 +70,8 @@ class TestFordSafety(common.PandaSafetyTest):
 
   # Cruise status
   def _pcm_status_msg(self, enable):
-    # TODO: combine with _brake_msg since they share a CAN message
     values = {
       "CcStat_D_Actl": 5 if enable else 0,
-      "BpedDrvAppl_D_Actl": 1,  # what to do
     }
     return self.packer.make_can_msg_panda("EngBrakeData", 0, values)
 


### PR DESCRIPTION
Implementing Ford safety for new(-er) cars with LCA option.

The structure of the code is based upon the VW safety code, and the Tesla/Nissan code (other angle based cars). I used the steering angle rate limit values from the Tesla. These values might need changing, but I would appreciate guidance on where to start with that.

## Related PRs
- https://github.com/commaai/openpilot/pull/23331