### PR TITLE
Honda: enter controls on falling edge of button presses

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -56,6 +56,7 @@ const uint16_t HONDA_PARAM_BOSCH_LONG = 2;
 const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 
 int honda_brake = 0;
+int honda_button_prev = 0;
 bool honda_brake_switch_prev = false;
 bool honda_alt_brake_msg = false;
 bool honda_fwd_brake = false;
@@ -138,22 +139,20 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     // state machine to enter and exit controls for button enabling
     // 0x1A6 for the ILX, 0x296 for the Civic Touring
     if (((addr == 0x1A6) || (addr == 0x296))) {
-      // check for button presses
       int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
-      switch (button) {
-        case 1:  // main
-        case 2:  // cancel
-          controls_allowed = 0;
-          break;
-        case 3:  // set
-        case 4:  // resume
-          if (acc_main_on && !pcm_cruise) {
-            controls_allowed = 1;
-          }
-          break;
-        default:
-          break; // any other button is irrelevant
+
+      // exit controls once main or cancel are pressed
+      if ((button == 1) || (button == 2)) {
+        controls_allowed = 0;
       }
+
+      // enter controls on the falling edge of set or resume
+      bool set = (button == 0) && (honda_button_prev = 3);
+      bool res = (button == 0) && (honda_button_prev = 4);
+      if (acc_main_on && (button == 0) && (set || res)) {
+        controls_allowed = 1;
+      }
+      honda_button_prev = button;
     }
 
     // user brake signal on 0x17C reports applied brake from computer brake on accord

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -149,7 +149,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       // enter controls on the falling edge of set or resume
       bool set = (button == 0) && (honda_button_prev = 3);
       bool res = (button == 0) && (honda_button_prev = 4);
-      if (acc_main_on && (button == 0) && (set || res)) {
+      if (acc_main_on && !pcm_cruise && (button == 0) && (set || res)) {
         controls_allowed = 1;
       }
       honda_button_prev = button;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -155,8 +155,8 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       }
 
       // enter controls on the falling edge of set or resume
-      bool set = (button == BTN_NONE) && (honda_button_prev = BTN_SET);
-      bool res = (button == BTN_NONE) && (honda_button_prev = BTN_RESUME);
+      bool set = (button == BTN_NONE) && (honda_button_prev == BTN_SET);
+      bool res = (button == BTN_NONE) && (honda_button_prev == BTN_RESUME);
       if (acc_main_on && !pcm_cruise && (set || res)) {
         controls_allowed = 1;
       }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -56,11 +56,11 @@ const uint16_t HONDA_PARAM_BOSCH_LONG = 2;
 const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 
 enum {
-  BTN_NONE = 0,
-  BTN_MAIN = 1,
-  BTN_CANCEL = 2,
-  BTN_SET = 3,
-  BTN_RESUME = 4,
+  HONDA_BTN_NONE = 0,
+  HONDA_BTN_MAIN = 1,
+  HONDA_BTN_CANCEL = 2,
+  HONDA_BTN_SET = 3,
+  HONDA_BTN_RESUME = 4,
 };
 
 int honda_brake = 0;
@@ -150,13 +150,13 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
 
       // exit controls once main or cancel are pressed
-      if ((button == BTN_MAIN) || (button == BTN_CANCEL)) {
+      if ((button == HONDA_BTN_MAIN) || (button == HONDA_BTN_CANCEL)) {
         controls_allowed = 0;
       }
 
       // enter controls on the falling edge of set or resume
-      bool set = (button == BTN_NONE) && (honda_button_prev == BTN_SET);
-      bool res = (button == BTN_NONE) && (honda_button_prev == BTN_RESUME);
+      bool set = (button == HONDA_BTN_NONE) && (honda_button_prev == HONDA_BTN_SET);
+      bool res = (button == HONDA_BTN_NONE) && (honda_button_prev == HONDA_BTN_RESUME);
       if (acc_main_on && !pcm_cruise && (set || res)) {
         controls_allowed = 1;
       }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -157,7 +157,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       // enter controls on the falling edge of set or resume
       bool set = (button == BTN_NONE) && (honda_button_prev = BTN_SET);
       bool res = (button == BTN_NONE) && (honda_button_prev = BTN_RESUME);
-      if (acc_main_on && !pcm_cruise && (button == BTN_NONE) && (set || res)) {
+      if (acc_main_on && !pcm_cruise && (set || res)) {
         controls_allowed = 1;
       }
       honda_button_prev = button;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -363,6 +363,7 @@ static const addr_checks* honda_nidec_init(int16_t param) {
   honda_hw = HONDA_NIDEC;
   honda_alt_brake_msg = false;
   honda_bosch_long = false;
+  honda_button_prev = 0;
 
   if (GET_FLAG(param, HONDA_PARAM_NIDEC_ALT)) {
     honda_rx_checks = (addr_checks){honda_nidec_alt_addr_checks, HONDA_NIDEC_ALT_ADDR_CHECKS_LEN};
@@ -378,6 +379,7 @@ static const addr_checks* honda_bosch_init(int16_t param) {
   honda_hw = HONDA_BOSCH;
   // Checking for alternate brake override from safety parameter
   honda_alt_brake_msg = GET_FLAG(param, HONDA_PARAM_ALT_BRAKE);
+  honda_button_prev = 0;
 
   // radar disabled so allow gas/brakes
 #ifdef ALLOW_DEBUG

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -55,6 +55,14 @@ const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
 const uint16_t HONDA_PARAM_BOSCH_LONG = 2;
 const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 
+enum {
+  BTN_NONE = 0,
+  BTN_MAIN = 1,
+  BTN_CANCEL = 2,
+  BTN_SET = 3,
+  BTN_RESUME = 4,
+};
+
 int honda_brake = 0;
 int honda_button_prev = 0;
 bool honda_brake_switch_prev = false;
@@ -142,14 +150,14 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
 
       // exit controls once main or cancel are pressed
-      if ((button == 1) || (button == 2)) {
+      if ((button == BTN_MAIN) || (button == BTN_CANCEL)) {
         controls_allowed = 0;
       }
 
       // enter controls on the falling edge of set or resume
-      bool set = (button == 0) && (honda_button_prev = 3);
-      bool res = (button == 0) && (honda_button_prev = 4);
-      if (acc_main_on && !pcm_cruise && (button == 0) && (set || res)) {
+      bool set = (button == BTN_NONE) && (honda_button_prev = BTN_SET);
+      bool res = (button == BTN_NONE) && (honda_button_prev = BTN_RESUME);
+      if (acc_main_on && !pcm_cruise && (button == BTN_NONE) && (set || res)) {
         controls_allowed = 1;
       }
       honda_button_prev = button;


### PR DESCRIPTION
The Honda safety now matches the behavior in openpilot and the stock system. This should also prevent mismatches between openpilot and panda.