### PR TITLE
Subaru Torque limit increase. 

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -1,4 +1,4 @@
-const int SUBARU_MAX_STEER = 2047; // 1s
+const int SUBARU_MAX_STEER = 3071; // 1s
 // real time torque limit to prevent controls spamming
 // the real time limit is 1500/sec
 const int SUBARU_MAX_RT_DELTA = 940;          // max delta torque allowed for real time checks

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -8,7 +8,7 @@ from panda.tests.safety.common import CANPackerPanda
 
 MAX_RATE_UP = 50
 MAX_RATE_DOWN = 70
-MAX_STEER = 2047
+MAX_STEER = 3071
 
 MAX_RT_DELTA = 940
 RT_INTERVAL = 250000


### PR DESCRIPTION
for the global platform the EPS enforces a maximum torque value and disables immediately if it's exceeded. 

This change enables the torque change on the '17-19 Impreza's and '18-19 Crosstreks (as well as the '20 Hybrid which is still in community) The max eps value is 3071, the value of 2047 was limiting the torque unintentionally. 

This change does not exceed torque already used on other models. 

2020+ impreza/crosstrek already has it's full torque using a value of 1439. 
2019 Forester has more torque to than either using it's value of 2047. 
