### PR TITLE
Rename GM PT dbc to generated

### DIFF
--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -32,7 +32,7 @@ class TestGmSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP: Dict[int, int] = {}
 
   def setUp(self):
-    self.packer = CANPackerPanda("gm_global_a_powertrain")
+    self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
     self.safety = libpandasafety_py.libpandasafety
     self.safety.set_safety_hooks(Panda.SAFETY_GM, 0)


### PR DESCRIPTION
GM powertrain dbc is now generated in PR https://github.com/commaai/opendbc/pull/478 
Updating dbc file name reference in Panda tests

Note: Associated OP PR: https://github.com/commaai/openpilot/pull/23614