### PR TITLE
Honda: match openpilot brake pressed check

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -171,11 +171,6 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       }
     }
 
-    bool is_user_brake_msg = honda_alt_brake_msg ? ((addr) == 0x1BE) : ((addr) == 0x17C);
-    if (is_user_brake_msg) {
-      brake_pressed = honda_alt_brake_msg ? (GET_BYTE((to_push), 0) & 0x10U) : (GET_BYTE((to_push), 6) & 0x20U);
-    }
-
     // length check because bosch hardware also uses this id (0x201 w/ len = 8)
     if ((addr == 0x201) && (len == 6)) {
       gas_interceptor_detected = 1;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -56,6 +56,7 @@ const uint16_t HONDA_PARAM_BOSCH_LONG = 2;
 const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 
 int honda_brake = 0;
+bool brake_switch_prev = false;
 bool honda_alt_brake_msg = false;
 bool honda_fwd_brake = false;
 bool honda_bosch_long = false;
@@ -154,8 +155,22 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // and crv, which prevents the usual brake safety from working correctly. these
     // cars have a signal on 0x1BE which only detects user's brake being applied so
     // in these cases, this is used instead.
-    // most hondas: 0x17C bit 53
+    // most hondas: 0x17C bit 53 and bit 32 for brake switch
     // accord, crv: 0x1BE bit 4
+
+    if (honda_alt_brake_msg) {
+      if (addr == 0x1BE) {
+        brake_pressed = GET_BIT(to_push, 4U) != 0U;
+      }
+    } else {
+      if (addr == 0x17C) {
+        // also if brake switch is 1 for two CAN frames, as brake pressed is delayed
+        const bool brake_switch = GET_BIT(to_push, 32U) != 0U;
+        brake_pressed = (GET_BIT(to_push, 53U) != 0U) || (brake_switch && brake_switch_prev);
+        brake_switch_prev = brake_switch;
+      }
+    }
+
     bool is_user_brake_msg = honda_alt_brake_msg ? ((addr) == 0x1BE) : ((addr) == 0x17C);
     if (is_user_brake_msg) {
       brake_pressed = honda_alt_brake_msg ? (GET_BYTE((to_push), 0) & 0x10U) : (GET_BYTE((to_push), 6) & 0x20U);
@@ -176,7 +191,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     }
 
     // disable stock Honda AEB in unsafe mode
-    if ( !(unsafe_mode & UNSAFE_DISABLE_STOCK_AEB) ) {
+    if (!(unsafe_mode & UNSAFE_DISABLE_STOCK_AEB)) {
       if ((bus == 2) && (addr == 0x1FA)) {
         bool honda_stock_aeb = GET_BYTE(to_push, 3) & 0x20U;
         int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) + ((GET_BYTE(to_push, 1) >> 6) & 0x3U);

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -165,7 +165,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     } else {
       if (addr == 0x17C) {
         // also if brake switch is 1 for two CAN frames, as brake pressed is delayed
-        const bool brake_switch = GET_BIT(to_push, 32U) != 0U;
+        bool brake_switch = GET_BIT(to_push, 32U) != 0U;
         brake_pressed = (GET_BIT(to_push, 53U) != 0U) || (brake_switch && honda_brake_switch_prev);
         honda_brake_switch_prev = brake_switch;
       }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -165,7 +165,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     } else {
       if (addr == 0x17C) {
         // also if brake switch is 1 for two CAN frames, as brake pressed is delayed
-        bool brake_switch = GET_BIT(to_push, 32U) != 0U;
+        const bool brake_switch = GET_BIT(to_push, 32U) != 0U;
         brake_pressed = (GET_BIT(to_push, 53U) != 0U) || (brake_switch && honda_brake_switch_prev);
         honda_brake_switch_prev = brake_switch;
       }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -56,7 +56,7 @@ const uint16_t HONDA_PARAM_BOSCH_LONG = 2;
 const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 
 int honda_brake = 0;
-bool brake_switch_prev = false;
+bool honda_brake_switch_prev = false;
 bool honda_alt_brake_msg = false;
 bool honda_fwd_brake = false;
 bool honda_bosch_long = false;
@@ -166,8 +166,8 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       if (addr == 0x17C) {
         // also if brake switch is 1 for two CAN frames, as brake pressed is delayed
         const bool brake_switch = GET_BIT(to_push, 32U) != 0U;
-        brake_pressed = (GET_BIT(to_push, 53U) != 0U) || (brake_switch && brake_switch_prev);
-        brake_switch_prev = brake_switch;
+        brake_pressed = (GET_BIT(to_push, 53U) != 0U) || (brake_switch && honda_brake_switch_prev);
+        honda_brake_switch_prev = brake_switch;
       }
     }
 

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -157,7 +157,6 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // in these cases, this is used instead.
     // most hondas: 0x17C
     // accord, crv: 0x1BE
-
     if (honda_alt_brake_msg) {
       if (addr == 0x1BE) {
         brake_pressed = GET_BIT(to_push, 4U) != 0U;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -155,8 +155,8 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // and crv, which prevents the usual brake safety from working correctly. these
     // cars have a signal on 0x1BE which only detects user's brake being applied so
     // in these cases, this is used instead.
-    // most hondas: 0x17C bit 53 and bit 32 for brake switch
-    // accord, crv: 0x1BE bit 4
+    // most hondas: 0x17C
+    // accord, crv: 0x1BE
 
     if (honda_alt_brake_msg) {
       if (addr == 0x1BE) {


### PR DESCRIPTION
In openpilot we now set brake pressed if either (brake pressed (as before)), **or** (brake switch is 1 for two frames in a row and it's being updated).