### PR TITLE
VW MQB: EPS configuration tool

### DIFF
--- a/examples/vw_mqb_config.py
+++ b/examples/vw_mqb_config.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import argparse
+import struct
+import time
+from datetime import date
+from panda import Panda
+from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--debug", action="store_true", help="enable ISO-TP/UDS stack debugging output")
+  parser.add_argument("action", choices={"show", "enable", "disable"}, help="show or modify current EPS HCA config")
+  args = parser.parse_args()
+
+  panda = Panda()
+  panda.set_safety_mode(Panda.SAFETY_ELM327)
+  bus = 1 if panda.has_obd else 0
+  uds_client = UdsClient(panda, 0x712, 0x77c, bus, timeout=0.2, debug=args.debug)
+
+  try:
+    uds_client.diagnostic_session_control(SESSION_TYPE.EXTENDED_DIAGNOSTIC)
+  except MessageTimeoutError:
+    print("Timeout opening session with EPS")
+    quit()
+
+  odx_file, current_coding = None, None
+  try:
+    hw_pn = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER).decode("utf-8")
+    sw_pn = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_SPARE_PART_NUMBER).decode("utf-8")
+    sw_ver = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.VEHICLE_MANUFACTURER_ECU_SOFTWARE_VERSION_NUMBER).decode("utf-8")
+    component = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.SYSTEM_NAME_OR_ENGINE_TYPE).decode("utf-8")
+    odx_file = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.ODX_FILE).decode("utf-8")
+    odx_ver = uds_client.read_data_by_identifier(0xF1A2).decode("utf-8")  # type: ignore
+    current_coding = uds_client.read_data_by_identifier(0x0600)  # type: ignore
+    coding_text = current_coding.hex()
+
+    print("\nDiagnostic data from EPS controller\n")
+    print(f"   Part No HW:   {hw_pn}")
+    print(f"   Part No SW:   {sw_pn}")
+    print(f"   SW version:   {sw_ver}")
+    print(f"   Component:    {component}")
+    print(f"   Coding:       {coding_text}")
+    print(f"   ASAM Dataset: {odx_file} version {odx_ver}")
+  except NegativeResponseError:
+    print("Error fetching data from EPS")
+    quit()
+  except MessageTimeoutError:
+    print("Timeout fetching data from EPS")
+    quit()
+
+  coding_variant, current_coding_array = None, None
+  # EV_SteerAssisMQB covers the majority of MQB racks (EPS_MQB_ZFLS)
+  # APA racks (MQB_PP_APA) have a different coding layout, which should
+  # be easy to support once we identify the specific config bit
+  if odx_file == "EV_SteerAssisMQB\x00":
+    coding_variant = "ZF"
+    current_coding_array = struct.unpack("!4B", current_coding)
+    hca_enabled = (current_coding_array[0] & 1 << 4 != 0)
+    hca_text = ("DISABLED", "ENABLED")[hca_enabled]
+    print(f"   Lane Assist:  {hca_text}")
+  else:
+    print("Configuration changes not yet supported on this EPS!")
+    quit()
+
+  if args.action in ["enable", "disable"]:
+    print("\nAttempting configuration update")
+    assert(coding_variant == "ZF")  # revisit when we have the APA rack coding bit
+    if args.action == "enable":
+      new_byte_0 = current_coding_array[0] | 1 << 4
+    else:
+      new_byte_0 = current_coding_array[0] & ~(1 << 4)
+    new_coding = new_byte_0.to_bytes(1, "little") + current_coding[1:]
+    try:
+      seed = uds_client.security_access(0x3)  # type: ignore
+      key = struct.unpack("!I", seed)[0] + 28183  # yeah, it's like that
+      uds_client.security_access(0x4, struct.pack("!I", key))  # type: ignore
+    except (NegativeResponseError, MessageTimeoutError):
+      print("Security access failed!")
+      quit()
+    try:
+      # Programming date and tester number must be written before making
+      # a change, or write to 0x0600 will fail with request sequence error
+      prog_date = b'\x22\x02\x08'
+      uds_client.write_data_by_identifier(DATA_IDENTIFIER_TYPE.PROGRAMMING_DATE, prog_date)
+      # Encoding on 0xF198 is unclear, it contains the workshop code in the
+      # last two bytes, but not the VZ/importer or tester serial number
+      # Can't seem to read it back, but we can read the calibration tester,
+      # so fib a little and say that same tester did the programming
+      tester_num = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE.CALIBRATION_REPAIR_SHOP_CODE_OR_CALIBRATION_EQUIPMENT_SERIAL_NUMBER)
+      uds_client.write_data_by_identifier(DATA_IDENTIFIER_TYPE.REPAIR_SHOP_CODE_OR_TESTER_SERIAL_NUMBER, tester_num)
+      uds_client.write_data_by_identifier(0x0600, new_coding)  # type: ignore
+    except (NegativeResponseError, MessageTimeoutError):
+      print("Writing new configuration failed!")
+      quit()
+    try:
+      # Read back result just to make 100% sure everything worked
+      current_coding_text = uds_client.read_data_by_identifier(0x0600).hex()  # type: ignore
+      print(f"   New coding:   {current_coding_text}")
+    except (NegativeResponseError, MessageTimeoutError):
+      print("Reading back updated coding failed!")
+      quit()
+    print("EPS configuration successfully updated")

--- a/examples/vw_mqb_config.py
+++ b/examples/vw_mqb_config.py
@@ -2,8 +2,6 @@
 
 import argparse
 import struct
-import time
-from datetime import date
 from panda import Panda
 from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
 
@@ -15,7 +13,7 @@ if __name__ == "__main__":
 
   panda = Panda()
   panda.set_safety_mode(Panda.SAFETY_ELM327)
-  bus = 1 if panda.has_obd else 0
+  bus = 1 if panda.has_obd() else 0
   uds_client = UdsClient(panda, 0x712, 0x77c, bus, timeout=0.2, debug=args.debug)
 
   try:


### PR DESCRIPTION
This is a simple tool to enable/disable HCA (Lane Assist) support in the Volkswagen MQB EPS. This is mainly useful if it's not already enabled from the factory, for those folks installing openpilot without factory Lane Assist using J533 harnesses.

This will work for the majority of MQB EPS racks. There is only one other major variant I'm aware of, and it should be trivial to add when we identify the proper bit to set. The tool will detect EPS models it doesn't support and refuse to configure them.

I plan to do more cleanup and feature work on this, but checking in what I have so I can work on other more urgent stuff.

**Short term TODO:**
* Support APA steering racks (just need to talk to someone with VCDS/OBDEleven and an APA rack)
* Handle programming date more correctly (cross manipulation of bit/byte/string data in Python is enraging)
* Add security access level to the UDS library (multiplier for access_type), then clean up my security_access code

**Long term TODO:**
* Extend this to support enabling/disabling Lane Assist messaging in the instrument cluster (lane lines, status, etc)
* Extend this to support tweaking the number of comfort blinks in the BCM (default to 3, nice for OP to use 5 or so)

These same tasks can eventually be done for VW PQ if we bring in Willem's new [TP2.0 and KWP2000 libraries](https://github.com/pd0wm/pq-flasher).

**Tool output, shows HCA disabled:**
```
comma@tici:/data/openpilot/panda/examples$ ./vw_mqb_config.py show
opening device 23001f001951393037323631 0xddcc
connected

Diagnostic data from EPS controller

   Part No HW:   3Q0909144L 
   Part No SW:   3Q0909144L 
   SW version:   5081
   Component:    EPS_MQB_ZFLS 
   Coding:       811f0000
   ASAM Dataset: EV_SteerAssisMQB version 015157
   Lane Assist:  DISABLED
```

**Tool output, changing coding to enable HCA:**
```
comma@tici:/data/openpilot/panda/examples$ ./vw_mqb_config.py enable
opening device 23001f001951393037323631 0xddcc
connected

Diagnostic data from EPS controller

   Part No HW:   3Q0909144L 
   Part No SW:   3Q0909144L 
   SW version:   5081
   Component:    EPS_MQB_ZFLS 
   Coding:       811f0000
   ASAM Dataset: EV_SteerAssisMQB version 015157
   Lane Assist:  DISABLED

Attempting configuration update
   New coding:   911f0000
EPS configuration successfully updated
```

**Tool output, shows HCA now enabled:**
```
comma@tici:/data/openpilot/panda/examples$ ./vw_mqb_config.py show
opening device 23001f001951393037323631 0xddcc
connected

Diagnostic data from EPS controller

   Part No HW:   3Q0909144L 
   Part No SW:   3Q0909144L 
   SW version:   5081
   Component:    EPS_MQB_ZFLS 
   Coding:       911f0000
   ASAM Dataset: EV_SteerAssisMQB version 015157
   Lane Assist:  ENABLED
```
