### PR TITLE
Bootkick on ignition if USB isn't enumerated

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -248,7 +248,7 @@ void tick_handler(void) {
         }
 
         // enter CDP mode when car starts to ensure we are charging a turned off EON
-        if (check_started() && (usb_power_mode != USB_POWER_CDP)) {
+        if (check_started() && ((usb_power_mode != USB_POWER_CDP) || !usb_enumerated)) {
           current_board->set_usb_power_mode(USB_POWER_CDP);
         }
       }


### PR DESCRIPTION
Helps when usb_power_mode was not set to client before shutdown of a C2 device.