### PR TITLE
HITL tests: change testing speeds

### DIFF
--- a/tests/automated/3_usb_to_can.py
+++ b/tests/automated/3_usb_to_can.py
@@ -23,8 +23,8 @@ def test_can_loopback(p):
   busses = [0, 1, 2]
 
   for bus in busses:
-    # set bus 0 speed to 250
-    p.set_can_speed_kbps(bus, 250)
+    # set bus 0 speed to 5000
+    p.set_can_speed_kbps(bus, 500)
 
     # send a message on bus 0
     p.can_send(0x1aa, b"message", bus)
@@ -116,7 +116,7 @@ def test_throughput(p):
   # enable CAN loopback mode
   p.set_can_loopback(True)
 
-  for speed in [100, 250, 500, 1000]:
+  for speed in [10, 20, 50, 100, 125, 250, 500, 1000]:
     # set bus 0 speed to speed
     p.set_can_speed_kbps(0, speed)
     time.sleep(0.05)

--- a/tests/automated/4_can_loopback.py
+++ b/tests/automated/4_can_loopback.py
@@ -26,7 +26,7 @@ def test_send_recv(p):
     busses = [0, 1, 2]
 
     for bus in busses:
-      for speed in [100, 250, 500, 1000]:
+      for speed in [10, 20, 50, 100, 125, 250, 500, 1000]:
         p_send.set_can_speed_kbps(bus, speed)
         p_recv.set_can_speed_kbps(bus, speed)
         time.sleep(0.05)
@@ -67,8 +67,8 @@ def test_latency(p):
     p_send.set_can_loopback(False)
     p_recv.set_can_loopback(False)
 
-    p_send.set_can_speed_kbps(0, 100)
-    p_recv.set_can_speed_kbps(0, 100)
+    p_send.set_can_speed_kbps(0, 500)
+    p_recv.set_can_speed_kbps(0, 500)
     time.sleep(0.05)
 
     p_send.can_send_many([(0x1ba, 0, b"testmsg", 0)] * 10)
@@ -79,7 +79,7 @@ def test_latency(p):
     busses = [0, 1, 2]
 
     for bus in busses:
-      for speed in [100, 250, 500, 1000]:
+      for speed in [10, 20, 50, 100, 125, 250, 500, 1000]:
         p_send.set_can_speed_kbps(bus, speed)
         p_recv.set_can_speed_kbps(bus, speed)
         time.sleep(0.1)


### PR DESCRIPTION
For singe speed tests we care only about 500Kbit/s (instead of 250)
For multiple speeds tests - larger speeds list to check for possible clock/prescaler problem.