### PR TITLE
GM Switch to AcceleratorPedal2 for pedal pressed

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -29,7 +29,7 @@ AddrCheckStruct gm_addr_checks[] = {
   {.msg = {{842, 0, 5, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{481, 0, 7, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{241, 0, 6, .expected_timestep = 100000U}, { 0 }, { 0 }}},
-  {.msg = {{417, 0, 7, .expected_timestep = 100000U}, { 0 }, { 0 }}},
+  {.msg = {{452, 0, 8, .expected_timestep = 100000U}, { 0 }, { 0 }}},
 };
 #define GM_RX_CHECK_LEN (sizeof(gm_addr_checks) / sizeof(gm_addr_checks[0]))
 addr_checks gm_rx_checks = {gm_addr_checks, GM_RX_CHECK_LEN};
@@ -77,8 +77,8 @@ static int gm_rx_hook(CANPacket_t *to_push) {
       brake_pressed = GET_BYTE(to_push, 1) >= 10U;
     }
 
-    if (addr == 417) {
-      gas_pressed = GET_BYTE(to_push, 6) != 0U;
+    if (addr == 452) {
+      gas_pressed = GET_BYTE(to_push, 5) != 0U;
     }
 
     // exit controls on regen paddle

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -65,8 +65,8 @@ class TestGmSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("EBCMBrakePedalPosition", 0, values)
 
   def _gas_msg(self, gas):
-    values = {"AcceleratorPedal": 1 if gas else 0}
-    return self.packer.make_can_msg_panda("AcceleratorPedal", 0, values)
+    values = {"AcceleratorPedal2": 1 if gas else 0}
+    return self.packer.make_can_msg_panda("AcceleratorPedal2", 0, values)
 
   def _send_brake_msg(self, brake):
     values = {"FrictionBrakeCmd": -brake}


### PR DESCRIPTION
Updated GM safety code and tests to use AcceleratorPedal2 (452) rather than AcceleratorPedal (417) for detecting gas pressed.

The values for the pedal in the two messages are identical, and AcceleratorPedal is not present on the 2020 Silverado. 452 is present in all the existing fingerprints that also contain 417, and they were* both required in OP.

Corresponds with OP PR https://github.com/commaai/openpilot/pull/23280