### PR TITLE
Docker: bump openpilot and fix Toyota EPS scale factor for test

### DIFF
--- a/Dockerfile.panda
+++ b/Dockerfile.panda
@@ -60,7 +60,7 @@ RUN cd /tmp && \
     git clone https://github.com/commaai/openpilot.git tmppilot || true && \
     cd /tmp/tmppilot && \
     git fetch && \
-    git checkout cdd3598146c9e06362683e2993af730157abf0b6 && \
+    git checkout c6e0f1a94103ae6b6c879615a00ef0855560bd42 && \
     git submodule update --init cereal opendbc rednose_repo && \
     mkdir /tmp/openpilot && \
     cp -pR SConstruct site_scons/ tools/ selfdrive/ common/ cereal/ opendbc/ rednose/ /tmp/openpilot && \

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -31,6 +31,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   RT_INTERVAL = 250000
   MAX_TORQUE_ERROR = 350
   TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conversative for rounding
+  EPS_SCALE = 0.73
 
   def setUp(self):
     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
@@ -39,7 +40,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     self.safety.init_tests()
 
   def _torque_meas_msg(self, torque):
-    values = {"STEER_TORQUE_EPS": torque}
+    values = {"STEER_TORQUE_EPS": (torque/self.EPS_SCALE)}
     return self.packer.make_can_msg_panda("STEER_TORQUE_SENSOR", 0, values)
 
   def _torque_msg(self, torque):


### PR DESCRIPTION
1. Jinja2 updated in the opendbc
2. EPS scale factor for Toyota was moved from opendbc to openpilot