### PR TITLE
Subaru: increase max steering torque to EPS limit

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -1,4 +1,4 @@
-const int SUBARU_MAX_STEER = 2047; // 1s
+const int SUBARU_MAX_STEER = 3071; // eps max steer torque limit
 // real time torque limit to prevent controls spamming
 // the real time limit is 1500/sec
 const int SUBARU_MAX_RT_DELTA = 940;          // max delta torque allowed for real time checks


### PR DESCRIPTION
This PR would increase Subaru steering torque limit to match EPS maximum allowed value. This would allow taking some sharper turns when combined with openpilot bigmodel (and planned slow down on turns) improvements. EPS has internal speed dependant rate and torque safety limits, so this change would move openpilot safety limits closer to EPS limits. 

Please advise which safety tests are required to increase the steering torque limit.