### PR TITLE
Update libusb to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-libusb1 == 1.6.6
+libusb1==2.0.1
 numpy==1.17.2
 hexdump>=3.3
 pycryptodome==3.9.8

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
   platforms='any',
   license='MIT',
   install_requires=[
-    'libusb1 == 1.6.6',
+    'libusb1 == 2.0.1',
     'hexdump >= 3.3',
     'pycryptodome >= 3.9.8',
     'tqdm >= 4.14.0',


### PR DESCRIPTION
1.6.6 seems to be broken.

```
Collecting libusb1==1.6.6
  Using cached libusb1-1.6.6.tar.gz (56 kB)
  Preparing metadata (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/willem/.local/share/virtualenvs/pq-flasher-VXrEoMdV/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-ivmtemtr/libusb1_6b45ebf3a98445a5ab9f2af595377054/setup.py'"'"'; __file__='"'"'/tmp/pip-install-ivmtemtr/libusb1_6b45ebf3a98445a5ab9f2af595377054/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-13cmhwnv
       cwd: /tmp/pip-install-ivmtemtr/libusb1_6b45ebf3a98445a5ab9f2af595377054/
  Complete output (1 lines):
  error in libusb1 setup command: use_2to3 is invalid.
```