### PR TITLE
GM: Change from brake value threshold to Brake_Pressed signal

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -28,7 +28,7 @@ AddrCheckStruct gm_addr_checks[] = {
   {.msg = {{388, 0, 8, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{842, 0, 5, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{481, 0, 7, .expected_timestep = 100000U}, { 0 }, { 0 }}},
-  {.msg = {{241, 0, 6, .expected_timestep = 100000U}, { 0 }, { 0 }}},
+  {.msg = {{201, 0, 8, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{452, 0, 8, .expected_timestep = 100000U}, { 0 }, { 0 }}},
 };
 #define GM_RX_CHECK_LEN (sizeof(gm_addr_checks) / sizeof(gm_addr_checks[0]))
@@ -70,11 +70,8 @@ static int gm_rx_hook(CANPacket_t *to_push) {
       }
     }
 
-    // speed > 0
-    if (addr == 241) {
-      // Brake pedal's potentiometer returns near-zero reading
-      // even when pedal is not pressed
-      brake_pressed = GET_BYTE(to_push, 1) >= 10U;
+    if (addr == 201) { // ECMEngineStatus.Brake_Pressed
+      brake_pressed = GET_BYTE(to_push, 5) & 1U;
     }
 
     if (addr == 452) {

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -60,9 +60,8 @@ class TestGmSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("ASCMSteeringButton", 0, values)
 
   def _brake_msg(self, brake):
-    # GM safety has a brake threshold of 10
-    values = {"BrakePedalPosition": 10 if brake else 0}
-    return self.packer.make_can_msg_panda("EBCMBrakePedalPosition", 0, values)
+    values = {"Brake_Pressed": 1 if brake else 0}
+    return self.packer.make_can_msg_panda("ECMEngineStatus", 0, values)
 
   def _gas_msg(self, gas):
     values = {"AcceleratorPedal2": 1 if gas else 0}


### PR DESCRIPTION
Increases the threshold for a brake press in the safety code from 10 to 12 due to higher values in large-frame vehicles. This change is required to prevent false disengages. It must match the value in OP to prevent controls mismatch errors.

See corresponding OP PR for details: https://github.com/commaai/openpilot/pull/23617