### PR TITLE
GM ignition: remove signal with noise and false positives

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -29,7 +29,6 @@ extern int can_silent;
 
 // Ignition detected from CAN meessages
 bool ignition_can = false;
-bool ignition_cadillac = false;
 uint32_t ignition_can_cnt = 0U;
 
 #define ALL_CAN_SILENT 0xFF
@@ -197,16 +196,9 @@ void ignition_can_hook(CANPacket_t *to_push) {
 
   if (bus == 0) {
     // GM exception
-    // TODO: verify on all supported GM models that we can reliably detect ignition using only this signal,
-    // since the 0x1F1 signal can briefly go low immediately after ignition
     if ((addr == 0x160) && (len == 5)) {
       // this message isn't all zeros when ignition is on
-      ignition_cadillac = GET_BYTES_04(to_push) != 0U;
-    }
-    if ((addr == 0x1F1) && (len == 8)) {
-      // Bit 5 is ignition "on"
-      bool ignition_gm = ((GET_BYTE(to_push, 0) & 0x20U) != 0U);
-      ignition_can = ignition_gm || ignition_cadillac;
+      ignition_can = GET_BYTES_04(to_push) != 0U;
     }
 
     // Tesla exception


### PR DESCRIPTION
Linked to issue https://github.com/commaai/openpilot/issues/23645

Verify on these cars:

  - [x] HOLDEN ASTRA RS-V BK 2017
  - [x] CHEVROLET MALIBU PREMIER 2017
  - [x] CADILLAC ATS Premium Performance 2018
  - [x] BUICK REGAL ESSENCE 2018 - no active users
  - [x] GMC ACADIA DENALI 2018 - there's only two active users, script checked one user and I manually verified the other using available recent rlogs (`e38a02cae1ef1e0c|2022-01-31--18-21-53`, `e38a02cae1ef1e0c|2021-11-28--01-36-02`, `e38a02cae1ef1e0c|2021-11-27--13-35-57`)

Thanks to a route provided by @twilsonco (`e69bcbc2c84de4d2|2022-02-02--17-03-51`), this shows the preconditioning feature of a Chevy Volt being used, and has the old signal at 1 and the new signal at 0. This is the reason there's so many mismatches in the Chevy Volt comparisons, they're all false positives. Plot: https://imgur.com/a/Ed2MHWk

A few plots: https://imgur.com/a/PEYtWm5

Checked data:
```
Platform: GMC ACADIA DENALI 2018
Checked 1 unique dongles, 53 unique routes, and 593 segments
Mismatches: 23 frames, 0 segments (any frame)
---
Platform: CADILLAC ESCALADE ESV 2016
Checked 10 unique dongles, 116 unique routes, and 617 segments
Mismatches: 0 frames, 0 segments (any frame)
---
Platform: CHEVROLET VOLT PREMIER 2017
Checked 45 unique dongles, 1464 unique routes, and 14022 segments
Mismatches: 751821 frames, 231 segments (any frame)
```