### PR TITLE
Tesla: only allow cancel button

### DIFF
--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -162,10 +162,10 @@ static int tesla_tx_hook(CANPacket_t *to_send) {
     }
   }
 
-  if(!tesla_powertrain && (addr == 0x45)) {
+  if (!tesla_powertrain && (addr == 0x45)) {
     // No button other than cancel can be sent by us
     int control_lever_status = (GET_BYTE(to_send, 0) & 0x3FU);
-    if((control_lever_status != 0) && (control_lever_status != 1)) {
+    if (control_lever_status != 1) {
       violation = true;
     }
   }

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -150,7 +150,7 @@ class TestTeslaSteeringSafety(TestTeslaSafety):
 
   def test_acc_buttons(self):
     """
-      FWD (cancel) and IDLE always allowed.
+      FWD (cancel) always allowed.
     """
     btns = [
       (CONTROL_LEVER_STATE.FWD, True),
@@ -159,7 +159,7 @@ class TestTeslaSteeringSafety(TestTeslaSafety):
       (CONTROL_LEVER_STATE.UP_2ND, False),
       (CONTROL_LEVER_STATE.DN_1ST, False),
       (CONTROL_LEVER_STATE.DN_2ND, False),
-      (CONTROL_LEVER_STATE.IDLE, True),
+      (CONTROL_LEVER_STATE.IDLE, False),
     ]
     for btn, should_tx in btns:
       for controls_allowed in (True, False):


### PR DESCRIPTION
@robbederks any reason IDLE is also allowed? Seems openpilot only sends FWD. https://github.com/commaai/openpilot/blob/3d8537ab23197a383fd1dd7082329ddee1acfdb7/selfdrive/car/tesla/carcontroller.py#L56