### PR TITLE
safety: split controls allowed into specific actuators

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -139,7 +139,8 @@ void safety_tick(const addr_checks *rx_checks) {
       bool lagging = elapsed_time > MAX(rx_checks->check[i].msg[rx_checks->check[i].index].expected_timestep * MAX_MISSED_MSGS, 1e6);
       rx_checks->check[i].lagging = lagging;
       if (lagging) {
-        controls_allowed = 0;
+        lat_controls_allowed = 0;
+        long_controls_allowed = 0;
       }
     }
   }
@@ -159,7 +160,8 @@ bool is_msg_valid(AddrCheckStruct addr_list[], int index) {
   if (index != -1) {
     if ((!addr_list[index].valid_checksum) || (addr_list[index].wrong_counters >= MAX_WRONG_COUNTERS)) {
       valid = false;
-      controls_allowed = 0;
+      lat_controls_allowed = 0;
+      long_controls_allowed = 0;
     }
   }
   return valid;
@@ -204,8 +206,15 @@ bool addr_safety_check(CANPacket_t *to_push,
 
 void generic_rx_checks(bool stock_ecu_detected) {
   // exit controls on rising edge of gas press
-  if (gas_pressed && !gas_pressed_prev && !(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
-    controls_allowed = 0;
+  if (gas_pressed && !gas_pressed_prev) {
+    long_controls_allowed = 0;
+    if (!(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
+      lat_controls_allowed = 0;
+    }
+  }
+  // allow long control on falling edge of gas press
+  if (!gas_pressed && gas_pressed_prev && (unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
+    long_controls_allowed = 1;
   }
   gas_pressed_prev = gas_pressed;
 

--- a/board/safety.h
+++ b/board/safety.h
@@ -139,8 +139,8 @@ void safety_tick(const addr_checks *rx_checks) {
       bool lagging = elapsed_time > MAX(rx_checks->check[i].msg[rx_checks->check[i].index].expected_timestep * MAX_MISSED_MSGS, 1e6);
       rx_checks->check[i].lagging = lagging;
       if (lagging) {
-        lat_controls_allowed = 0;
-        long_controls_allowed = 0;
+        lat_control_allowed = 0;
+        long_control_allowed = 0;
       }
     }
   }
@@ -160,8 +160,8 @@ bool is_msg_valid(AddrCheckStruct addr_list[], int index) {
   if (index != -1) {
     if ((!addr_list[index].valid_checksum) || (addr_list[index].wrong_counters >= MAX_WRONG_COUNTERS)) {
       valid = false;
-      lat_controls_allowed = 0;
-      long_controls_allowed = 0;
+      lat_control_allowed = 0;
+      long_control_allowed = 0;
     }
   }
   return valid;
@@ -207,21 +207,21 @@ bool addr_safety_check(CANPacket_t *to_push,
 void generic_rx_checks(bool stock_ecu_detected) {
   // exit controls on rising edge of gas press
   if (gas_pressed && !gas_pressed_prev) {
-    long_controls_allowed = 0;
+    long_control_allowed = 0;
     if (!(unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
-      lat_controls_allowed = 0;
+      lat_control_allowed = 0;
     }
   }
   // allow long control on falling edge of gas press if lat is allowed
-  if (!gas_pressed && gas_pressed_prev && lat_controls_allowed && (unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
-    long_controls_allowed = 1;
+  if (!gas_pressed && gas_pressed_prev && lat_control_allowed && (unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
+    long_control_allowed = 1;
   }
   gas_pressed_prev = gas_pressed;
 
   // exit controls on rising edge of brake press
   if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
-    lat_controls_allowed = 0;
-    long_controls_allowed = 0;
+    lat_control_allowed = 0;
+    long_control_allowed = 0;
   }
   brake_pressed_prev = brake_pressed;
 

--- a/board/safety.h
+++ b/board/safety.h
@@ -212,15 +212,16 @@ void generic_rx_checks(bool stock_ecu_detected) {
       lat_controls_allowed = 0;
     }
   }
-  // allow long control on falling edge of gas press
-  if (!gas_pressed && gas_pressed_prev && (unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
+  // allow long control on falling edge of gas press if lat is allowed
+  if (!gas_pressed && gas_pressed_prev && lat_controls_allowed && (unsafe_mode & UNSAFE_DISABLE_DISENGAGE_ON_GAS)) {
     long_controls_allowed = 1;
   }
   gas_pressed_prev = gas_pressed;
 
   // exit controls on rising edge of brake press
   if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
-    controls_allowed = 0;
+    lat_controls_allowed = 0;
+    long_controls_allowed = 0;
   }
   brake_pressed_prev = brake_pressed;
 

--- a/board/safety/safety_defaults.h
+++ b/board/safety/safety_defaults.h
@@ -13,6 +13,8 @@ int default_rx_hook(CANPacket_t *to_push) {
 static const addr_checks* nooutput_init(int16_t param) {
   UNUSED(param);
   controls_allowed = false;
+  lat_controls_allowed = false;
+  long_controls_allowed = false;
   relay_malfunction_reset();
   return &default_rx_checks;
 }
@@ -53,6 +55,8 @@ static const addr_checks* alloutput_init(int16_t param) {
   UNUSED(param);
   alloutput_passthrough = GET_FLAG(param, ALLOUTPUT_PARAM_PASSTHROUGH);
   controls_allowed = true;
+  lat_controls_allowed = true;
+  long_controls_allowed = true;
   relay_malfunction_reset();
   return &default_rx_checks;
 }

--- a/board/safety/safety_defaults.h
+++ b/board/safety/safety_defaults.h
@@ -13,8 +13,8 @@ int default_rx_hook(CANPacket_t *to_push) {
 static const addr_checks* nooutput_init(int16_t param) {
   UNUSED(param);
   controls_allowed = false;
-  lat_controls_allowed = false;
-  long_controls_allowed = false;
+  lat_control_allowed = false;
+  long_control_allowed = false;
   relay_malfunction_reset();
   return &default_rx_checks;
 }
@@ -55,8 +55,8 @@ static const addr_checks* alloutput_init(int16_t param) {
   UNUSED(param);
   alloutput_passthrough = GET_FLAG(param, ALLOUTPUT_PARAM_PASSTHROUGH);
   controls_allowed = true;
-  lat_controls_allowed = true;
-  long_controls_allowed = true;
+  lat_control_allowed = true;
+  long_control_allowed = true;
   relay_malfunction_reset();
   return &default_rx_checks;
 }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -172,14 +172,16 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
         // exit controls on cancel press
         if (button == HYUNDAI_BTN_CANCEL) {
-          controls_allowed = 0;
+          lat_controls_allowed = 0;
+          long_controls_allowed = 0;
         }
 
         // enter controls on falling edge of resume or set
         bool set = (button == HYUNDAI_BTN_NONE) && (cruise_button_prev == HYUNDAI_BTN_SET);
         bool res = (button == HYUNDAI_BTN_NONE) && (cruise_button_prev == HYUNDAI_BTN_RESUME);
         if (set || res) {
-          controls_allowed = 1;
+          lat_controls_allowed = 1;
+          long_controls_allowed = 1;
         }
 
         cruise_button_prev = button;
@@ -190,10 +192,12 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
         // 2 bits: 13-14
         int cruise_engaged = (GET_BYTES_04(to_push) >> 13) & 0x3U;
         if (cruise_engaged && !cruise_engaged_prev) {
-          controls_allowed = 1;
+          lat_controls_allowed = 1;
+          long_controls_allowed = 1;
         }
         if (!cruise_engaged) {
-          controls_allowed = 0;
+          lat_controls_allowed = 0;
+          long_controls_allowed = 0;
         }
         cruise_engaged_prev = cruise_engaged;
       }
@@ -264,7 +268,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
 
     bool violation = 0;
 
-    if (!controls_allowed) {
+    if (!long_controls_allowed) {
       if ((desired_accel_raw != 0) || (desired_accel_val != 0)) {
         violation = 1;
       }
@@ -286,7 +290,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
     uint32_t ts = microsecond_timer_get();
     bool violation = 0;
 
-    if (controls_allowed) {
+    if (lat_controls_allowed) {
 
       // *** global torque limit check ***
       violation |= max_limit_check(desired_torque, HYUNDAI_MAX_STEER, -HYUNDAI_MAX_STEER);
@@ -311,12 +315,12 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
     }
 
     // no torque if controls is not allowed
-    if (!controls_allowed && (desired_torque != 0)) {
+    if (!lat_controls_allowed && (desired_torque != 0)) {
       violation = 1;
     }
 
     // reset to 0 if either controls is not allowed or there's a violation
-    if (violation || !controls_allowed) {
+    if (violation || !lat_controls_allowed) {
       desired_torque_last = 0;
       rt_torque_last = 0;
       ts_last = ts;
@@ -338,7 +342,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
   if ((addr == 1265) && !hyundai_longitudinal) {
     int button = GET_BYTE(to_send, 0) & 0x7U;
 
-    bool allowed_resume = (button == 1) && controls_allowed;
+    bool allowed_resume = (button == 1) && (lat_controls_allowed || long_controls_allowed);
     bool allowed_cancel = (button == 4) && cruise_engaged_prev;
     if (!(allowed_resume || allowed_cancel)) {
       tx = 0;
@@ -365,7 +369,8 @@ static int hyundai_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
 }
 
 static const addr_checks* hyundai_init(int16_t param) {
-  controls_allowed = false;
+  lat_controls_allowed = false;
+  long_controls_allowed = false;
   relay_malfunction_reset();
 
   hyundai_legacy = false;
@@ -385,7 +390,8 @@ static const addr_checks* hyundai_init(int16_t param) {
 }
 
 static const addr_checks* hyundai_legacy_init(int16_t param) {
-  controls_allowed = false;
+  lat_controls_allowed = false;
+  long_controls_allowed = false;
   relay_malfunction_reset();
 
   hyundai_legacy = true;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -89,12 +89,12 @@ static int toyota_rx_hook(CANPacket_t *to_push) {
       // 5th bit is CRUISE_ACTIVE
       int cruise_engaged = GET_BYTE(to_push, 0) & 0x20U;
       if (!cruise_engaged) {
-        lat_controls_allowed = 0;
-        long_controls_allowed = 0;
+        lat_control_allowed = 0;
+        long_control_allowed = 0;
       }
       if (cruise_engaged && !cruise_engaged_prev) {
-        lat_controls_allowed = 1;
-        long_controls_allowed = 1;
+        lat_control_allowed = 1;
+        long_control_allowed = 1;
       }
       cruise_engaged_prev = cruise_engaged;
 
@@ -151,7 +151,7 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
 
     // GAS PEDAL: safety check
     if (addr == 0x200) {
-      if (!long_controls_allowed) {
+      if (!long_control_allowed) {
         if (GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) {
           tx = 0;
         }
@@ -162,7 +162,7 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
     if (addr == 0x343) {
       int desired_accel = (GET_BYTE(to_send, 0) << 8) | GET_BYTE(to_send, 1);
       desired_accel = to_signed(desired_accel, 16);
-      if (!long_controls_allowed) {
+      if (!long_control_allowed) {
         if (desired_accel != 0) {
           tx = 0;
         }
@@ -206,7 +206,7 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
 
       uint32_t ts = microsecond_timer_get();
 
-      if (lat_controls_allowed) {
+      if (lat_control_allowed) {
 
         // *** global torque limit check ***
         violation |= max_limit_check(desired_torque, TOYOTA_MAX_TORQUE, -TOYOTA_MAX_TORQUE);
@@ -230,12 +230,12 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
       }
 
       // no torque if controls is not allowed
-      if (!lat_controls_allowed && (desired_torque != 0)) {
+      if (!lat_control_allowed && (desired_torque != 0)) {
         violation = 1;
       }
 
       // reset to 0 if either controls is not allowed or there's a violation
-      if (violation || !lat_controls_allowed) {
+      if (violation || !lat_control_allowed) {
         desired_torque_last = 0;
         rt_torque_last = 0;
         ts_last = ts;
@@ -251,8 +251,8 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
 }
 
 static const addr_checks* toyota_init(int16_t param) {
-  lat_controls_allowed = 0;
-  long_controls_allowed = 0;
+  lat_control_allowed = 0;
+  long_control_allowed = 0;
   relay_malfunction_reset();
   gas_interceptor_detected = 0;
   toyota_dbc_eps_torque_factor = param;

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -100,7 +100,9 @@ typedef struct {
 void safety_tick(const addr_checks *addr_checks);
 
 // This can be set by the safety hooks
-bool controls_allowed = false;
+bool controls_allowed = false;  // TODO: remove this when all makes are moved over
+bool lat_controls_allowed = false;
+bool long_controls_allowed = false;
 bool relay_malfunction = false;
 bool gas_interceptor_detected = false;
 int gas_interceptor_prev = 0;

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -101,8 +101,8 @@ void safety_tick(const addr_checks *addr_checks);
 
 // This can be set by the safety hooks
 bool controls_allowed = false;  // TODO: remove this when all makes are moved over
-bool lat_controls_allowed = false;
-bool long_controls_allowed = false;
+bool lat_control_allowed = false;
+bool long_control_allowed = false;
 bool relay_malfunction = false;
 bool gas_interceptor_detected = false;
 int gas_interceptor_prev = 0;

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -27,6 +27,8 @@ typedef struct
 
 void set_controls_allowed(bool c);
 bool get_controls_allowed(void);
+bool get_lat_controls_allowed(void);
+bool get_long_controls_allowed(void);
 void set_unsafe_mode(int mode);
 int get_unsafe_mode(void);
 void set_relay_malfunction(bool c);

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -25,13 +25,13 @@ typedef struct
   uint32_t CNT;
 } TIM_TypeDef;
 
-void set_controls_allowed(bool c);
-void set_all_controls_allowed(bool c);
-void set_lat_controls_allowed(bool c);
-void set_long_controls_allowed(bool c);
-bool get_controls_allowed(void);
-bool get_lat_controls_allowed(void);
-bool get_long_controls_allowed(void);
+void set_control_allowed(bool c);
+void set_all_control_allowed(bool c);
+void set_lat_control_allowed(bool c);
+void set_long_control_allowed(bool c);
+bool get_control_allowed(void);
+bool get_lat_control_allowed(void);
+bool get_long_control_allowed(void);
 void set_unsafe_mode(int mode);
 int get_unsafe_mode(void);
 void set_relay_malfunction(bool c);

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -26,6 +26,8 @@ typedef struct
 } TIM_TypeDef;
 
 void set_controls_allowed(bool c);
+void set_lat_controls_allowed(bool c);
+void set_long_controls_allowed(bool c);
 bool get_controls_allowed(void);
 bool get_lat_controls_allowed(void);
 bool get_long_controls_allowed(void);

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -26,6 +26,7 @@ typedef struct
 } TIM_TypeDef;
 
 void set_controls_allowed(bool c);
+void set_all_controls_allowed(bool c);
 void set_lat_controls_allowed(bool c);
 void set_long_controls_allowed(bool c);
 bool get_controls_allowed(void);

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -105,6 +105,14 @@ bool get_controls_allowed(void){
   return controls_allowed;
 }
 
+bool get_lat_controls_allowed(void){
+  return lat_controls_allowed;
+}
+
+bool get_long_controls_allowed(void){
+  return long_controls_allowed;
+}
+
 int get_unsafe_mode(void){
   return unsafe_mode;
 }

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -85,21 +85,21 @@ bool addr_checks_valid() {
   return true;
 }
 
-void set_controls_allowed(bool c){
+void set_control_allowed(bool c){
   controls_allowed = c;
 }
 
-void set_lat_controls_allowed(bool c){
-  lat_controls_allowed = c;
+void set_lat_control_allowed(bool c){
+  lat_control_allowed = c;
 }
 
-void set_long_controls_allowed(bool c){
-  long_controls_allowed = c;
+void set_long_control_allowed(bool c){
+  long_control_allowed = c;
 }
 
-void set_all_controls_allowed(bool c){
-  lat_controls_allowed = c;
-  long_controls_allowed = c;
+void set_all_control_allowed(bool c){
+  lat_control_allowed = c;
+  long_control_allowed = c;
 }
 
 void set_unsafe_mode(int mode){
@@ -114,16 +114,16 @@ void set_gas_interceptor_detected(bool c){
   gas_interceptor_detected = c;
 }
 
-bool get_controls_allowed(void){
+bool get_control_allowed(void){
   return controls_allowed;
 }
 
-bool get_lat_controls_allowed(void){
-  return lat_controls_allowed;
+bool get_lat_control_allowed(void){
+  return lat_control_allowed;
 }
 
-bool get_long_controls_allowed(void){
-  return long_controls_allowed;
+bool get_long_control_allowed(void){
+  return long_control_allowed;
 }
 
 int get_unsafe_mode(void){

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -97,6 +97,11 @@ void set_long_controls_allowed(bool c){
   long_controls_allowed = c;
 }
 
+void set_all_controls_allowed(bool c){
+  lat_controls_allowed = c;
+  long_controls_allowed = c;
+}
+
 void set_unsafe_mode(int mode){
   unsafe_mode = mode;
 }

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -89,6 +89,14 @@ void set_controls_allowed(bool c){
   controls_allowed = c;
 }
 
+void set_lat_controls_allowed(bool c){
+  lat_controls_allowed = c;
+}
+
+void set_long_controls_allowed(bool c){
+  long_controls_allowed = c;
+}
+
 void set_unsafe_mode(int mode){
   unsafe_mode = mode;
 }

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -121,7 +121,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
   def test_steer_safety_check(self):
     for enabled in [0, 1]:
       for t in range(-0x200, 0x200):
-        self.safety.set_lat_controls_allowed(enabled)
+        self.safety.set_lat_control_allowed(enabled)
         self._set_prev_torque(t)
         if abs(t) > MAX_STEER or (not enabled and abs(t) > 0):
           self.assertFalse(self._tx(self._torque_msg(t)))
@@ -130,7 +130,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
 
   def test_non_realtime_limit_up(self):
     self.safety.set_torque_driver(0, 0)
-    self.safety.set_lat_controls_allowed(True)
+    self.safety.set_lat_control_allowed(True)
 
     self._set_prev_torque(0)
     self.assertTrue(self._tx(self._torque_msg(MAX_RATE_UP)))
@@ -139,16 +139,16 @@ class TestHyundaiSafety(common.PandaSafetyTest):
 
     self._set_prev_torque(0)
     self.assertFalse(self._tx(self._torque_msg(MAX_RATE_UP + 1)))
-    self.safety.set_lat_controls_allowed(True)
+    self.safety.set_lat_control_allowed(True)
     self._set_prev_torque(0)
     self.assertFalse(self._tx(self._torque_msg(-MAX_RATE_UP - 1)))
 
   def test_non_realtime_limit_down(self):
     self.safety.set_torque_driver(0, 0)
-    self.safety.set_lat_controls_allowed(True)
+    self.safety.set_lat_control_allowed(True)
 
   def test_against_torque_driver(self):
-    self.safety.set_lat_controls_allowed(True)
+    self.safety.set_lat_control_allowed(True)
 
     for sign in [-1, 1]:
       for t in np.arange(0, DRIVER_TORQUE_ALLOWANCE + 1, 1):
@@ -183,7 +183,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
       self.assertFalse(self._tx(self._torque_msg((MAX_STEER - MAX_RATE_DOWN + 1) * sign)))
 
   def test_realtime_limits(self):
-    self.safety.set_lat_controls_allowed(True)
+    self.safety.set_lat_control_allowed(True)
 
     for sign in [-1, 1]:
       self.safety.init_tests()
@@ -210,11 +210,11 @@ class TestHyundaiSafety(common.PandaSafetyTest):
       - RES allowed while controls allowed
       - CANCEL allowed while cruise is enabled
     """
-    self.safety.set_all_controls_allowed(0)
+    self.safety.set_all_control_allowed(0)
     self.assertFalse(self._tx(self._button_msg(Buttons.RESUME)))
     self.assertFalse(self._tx(self._button_msg(Buttons.SET)))
 
-    self.safety.set_all_controls_allowed(1)
+    self.safety.set_all_control_allowed(1)
     self.assertTrue(self._tx(self._button_msg(Buttons.RESUME)))
     self.assertFalse(self._tx(self._button_msg(Buttons.SET)))
 
@@ -320,31 +320,31 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
       SET and RESUME enter controls allowed on their falling edge.
     """
     for btn in range(8):
-      self.safety.set_all_controls_allowed(0)
+      self.safety.set_all_control_allowed(0)
       for _ in range(10):
         self._rx(self._button_msg(btn))
-        self.assertFalse(self.safety.get_lat_controls_allowed())
-        self.assertFalse(self.safety.get_long_controls_allowed())
+        self.assertFalse(self.safety.get_lat_control_allowed())
+        self.assertFalse(self.safety.get_long_control_allowed())
 
       # should enter controls allowed on falling edge
       if btn in (Buttons.RESUME, Buttons.SET):
         self._rx(self._button_msg(Buttons.NONE))
-        self.assertTrue(self.safety.get_lat_controls_allowed())
-        self.assertTrue(self.safety.get_long_controls_allowed())
+        self.assertTrue(self.safety.get_lat_control_allowed())
+        self.assertTrue(self.safety.get_long_control_allowed())
 
   def test_cancel_button(self):
-    self.safety.set_all_controls_allowed(1)
+    self.safety.set_all_control_allowed(1)
     self._rx(self._button_msg(Buttons.CANCEL))
-    self.assertFalse(self.safety.get_lat_controls_allowed())
-    self.assertFalse(self.safety.get_long_controls_allowed())
+    self.assertFalse(self.safety.get_lat_control_allowed())
+    self.assertFalse(self.safety.get_long_control_allowed())
 
   def test_accel_safety_check(self):
-    for long_controls_allowed in [True, False]:
+    for long_control_allowed in [True, False]:
       for accel in np.arange(MIN_ACCEL - 1, MAX_ACCEL + 1, 0.01):
         accel = round(accel, 2)  # floats might not hit exact boundary conditions without rounding
-        self.safety.set_long_controls_allowed(long_controls_allowed)
-        send = MIN_ACCEL <= accel <= MAX_ACCEL if long_controls_allowed else accel == 0
-        self.assertEqual(send, self._tx(self._send_accel_msg(accel)), (long_controls_allowed, accel))
+        self.safety.set_long_control_allowed(long_control_allowed)
+        send = MIN_ACCEL <= accel <= MAX_ACCEL if long_control_allowed else accel == 0
+        self.assertEqual(send, self._tx(self._send_accel_msg(accel)), (long_control_allowed, accel))
 
   def test_diagnostics(self):
     tester_present = common.package_can_msg((0x7d0, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 0))

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -110,7 +110,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):
     for engaged in [True, False]:
-      self.safety.set_controls_allowed(engaged)
+      self.safety.set_lat_controls_allowed(engaged)
 
       # good msg
       self.assertTrue(self._tx(self._lta_msg(0, 0, 0)))

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -64,7 +64,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
 
   def _gas_msg(self, gas):
-    cruise_active = self.safety.get_long_controls_allowed() or self.safety.get_lat_controls_allowed()
+    cruise_active = self.safety.get_long_control_allowed() or self.safety.get_lat_control_allowed()
     values = {"GAS_RELEASED": not gas, "CRUISE_ACTIVE": cruise_active}
     return self.packer.make_can_msg_panda("PCM_CRUISE", 0, values)
 
@@ -85,7 +85,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     for controls_allowed in (True, False):
       for bad in (True, False):
         for _ in range(10):
-          self.safety.set_all_controls_allowed(controls_allowed)
+          self.safety.set_all_control_allowed(controls_allowed)
           dat = [random.randint(1, 255) for _ in range(7)]
           if not bad:
             dat = [0]*6 + dat[-1:]
@@ -98,10 +98,10 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
 
     for min_accel, max_accel, unsafe_mode in limits:
       for accel in np.arange(min_accel - 1, max_accel + 1, 0.1):
-        for long_controls_allowed in [True, False]:
-          self.safety.set_long_controls_allowed(long_controls_allowed)
+        for long_control_allowed in [True, False]:
+          self.safety.set_long_control_allowed(long_control_allowed)
           self.safety.set_unsafe_mode(unsafe_mode)
-          if long_controls_allowed:
+          if long_control_allowed:
             should_tx = int(min_accel * 1000) <= int(accel * 1000) <= int(max_accel * 1000)
           else:
             should_tx = np.isclose(accel, 0, atol=0.0001)
@@ -110,7 +110,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):
     for engaged in [True, False]:
-      self.safety.set_all_controls_allowed(engaged)
+      self.safety.set_all_control_allowed(engaged)
 
       # good msg
       self.assertTrue(self._tx(self._lta_msg(0, 0, 0)))
@@ -130,7 +130,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   def test_rx_hook(self):
     # checksum checks
     for msg in ["trq", "pcm"]:
-      self.safety.set_all_controls_allowed(1)
+      self.safety.set_all_control_allowed(1)
       if msg == "trq":
         to_push = self._torque_meas_msg(0)
       if msg == "pcm":
@@ -141,8 +141,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
       to_push[0].data[6] = 0
       to_push[0].data[7] = 0
       self.assertFalse(self._rx(to_push))
-      self.assertFalse(self.safety.get_lat_controls_allowed())
-      self.assertFalse(self.safety.get_long_controls_allowed())
+      self.assertFalse(self.safety.get_lat_control_allowed())
+      self.assertFalse(self.safety.get_long_control_allowed())
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -64,7 +64,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
 
   def _gas_msg(self, gas):
-    cruise_active = self.safety.get_controls_allowed()
+    cruise_active = self.safety.get_long_controls_allowed()
     values = {"GAS_RELEASED": not gas, "CRUISE_ACTIVE": cruise_active}
     return self.packer.make_can_msg_panda("PCM_CRUISE", 0, values)
 
@@ -83,9 +83,11 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
 
   def test_block_aeb(self):
     for controls_allowed in (True, False):
+      print('here')
       for bad in (True, False):
         for _ in range(10):
-          self.safety.set_controls_allowed(controls_allowed)
+          self.safety.set_lat_controls_allowed(controls_allowed)
+          self.safety.set_long_controls_allowed(controls_allowed)
           dat = [random.randint(1, 255) for _ in range(7)]
           if not bad:
             dat = [0]*6 + dat[-1:]
@@ -99,7 +101,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     for min_accel, max_accel, unsafe_mode in limits:
       for accel in np.arange(min_accel - 1, max_accel + 1, 0.1):
         for controls_allowed in [True, False]:
-          self.safety.set_controls_allowed(controls_allowed)
+          self.safety.set_long_controls_allowed(controls_allowed)
           self.safety.set_unsafe_mode(unsafe_mode)
           if controls_allowed:
             should_tx = int(min_accel * 1000) <= int(accel * 1000) <= int(max_accel * 1000)
@@ -111,6 +113,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   def test_lta_steer_cmd(self):
     for engaged in [True, False]:
       self.safety.set_lat_controls_allowed(engaged)
+      self.safety.set_long_controls_allowed(engaged)
 
       # good msg
       self.assertTrue(self._tx(self._lta_msg(0, 0, 0)))
@@ -130,7 +133,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   def test_rx_hook(self):
     # checksum checks
     for msg in ["trq", "pcm"]:
-      self.safety.set_controls_allowed(1)
+      self.safety.set_lat_controls_allowed(1)
+      self.safety.set_long_controls_allowed(1)
       if msg == "trq":
         to_push = self._torque_meas_msg(0)
       if msg == "pcm":
@@ -141,7 +145,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
       to_push[0].data[6] = 0
       to_push[0].data[7] = 0
       self.assertFalse(self._rx(to_push))
-      self.assertFalse(self.safety.get_controls_allowed())
+      self.assertFalse(self.safety.get_lat_controls_allowed())
+      self.assertFalse(self.safety.get_long_controls_allowed())
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -64,7 +64,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
 
   def _gas_msg(self, gas):
-    cruise_active = self.safety.get_long_controls_allowed()
+    cruise_active = self.safety.get_long_controls_allowed() or self.safety.get_lat_controls_allowed()
     values = {"GAS_RELEASED": not gas, "CRUISE_ACTIVE": cruise_active}
     return self.packer.make_can_msg_panda("PCM_CRUISE", 0, values)
 
@@ -83,11 +83,9 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
 
   def test_block_aeb(self):
     for controls_allowed in (True, False):
-      print('here')
       for bad in (True, False):
         for _ in range(10):
-          self.safety.set_lat_controls_allowed(controls_allowed)
-          self.safety.set_long_controls_allowed(controls_allowed)
+          self.safety.set_all_controls_allowed(controls_allowed)
           dat = [random.randint(1, 255) for _ in range(7)]
           if not bad:
             dat = [0]*6 + dat[-1:]
@@ -100,10 +98,10 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
 
     for min_accel, max_accel, unsafe_mode in limits:
       for accel in np.arange(min_accel - 1, max_accel + 1, 0.1):
-        for controls_allowed in [True, False]:
-          self.safety.set_long_controls_allowed(controls_allowed)
+        for long_controls_allowed in [True, False]:
+          self.safety.set_long_controls_allowed(long_controls_allowed)
           self.safety.set_unsafe_mode(unsafe_mode)
-          if controls_allowed:
+          if long_controls_allowed:
             should_tx = int(min_accel * 1000) <= int(accel * 1000) <= int(max_accel * 1000)
           else:
             should_tx = np.isclose(accel, 0, atol=0.0001)
@@ -112,8 +110,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):
     for engaged in [True, False]:
-      self.safety.set_lat_controls_allowed(engaged)
-      self.safety.set_long_controls_allowed(engaged)
+      self.safety.set_all_controls_allowed(engaged)
 
       # good msg
       self.assertTrue(self._tx(self._lta_msg(0, 0, 0)))
@@ -133,8 +130,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   def test_rx_hook(self):
     # checksum checks
     for msg in ["trq", "pcm"]:
-      self.safety.set_lat_controls_allowed(1)
-      self.safety.set_long_controls_allowed(1)
+      self.safety.set_all_controls_allowed(1)
       if msg == "trq":
         to_push = self._torque_meas_msg(0)
       if msg == "pcm":


### PR DESCRIPTION
Splits `controls_allowed` into `lat_control_allowed` and `long_control_allowed`