### PR TITLE
Red Panda: enable auto switching to CAN FD with BRS

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -161,9 +161,9 @@ void can_clear(can_ring *q) {
 // Helpers
 // Panda:       Bus 0=CAN1   Bus 1=CAN2   Bus 2=CAN3
 bus_config_t bus_config[] = {
-  { .bus_lookup = 0U, .can_num_lookup = 0U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
-  { .bus_lookup = 1U, .can_num_lookup = 1U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
-  { .bus_lookup = 2U, .can_num_lookup = 2U, .can_speed = 5000U, .can_data_speed = 5000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 0U, .can_num_lookup = 0U, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 1U, .can_num_lookup = 1U, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_enabled = false, .brs_enabled = false },
+  { .bus_lookup = 2U, .can_num_lookup = 2U, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_enabled = false, .brs_enabled = false },
   { .bus_lookup = 0xFFU, .can_num_lookup = 0xFFU, .can_speed = 333U, .can_data_speed = 333U, .canfd_enabled = false, .brs_enabled = false },
 };
 

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -152,6 +152,9 @@ void can_rx(uint8_t can_number) {
       to_push.bus = bus_number;
       to_push.data_len_code = ((fifo->header[1] >> 16) & 0xFU);
 
+      bool canfd_frame = ((fifo->header[1] >> 21) & 0x1U);
+      bool brs_frame = ((fifo->header[1] >> 20) & 0x1U);
+
       uint8_t data_len_w = (dlc_to_len[to_push.data_len_code] / 4U);
       data_len_w += ((dlc_to_len[to_push.data_len_code] % 4U) > 0U) ? 1U : 0U;
       for (unsigned int i = 0; i < data_len_w; i++) {
@@ -178,6 +181,14 @@ void can_rx(uint8_t can_number) {
 
       current_board->set_led(LED_BLUE, true);
       can_send_errs += can_push(&can_rx_q, &to_push) ? 0U : 1U;
+
+      // Enable CAN FD and BRS if CAN FD message was received
+      if (!(bus_config[can_number].canfd_enabled) && (canfd_frame)) {
+        bus_config[can_number].canfd_enabled = true;
+      }
+      if (!(bus_config[can_number].brs_enabled) && (brs_frame)) {
+        bus_config[can_number].brs_enabled = true;
+      }
 
       // update read index
       CANx->RXF0A = rx_fifo_idx;

--- a/tests/canfd/test_ci_canfd.py
+++ b/tests/canfd/test_ci_canfd.py
@@ -13,7 +13,7 @@ if os.getenv("H7_PANDAS_EXCLUDE"):
   H7_PANDAS_EXCLUDE = os.getenv("H7_PANDAS_EXCLUDE").strip().split(" ") # type: ignore
 
 #TODO: REMOVE, temporary list of CAN FD lengths, one in panda python lib MUST be used
-DLC_TO_LEN = [0,1,2,3,4,5,6,7,8, 12, 16, 20, 24, 32, 48]
+DLC_TO_LEN = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48]
 
 _panda_serials = []
 
@@ -27,12 +27,14 @@ def start_heartbeat_thread(p):
         break
   _thread.start_new_thread(heartbeat_thread, (p,))
 
-def panda_init(serial):
+def panda_init(serial, enable_canfd=False):
   p = Panda(serial=serial)
-  assert p.recover(timeout=30)
   start_heartbeat_thread(p)
-  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
   p.set_power_save(False)
+  for bus in range(3):
+    if enable_canfd:
+      p.set_can_data_speed_kbps(bus, 2000)
+  p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
   return p
 
 if JUNGLE_SERIAL:
@@ -41,14 +43,12 @@ if JUNGLE_SERIAL:
   time.sleep(2)
   panda_jungle.set_panda_power(True)
   time.sleep(4)
-  #panda_jungle.set_can_enable(0, False)
-  #panda_jungle.set_can_enable(1, False)
-  #panda_jungle.set_can_enable(2, False)
 
 for serial in Panda.list():
   if serial not in H7_PANDAS_EXCLUDE:
     p = Panda(serial=serial)
     if p.get_type() in H7_HW_TYPES:
+      assert p.recover(timeout=30)
       _panda_serials.append(serial)
     p.close()
 
@@ -58,7 +58,7 @@ if len(_panda_serials) < 2:
 
 
 def canfd_test(p_send, p_recv):
-  for _ in range(500):
+  for _ in range(100):
     sent_msgs = defaultdict(set)
     to_send = []
     for _ in range(200):
@@ -71,10 +71,9 @@ def canfd_test(p_send, p_recv):
 
     p_send.can_send_many(to_send, timeout=0)
 
-    while True:
+    start_time = time.time()
+    while time.time() - start_time < 1:
       incoming = p_recv.can_recv()
-      if not incoming:
-        break
       for msg in incoming:
         address, _, data, bus = msg
         k = (address, bytes(data))
@@ -92,17 +91,24 @@ def canfd_test(p_send, p_recv):
   print("Got all messages intact")
 
 
-p_send = panda_init(_panda_serials[0])
-# Enable CAN FD for sending panda only(to test auto enable feature)
-for bus in range(3):
-  p_send.set_can_speed_kbps(bus,  500)
-  p_send.set_can_data_speed_kbps(bus, 2000)
+p_send = panda_init(_panda_serials[0], enable_canfd=False)
+p_recv = panda_init(_panda_serials[1], enable_canfd=True)
 
-p_recv = panda_init(_panda_serials[1])
-canfd_test(p_send, p_recv)
-
-# Check if all tested buses on receiveing panda have swithed to CAN FD with BRS
+# Check that sending panda CAN FD and BRS are turned off
 for bus in range(3):
-  canfd, brs = p_recv.get_canfd_status(bus)
+  canfd, brs = p_send.get_canfd_status(bus)
+  assert not canfd
+  assert not brs
+
+# Receiving panda sends dummy CAN FD message that should enable CAN FD on sender side
+for bus in range(3):
+  p_recv.can_send(0x200, b"dummymessage", bus)
+p_recv.can_recv()
+
+# Check if all tested buses on sending panda have swithed to CAN FD with BRS
+for bus in range(3):
+  canfd, brs = p_send.get_canfd_status(bus)
   assert canfd
   assert brs
+
+canfd_test(p_send, p_recv)

--- a/tests/canfd/test_ci_canfd.py
+++ b/tests/canfd/test_ci_canfd.py
@@ -31,9 +31,6 @@ def panda_init(serial):
   p = Panda(serial=serial)
   assert p.recover(timeout=30)
   start_heartbeat_thread(p)
-  for bus in range(3):
-    p.set_can_speed_kbps(bus,  500)
-    p.set_can_data_speed_kbps(bus, 2000)
   p.set_safety_mode(Panda.SAFETY_ALLOUTPUT)
   p.set_power_save(False)
   return p
@@ -96,5 +93,16 @@ def canfd_test(p_send, p_recv):
 
 
 p_send = panda_init(_panda_serials[0])
+# Enable CAN FD for sending panda only(to test auto enable feature)
+for bus in range(3):
+  p_send.set_can_speed_kbps(bus,  500)
+  p_send.set_can_data_speed_kbps(bus, 2000)
+
 p_recv = panda_init(_panda_serials[1])
 canfd_test(p_send, p_recv)
+
+# Check if all tested buses on receiveing panda have swithed to CAN FD with BRS
+for bus in range(3):
+  canfd, brs = p_recv.get_canfd_status(bus)
+  assert canfd
+  assert brs


### PR DESCRIPTION
If panda got CAN FD message on a bus - it will switch automatically to CAN FD mode on send on this bus.

Closes #795 