### PR TITLE
Honda: fix missing Honda interceptor tests

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -37,12 +37,12 @@ class CANPackerPanda(CANPacker):
       msg = fix_checksum(msg)
     return package_can_msg(msg)
 
-class PandaSafetyTestBase(unittest.TestCase):
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "PandaSafetyTestBase":
-      cls.safety = None
-      raise unittest.SkipTest
+class PandaSafetyTestBase(object):
+  # @classmethod
+  # def setUpClass(cls):
+    # if cls.__name__ == "PandaSafetyTestBase":
+    #   cls.safety = None
+    #   raise unittest.SkipTest
 
   def _rx(self, msg):
     return self.safety.safety_rx_hook(msg)
@@ -53,15 +53,6 @@ class PandaSafetyTestBase(unittest.TestCase):
 class InterceptorSafetyTest(PandaSafetyTestBase):
 
   INTERCEPTOR_THRESHOLD = 0
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "InterceptorSafetyTest":
-      cls.safety = None
-      raise unittest.SkipTest
-
-    # make sure interceptor is detected
-    cls._rx(cls._interceptor_msg(0, 0x201)) # pylint: disable=no-value-for-parameter
 
   @abc.abstractmethod
   def _interceptor_msg(self, gas, addr):
@@ -123,11 +114,11 @@ class TorqueSteeringSafetyTest(PandaSafetyTestBase):
   MAX_TORQUE_ERROR = 0
   TORQUE_MEAS_TOLERANCE = 0
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TorqueSteeringSafetyTest":
-      cls.safety = None
-      raise unittest.SkipTest
+  # @classmethod
+  # def setUpClass(cls):
+  #   if cls.__name__ == "TorqueSteeringSafetyTest":
+  #     cls.safety = None
+  #     raise unittest.SkipTest
 
   @abc.abstractmethod
   def _torque_meas_msg(self, torque):
@@ -262,11 +253,11 @@ class PandaSafetyTest(PandaSafetyTestBase):
   FWD_BLACKLISTED_ADDRS: Dict[int, List[int]] = {}  # {bus: [addr]}
   FWD_BUS_LOOKUP: Dict[int, int] = {}
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "PandaSafetyTest" or cls.__name__.endswith('Base'):
-      cls.safety = None
-      raise unittest.SkipTest
+  # @classmethod
+  # def setUpClass(cls):
+  #   if cls.__name__ == "PandaSafetyTest" or cls.__name__.endswith('Base'):
+  #     cls.safety = None
+  #     raise unittest.SkipTest
 
   @abc.abstractmethod
   def _brake_msg(self, brake):

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -38,12 +38,6 @@ class CANPackerPanda(CANPacker):
     return package_can_msg(msg)
 
 class PandaSafetyTestBase(object):
-  # @classmethod
-  # def setUpClass(cls):
-    # if cls.__name__ == "PandaSafetyTestBase":
-    #   cls.safety = None
-    #   raise unittest.SkipTest
-
   def _rx(self, msg):
     return self.safety.safety_rx_hook(msg)
 
@@ -113,12 +107,6 @@ class TorqueSteeringSafetyTest(PandaSafetyTestBase):
   RT_INTERVAL = 0
   MAX_TORQUE_ERROR = 0
   TORQUE_MEAS_TOLERANCE = 0
-
-  # @classmethod
-  # def setUpClass(cls):
-  #   if cls.__name__ == "TorqueSteeringSafetyTest":
-  #     cls.safety = None
-  #     raise unittest.SkipTest
 
   @abc.abstractmethod
   def _torque_meas_msg(self, torque):
@@ -252,12 +240,6 @@ class PandaSafetyTest(PandaSafetyTestBase):
   RELAY_MALFUNCTION_BUS: Optional[int] = None
   FWD_BLACKLISTED_ADDRS: Dict[int, List[int]] = {}  # {bus: [addr]}
   FWD_BUS_LOOKUP: Dict[int, int] = {}
-
-  # @classmethod
-  # def setUpClass(cls):
-  #   if cls.__name__ == "PandaSafetyTest" or cls.__name__.endswith('Base'):
-  #     cls.safety = None
-  #     raise unittest.SkipTest
 
   @abc.abstractmethod
   def _brake_msg(self, brake):

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -5,7 +5,7 @@ from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
 
-class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest):
+class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest, unittest.TestCase):
   TX_MSGS = [[571, 0], [658, 0], [678, 0]]
   STANDSTILL_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDR = 0x292

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -5,7 +5,7 @@ from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
 
-class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest, unittest.TestCase):
+class TestChryslerSafety(common.BaseTestCases.PandaSafetyTest, common.BaseTestCases.TorqueSteeringSafetyTest):
   TX_MSGS = [[571, 0], [658, 0], [678, 0]]
   STANDSTILL_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDR = 0x292

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -26,7 +26,7 @@ class Buttons:
   DECEL_SET = 3
   CANCEL = 6
 
-class TestGmSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestGmSafety(common.BaseTestCases.PandaSafetyTest):
   TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0],  # pt bus
              [161, 1], [774, 1], [776, 1], [784, 1],  # obs bus
              [789, 2],  # ch bus

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -26,7 +26,7 @@ class Buttons:
   DECEL_SET = 3
   CANCEL = 6
 
-class TestGmSafety(common.PandaSafetyTest):
+class TestGmSafety(common.PandaSafetyTest, unittest.TestCase):
   TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0],  # pt bus
              [161, 1], [774, 1], [776, 1], [784, 1],  # obs bus
              [789, 2],  # ch bus

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -207,13 +207,6 @@ class HondaBase(common.PandaSafetyTest):
   cnt_powertrain_data = 0
   cnt_acc_state = 0
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "HondaBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _powertrain_data_msg(self, cruise_on=None, brake_pressed=None, gas_pressed=None):
     # preserve the state
     if cruise_on is None:
@@ -288,12 +281,6 @@ class TestHondaNidecSafetyBase(HondaBase):
 
   INTERCEPTOR_THRESHOLD = 344
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestHondaNidecSafetyBase":
-      cls.safety = None
-      raise unittest.SkipTest
-
   def setUp(self):
     self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
     self.safety = libpandasafety_py.libpandasafety
@@ -365,7 +352,7 @@ class TestHondaNidecSafetyBase(HondaBase):
 
 
 
-class TestHondaNidecSafety(HondaPcmEnableBase, TestHondaNidecSafetyBase):
+class TestHondaNidecSafety(HondaPcmEnableBase, TestHondaNidecSafetyBase, unittest.TestCase):
   """
     Covers the Honda Nidec safety mode
   """
@@ -375,16 +362,14 @@ class TestHondaNidecSafety(HondaPcmEnableBase, TestHondaNidecSafetyBase):
     pass
 
 
-class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.InterceptorSafetyTest):
+class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.InterceptorSafetyTest, unittest.TestCase):
   """
     Covers the Honda Nidec safety mode with a gas interceptor
   """
-  def setUp(self):
-    TestHondaNidecSafety.setUpClass()
-    common.InterceptorSafetyTest.setUpClass()
+  pass
 
 
-class TestHondaNidecAltSafety(TestHondaNidecSafety):
+class TestHondaNidecAltSafety(TestHondaNidecSafety, unittest.TestCase):
   """
     Covers the Honda Nidec safety mode with alt SCM messages
   """
@@ -405,7 +390,7 @@ class TestHondaNidecAltSafety(TestHondaNidecSafety):
     return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
 
 
-class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.InterceptorSafetyTest):
+class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.InterceptorSafetyTest, unittest.TestCase):
   """
     Covers the Honda Nidec safety mode with alt SCM messages and gas interceptor
   """
@@ -414,7 +399,6 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     self.safety = libpandasafety_py.libpandasafety
     self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
     self.safety.init_tests_honda()
-    common.InterceptorSafetyTest.setUpClass()
 
   def _acc_state_msg(self, main_on):
     values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
@@ -437,13 +421,6 @@ class TestHondaBoschSafetyBase(HondaBase):
 
   TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestHondaBoschSafetyBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   def setUp(self):
     self.packer = CANPackerPanda("honda_accord_2018_can_generated")
@@ -478,7 +455,7 @@ class TestHondaBoschSafetyBase(HondaBase):
     self.assertTrue(self.safety.get_controls_allowed())
 
 
-class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
+class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase, unittest.TestCase):
   """
     Covers the Honda Bosch safety mode with stock longitudinal
   """
@@ -497,7 +474,7 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
     self.assertTrue(self._tx(self._button_msg(Btn.RESUME)))
 
 
-class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
+class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase, unittest.TestCase):
   """
     Covers the Honda Bosch safety mode with longitudinal control
   """

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -28,331 +28,367 @@ HONDA_BOSCH = 1
 #  * Bosch
 #    * Bosch with Longitudinal Support
 
+class HondaBaseTestCases:
+  class HondaButtonEnableBase(common.BaseTestCases.PandaSafetyTest):
+    # pylint: disable=no-member,abstract-method
 
-class HondaButtonEnableBase(common.PandaSafetyTest):
-  # pylint: disable=no-member,abstract-method
+    # override these inherited tests since we're using button enable
+    def test_disable_control_allowed_from_cruise(self):
+      pass
 
-  # override these inherited tests since we're using button enable
-  def test_disable_control_allowed_from_cruise(self):
-    pass
+    def test_enable_control_allowed_from_cruise(self):
+      pass
 
-  def test_enable_control_allowed_from_cruise(self):
-    pass
+    def test_cruise_engaged_prev(self):
+      pass
 
-  def test_cruise_engaged_prev(self):
-    pass
+    def test_buttons_with_main_off(self):
+      for btn in (Btn.SET, Btn.RESUME, Btn.CANCEL):
+        self.safety.set_controls_allowed(1)
+        self._rx(self._acc_state_msg(False))
+        self._rx(self._button_msg(btn, main_on=False))
+        self.assertFalse(self.safety.get_controls_allowed())
 
-  def test_buttons_with_main_off(self):
-    for btn in (Btn.SET, Btn.RESUME, Btn.CANCEL):
+    def test_set_resume_buttons(self):
+      """
+        Both SET and RES should enter controls allowed on their falling edge.
+      """
+      for btn in (Btn.SET, Btn.RESUME):
+        for main_on in (True, False):
+          self._rx(self._acc_state_msg(main_on))
+          self.safety.set_controls_allowed(0)
+
+          # nothing until falling edge
+          for _ in range(10):
+            self._rx(self._button_msg(btn, main_on=main_on))
+          self.assertFalse(self.safety.get_controls_allowed())
+
+          self._rx(self._button_msg(Btn.NONE, main_on=main_on))
+          self.assertEqual(main_on, self.safety.get_controls_allowed(), msg=f"{main_on=} {btn=}")
+
+    def test_main_cancel_buttons(self):
+      """
+        Both MAIN and CANCEL should exit controls immediately.
+      """
+      for btn in (Btn.MAIN, Btn.CANCEL):
+        self.safety.set_controls_allowed(1)
+        self._rx(self._button_msg(btn, main_on=True))
+        self.assertFalse(self.safety.get_controls_allowed())
+
+    def test_disengage_on_main(self):
       self.safety.set_controls_allowed(1)
+      self._rx(self._acc_state_msg(True))
+      self.assertTrue(self.safety.get_controls_allowed())
       self._rx(self._acc_state_msg(False))
-      self._rx(self._button_msg(btn, main_on=False))
       self.assertFalse(self.safety.get_controls_allowed())
 
-  def test_set_resume_buttons(self):
-    """
-      Both SET and RES should enter controls allowed on their falling edge.
-    """
-    for btn in (Btn.SET, Btn.RESUME):
-      for main_on in (True, False):
-        self._rx(self._acc_state_msg(main_on))
-        self.safety.set_controls_allowed(0)
+    def test_rx_hook(self):
 
-        # nothing until falling edge
-        for _ in range(10):
-          self._rx(self._button_msg(btn, main_on=main_on))
-        self.assertFalse(self.safety.get_controls_allowed())
+      # TODO: move this test to common
+      # checksum checks
+      for msg in ["btn", "gas", "speed"]:
+        self.safety.set_controls_allowed(1)
+        if msg == "btn":
+          to_push = self._button_msg(Btn.SET)
+        if msg == "gas":
+          to_push = self._gas_msg(0)
+        if msg == "speed":
+          to_push = self._speed_msg(0)
+        self.assertTrue(self._rx(to_push))
+        if msg != "btn":
+          to_push[0].data[4] = 0  # invalidate checksum
+          to_push[0].data[5] = 0
+          to_push[0].data[6] = 0
+          to_push[0].data[7] = 0
+          self.assertFalse(self._rx(to_push))
+          self.assertFalse(self.safety.get_controls_allowed())
 
-        self._rx(self._button_msg(Btn.NONE, main_on=main_on))
-        self.assertEqual(main_on, self.safety.get_controls_allowed(), msg=f"{main_on=} {btn=}")
+      # counter
+      # reset wrong_counters to zero by sending valid messages
+      for i in range(MAX_WRONG_COUNTERS + 1):
+        self.__class__.cnt_speed += 1
+        self.__class__.cnt_button += 1
+        self.__class__.cnt_powertrain_data += 1
+        if i < MAX_WRONG_COUNTERS:
+          self.safety.set_controls_allowed(1)
+          self._rx(self._button_msg(Btn.SET))
+          self._rx(self._speed_msg(0))
+          self._rx(self._gas_msg(0))
+        else:
+          self.assertFalse(self._rx(self._button_msg(Btn.SET)))
+          self.assertFalse(self._rx(self._speed_msg(0)))
+          self.assertFalse(self._rx(self._gas_msg(0)))
+          self.assertFalse(self.safety.get_controls_allowed())
 
-  def test_main_cancel_buttons(self):
-    """
-      Both MAIN and CANCEL should exit controls immediately.
-    """
-    for btn in (Btn.MAIN, Btn.CANCEL):
-      self.safety.set_controls_allowed(1)
-      self._rx(self._button_msg(btn, main_on=True))
-      self.assertFalse(self.safety.get_controls_allowed())
-
-  def test_disengage_on_main(self):
-    self.safety.set_controls_allowed(1)
-    self._rx(self._acc_state_msg(True))
-    self.assertTrue(self.safety.get_controls_allowed())
-    self._rx(self._acc_state_msg(False))
-    self.assertFalse(self.safety.get_controls_allowed())
-
-  def test_rx_hook(self):
-
-    # TODO: move this test to common
-    # checksum checks
-    for msg in ["btn", "gas", "speed"]:
-      self.safety.set_controls_allowed(1)
-      if msg == "btn":
-        to_push = self._button_msg(Btn.SET)
-      if msg == "gas":
-        to_push = self._gas_msg(0)
-      if msg == "speed":
-        to_push = self._speed_msg(0)
-      self.assertTrue(self._rx(to_push))
-      if msg != "btn":
-        to_push[0].data[4] = 0  # invalidate checksum
-        to_push[0].data[5] = 0
-        to_push[0].data[6] = 0
-        to_push[0].data[7] = 0
-        self.assertFalse(self._rx(to_push))
-        self.assertFalse(self.safety.get_controls_allowed())
-
-    # counter
-    # reset wrong_counters to zero by sending valid messages
-    for i in range(MAX_WRONG_COUNTERS + 1):
-      self.__class__.cnt_speed += 1
-      self.__class__.cnt_button += 1
-      self.__class__.cnt_powertrain_data += 1
-      if i < MAX_WRONG_COUNTERS:
+      # restore counters for future tests with a couple of good messages
+      for i in range(2):
         self.safety.set_controls_allowed(1)
         self._rx(self._button_msg(Btn.SET))
         self._rx(self._speed_msg(0))
         self._rx(self._gas_msg(0))
-      else:
-        self.assertFalse(self._rx(self._button_msg(Btn.SET)))
-        self.assertFalse(self._rx(self._speed_msg(0)))
-        self.assertFalse(self._rx(self._gas_msg(0)))
-        self.assertFalse(self.safety.get_controls_allowed())
+      self._rx(self._button_msg(Btn.SET, main_on=True))
+      self.assertTrue(self.safety.get_controls_allowed())
 
-    # restore counters for future tests with a couple of good messages
-    for i in range(2):
+    def test_tx_hook_on_pedal_pressed(self):
+      for mode in [UNSAFE_MODE.DEFAULT, UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS]:
+        for pedal in ['brake', 'gas']:
+          self.safety.set_unsafe_mode(mode)
+          allow_ctrl = False
+          if pedal == 'brake':
+            # brake_pressed_prev and vehicle_moving
+            self._rx(self._speed_msg(100))
+            self._rx(self._brake_msg(1))
+          elif pedal == 'gas':
+            # gas_pressed_prev
+            self._rx(self._gas_msg(1))
+            allow_ctrl = mode == UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS
+
+          self.safety.set_controls_allowed(1)
+          hw = self.safety.get_honda_hw()
+          if hw == HONDA_NIDEC:
+            self.safety.set_honda_fwd_brake(False)
+            self.assertEqual(allow_ctrl, self._tx(self._send_brake_msg(self.MAX_BRAKE)))
+          self.assertEqual(allow_ctrl, self._tx(self._send_steer_msg(0x1000)))
+
+          # reset status
+          self.safety.set_controls_allowed(0)
+          self.safety.set_unsafe_mode(UNSAFE_MODE.DEFAULT)
+          if hw == HONDA_NIDEC:
+            self._tx(self._send_brake_msg(0))
+          self._tx(self._send_steer_msg(0))
+          if pedal == 'brake':
+            self._rx(self._speed_msg(0))
+            self._rx(self._brake_msg(0))
+          elif pedal == 'gas':
+            self._rx(self._gas_msg(0))
+
+  class HondaPcmEnableBase(common.BaseTestCases.PandaSafetyTest):
+    # pylint: disable=no-member,abstract-method
+
+    def test_buttons(self):
+      """
+        Buttons should only cancel in this configuration,
+        since our state is tied to the PCM's cruise state.
+      """
+      for controls_allowed in (True, False):
+        for main_on in (True, False):
+          # not a valid state
+          if controls_allowed and not main_on:
+            continue
+
+          for btn in (Btn.SET, Btn.RESUME, Btn.CANCEL):
+            self.safety.set_controls_allowed(controls_allowed)
+            self._rx(self._acc_state_msg(main_on))
+
+            # btn + none for falling edge
+            self._rx(self._button_msg(btn, main_on=main_on))
+            self._rx(self._button_msg(Btn.NONE, main_on=main_on))
+
+            if btn == Btn.CANCEL:
+              self.assertFalse(self.safety.get_controls_allowed())
+            else:
+              self.assertEqual(controls_allowed, self.safety.get_controls_allowed())
+
+  class HondaBase(common.BaseTestCases.PandaSafetyTest):
+    MAX_BRAKE: float = 255
+    PT_BUS: Optional[int] = None  # must be set when inherited
+    STEER_BUS: Optional[int] = None  # must be set when inherited
+
+    STANDSTILL_THRESHOLD = 0
+    RELAY_MALFUNCTION_ADDR = 0xE4
+    RELAY_MALFUNCTION_BUS = 0
+    FWD_BUS_LOOKUP = {0: 2, 2: 0}
+
+    cnt_speed = 0
+    cnt_button = 0
+    cnt_brake = 0
+    cnt_powertrain_data = 0
+    cnt_acc_state = 0
+
+    def _powertrain_data_msg(self, cruise_on=None, brake_pressed=None, gas_pressed=None):
+      # preserve the state
+      if cruise_on is None:
+        # or'd with controls allowed since the tests use it to "enable" cruise
+        cruise_on = self.safety.get_cruise_engaged_prev() or self.safety.get_controls_allowed()
+      if brake_pressed is None:
+        brake_pressed = self.safety.get_brake_pressed_prev()
+      if gas_pressed is None:
+        gas_pressed = self.safety.get_gas_pressed_prev()
+
+      values = {
+        "ACC_STATUS": cruise_on,
+        "BRAKE_PRESSED": brake_pressed,
+        "PEDAL_GAS": gas_pressed,
+        "COUNTER": self.cnt_powertrain_data % 4
+      }
+      self.__class__.cnt_powertrain_data += 1
+      return self.packer.make_can_msg_panda("POWERTRAIN_DATA", self.PT_BUS, values)
+
+    def _pcm_status_msg(self, enable):
+      return self._powertrain_data_msg(cruise_on=enable)
+
+    def _speed_msg(self, speed):
+      values = {"XMISSION_SPEED": speed, "COUNTER": self.cnt_speed % 4}
+      self.__class__.cnt_speed += 1
+      return self.packer.make_can_msg_panda("ENGINE_DATA", self.PT_BUS, values)
+
+    def _acc_state_msg(self, main_on):
+      values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
+      self.__class__.cnt_acc_state += 1
+      return self.packer.make_can_msg_panda("SCM_FEEDBACK", self.PT_BUS, values)
+
+    def _button_msg(self, buttons, main_on=False):
+      values = {"CRUISE_BUTTONS": buttons, "COUNTER": self.cnt_button % 4}
+      self.__class__.cnt_button += 1
+      return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
+
+    def _brake_msg(self, brake):
+      return self._powertrain_data_msg(brake_pressed=brake)
+
+    def _gas_msg(self, gas):
+      return self._powertrain_data_msg(gas_pressed=gas)
+
+    def _send_steer_msg(self, steer):
+      values = {"STEER_TORQUE": steer}
+      return self.packer.make_can_msg_panda("STEERING_CONTROL", self.STEER_BUS, values)
+
+    def _send_brake_msg(self, brake):
+      # must be implemented when inherited
+      raise NotImplementedError
+
+    def test_disengage_on_brake(self):
       self.safety.set_controls_allowed(1)
-      self._rx(self._button_msg(Btn.SET))
-      self._rx(self._speed_msg(0))
-      self._rx(self._gas_msg(0))
-    self._rx(self._button_msg(Btn.SET, main_on=True))
-    self.assertTrue(self.safety.get_controls_allowed())
+      self._rx(self._brake_msg(1))
+      self.assertFalse(self.safety.get_controls_allowed())
 
-  def test_tx_hook_on_pedal_pressed(self):
-    for mode in [UNSAFE_MODE.DEFAULT, UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS]:
-      for pedal in ['brake', 'gas']:
+    def test_steer_safety_check(self):
+      self.safety.set_controls_allowed(0)
+      self.assertTrue(self._tx(self._send_steer_msg(0x0000)))
+      self.assertFalse(self._tx(self._send_steer_msg(0x1000)))
+
+  # ********************* Honda Nidec **********************
+
+  class TestHondaNidecSafetyBase(HondaBase):
+    TX_MSGS = [[0xE4, 0], [0x194, 0], [0x1FA, 0], [0x200, 0], [0x30C, 0], [0x33D, 0]]
+    FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x194, 0x33D, 0x30C]}
+
+    PT_BUS = 0
+    STEER_BUS = 0
+
+    INTERCEPTOR_THRESHOLD = 344
+
+    def setUp(self):
+      self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
+      self.safety = libpandasafety_py.libpandasafety
+      self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
+      self.safety.init_tests_honda()
+
+    # Honda gas gains are the different
+    def _interceptor_msg(self, gas, addr):
+      to_send = make_msg(0, addr, 6)
+      gas2 = gas * 2
+      to_send[0].data[0] = (gas & 0xFF00) >> 8
+      to_send[0].data[1] = gas & 0xFF
+      to_send[0].data[2] = (gas2 & 0xFF00) >> 8
+      to_send[0].data[3] = gas2 & 0xFF
+      return to_send
+
+    def _send_brake_msg(self, brake):
+      values = {"COMPUTER_BRAKE": brake}
+      return self.packer.make_can_msg_panda("BRAKE_COMMAND", 0, values)
+
+    def test_fwd_hook(self):
+      # normal operation, not forwarding AEB
+      self.FWD_BLACKLISTED_ADDRS[2].append(0x1FA)
+      self.safety.set_honda_fwd_brake(False)
+      super().test_fwd_hook()
+
+      # TODO: test latching until AEB event is over?
+      # forwarding AEB brake signal
+      self.FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x194, 0x33D, 0x30C]}
+      self.safety.set_honda_fwd_brake(True)
+      super().test_fwd_hook()
+
+    def test_brake_safety_check(self):
+      for fwd_brake in [False, True]:
+        self.safety.set_honda_fwd_brake(fwd_brake)
+        for brake in np.arange(0, self.MAX_BRAKE + 10, 1):
+          for controls_allowed in [True, False]:
+            self.safety.set_controls_allowed(controls_allowed)
+            if fwd_brake:
+              send = False  # block openpilot brake msg when fwd'ing stock msg
+            elif controls_allowed:
+              send = self.MAX_BRAKE >= brake >= 0
+            else:
+              send = brake == 0
+            self.assertEqual(send, self._tx(self._send_brake_msg(brake)))
+      self.safety.set_honda_fwd_brake(False)
+
+    def test_tx_hook_on_interceptor_pressed(self):
+      for mode in [UNSAFE_MODE.DEFAULT, UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS]:
         self.safety.set_unsafe_mode(mode)
-        allow_ctrl = False
-        if pedal == 'brake':
-          # brake_pressed_prev and vehicle_moving
-          self._rx(self._speed_msg(100))
-          self._rx(self._brake_msg(1))
-        elif pedal == 'gas':
-          # gas_pressed_prev
-          self._rx(self._gas_msg(1))
-          allow_ctrl = mode == UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS
+        # gas_interceptor_prev > INTERCEPTOR_THRESHOLD
+        self._rx(self._interceptor_msg(self.INTERCEPTOR_THRESHOLD + 1, 0x201))
+        self._rx(self._interceptor_msg(self.INTERCEPTOR_THRESHOLD + 1, 0x201))
+        allow_ctrl = mode == UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS
 
         self.safety.set_controls_allowed(1)
-        hw = self.safety.get_honda_hw()
-        if hw == HONDA_NIDEC:
-          self.safety.set_honda_fwd_brake(False)
-          self.assertEqual(allow_ctrl, self._tx(self._send_brake_msg(self.MAX_BRAKE)))
+        self.safety.set_honda_fwd_brake(False)
+        self.assertEqual(allow_ctrl, self._tx(self._send_brake_msg(self.MAX_BRAKE)))
+        self.assertEqual(allow_ctrl, self._tx(self._interceptor_msg(self.INTERCEPTOR_THRESHOLD, 0x200)))
         self.assertEqual(allow_ctrl, self._tx(self._send_steer_msg(0x1000)))
 
         # reset status
         self.safety.set_controls_allowed(0)
         self.safety.set_unsafe_mode(UNSAFE_MODE.DEFAULT)
-        if hw == HONDA_NIDEC:
-          self._tx(self._send_brake_msg(0))
+        self._tx(self._send_brake_msg(0))
         self._tx(self._send_steer_msg(0))
-        if pedal == 'brake':
-          self._rx(self._speed_msg(0))
-          self._rx(self._brake_msg(0))
-        elif pedal == 'gas':
-          self._rx(self._gas_msg(0))
+        self._tx(self._interceptor_msg(0, 0x200))
+        self.safety.set_gas_interceptor_detected(False)
 
+  # ********************* Honda Bosch **********************
 
-class HondaPcmEnableBase(common.PandaSafetyTest):
-  # pylint: disable=no-member,abstract-method
+  class TestHondaBoschSafetyBase(HondaBase):
+    PT_BUS = 1
+    STEER_BUS = 0
 
-  def test_buttons(self):
-    """
-      Buttons should only cancel in this configuration,
-      since our state is tied to the PCM's cruise state.
-    """
-    for controls_allowed in (True, False):
-      for main_on in (True, False):
-        # not a valid state
-        if controls_allowed and not main_on:
-          continue
+    TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
+    FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
-        for btn in (Btn.SET, Btn.RESUME, Btn.CANCEL):
-          self.safety.set_controls_allowed(controls_allowed)
-          self._rx(self._acc_state_msg(main_on))
+    def setUp(self):
+      self.packer = CANPackerPanda("honda_accord_2018_can_generated")
+      self.safety = libpandasafety_py.libpandasafety
 
-          # btn + none for falling edge
-          self._rx(self._button_msg(btn, main_on=main_on))
-          self._rx(self._button_msg(Btn.NONE, main_on=main_on))
+    def _alt_brake_msg(self, brake):
+      values = {"BRAKE_PRESSED": brake, "COUNTER": self.cnt_brake % 4}
+      self.__class__.cnt_brake += 1
+      return self.packer.make_can_msg_panda("BRAKE_MODULE", self.PT_BUS, values)
 
-          if btn == Btn.CANCEL:
-            self.assertFalse(self.safety.get_controls_allowed())
-          else:
-            self.assertEqual(controls_allowed, self.safety.get_controls_allowed())
+    def _send_brake_msg(self, brake):
+      pass
 
-
-class HondaBase(common.PandaSafetyTest):
-  MAX_BRAKE: float = 255
-  PT_BUS: Optional[int] = None  # must be set when inherited
-  STEER_BUS: Optional[int] = None  # must be set when inherited
-
-  STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDR = 0xE4
-  RELAY_MALFUNCTION_BUS = 0
-  FWD_BUS_LOOKUP = {0: 2, 2: 0}
-
-  cnt_speed = 0
-  cnt_button = 0
-  cnt_brake = 0
-  cnt_powertrain_data = 0
-  cnt_acc_state = 0
-
-  def _powertrain_data_msg(self, cruise_on=None, brake_pressed=None, gas_pressed=None):
-    # preserve the state
-    if cruise_on is None:
-      # or'd with controls allowed since the tests use it to "enable" cruise
-      cruise_on = self.safety.get_cruise_engaged_prev() or self.safety.get_controls_allowed()
-    if brake_pressed is None:
-      brake_pressed = self.safety.get_brake_pressed_prev()
-    if gas_pressed is None:
-      gas_pressed = self.safety.get_gas_pressed_prev()
-
-    values = {
-      "ACC_STATUS": cruise_on,
-      "BRAKE_PRESSED": brake_pressed,
-      "PEDAL_GAS": gas_pressed,
-      "COUNTER": self.cnt_powertrain_data % 4
-    }
-    self.__class__.cnt_powertrain_data += 1
-    return self.packer.make_can_msg_panda("POWERTRAIN_DATA", self.PT_BUS, values)
-
-  def _pcm_status_msg(self, enable):
-    return self._powertrain_data_msg(cruise_on=enable)
-
-  def _speed_msg(self, speed):
-    values = {"XMISSION_SPEED": speed, "COUNTER": self.cnt_speed % 4}
-    self.__class__.cnt_speed += 1
-    return self.packer.make_can_msg_panda("ENGINE_DATA", self.PT_BUS, values)
-
-  def _acc_state_msg(self, main_on):
-    values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
-    self.__class__.cnt_acc_state += 1
-    return self.packer.make_can_msg_panda("SCM_FEEDBACK", self.PT_BUS, values)
-
-  def _button_msg(self, buttons, main_on=False):
-    values = {"CRUISE_BUTTONS": buttons, "COUNTER": self.cnt_button % 4}
-    self.__class__.cnt_button += 1
-    return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
-
-  def _brake_msg(self, brake):
-    return self._powertrain_data_msg(brake_pressed=brake)
-
-  def _gas_msg(self, gas):
-    return self._powertrain_data_msg(gas_pressed=gas)
-
-  def _send_steer_msg(self, steer):
-    values = {"STEER_TORQUE": steer}
-    return self.packer.make_can_msg_panda("STEERING_CONTROL", self.STEER_BUS, values)
-
-  def _send_brake_msg(self, brake):
-    # must be implemented when inherited
-    raise NotImplementedError
-
-  def test_disengage_on_brake(self):
-    self.safety.set_controls_allowed(1)
-    self._rx(self._brake_msg(1))
-    self.assertFalse(self.safety.get_controls_allowed())
-
-  def test_steer_safety_check(self):
-    self.safety.set_controls_allowed(0)
-    self.assertTrue(self._tx(self._send_steer_msg(0x0000)))
-    self.assertFalse(self._tx(self._send_steer_msg(0x1000)))
-
-
-# ********************* Honda Nidec **********************
-
-
-class TestHondaNidecSafetyBase(HondaBase):
-  TX_MSGS = [[0xE4, 0], [0x194, 0], [0x1FA, 0], [0x200, 0], [0x30C, 0], [0x33D, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x194, 0x33D, 0x30C]}
-
-  PT_BUS = 0
-  STEER_BUS = 0
-
-  INTERCEPTOR_THRESHOLD = 344
-
-  def setUp(self):
-    self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
-    self.safety.init_tests_honda()
-
-  # Honda gas gains are the different
-  def _interceptor_msg(self, gas, addr):
-    to_send = make_msg(0, addr, 6)
-    gas2 = gas * 2
-    to_send[0].data[0] = (gas & 0xFF00) >> 8
-    to_send[0].data[1] = gas & 0xFF
-    to_send[0].data[2] = (gas2 & 0xFF00) >> 8
-    to_send[0].data[3] = gas2 & 0xFF
-    return to_send
-
-  def _send_brake_msg(self, brake):
-    values = {"COMPUTER_BRAKE": brake}
-    return self.packer.make_can_msg_panda("BRAKE_COMMAND", 0, values)
-
-  def test_fwd_hook(self):
-    # normal operation, not forwarding AEB
-    self.FWD_BLACKLISTED_ADDRS[2].append(0x1FA)
-    self.safety.set_honda_fwd_brake(False)
-    super().test_fwd_hook()
-
-    # TODO: test latching until AEB event is over?
-    # forwarding AEB brake signal
-    self.FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x194, 0x33D, 0x30C]}
-    self.safety.set_honda_fwd_brake(True)
-    super().test_fwd_hook()
-
-  def test_brake_safety_check(self):
-    for fwd_brake in [False, True]:
-      self.safety.set_honda_fwd_brake(fwd_brake)
-      for brake in np.arange(0, self.MAX_BRAKE + 10, 1):
-        for controls_allowed in [True, False]:
-          self.safety.set_controls_allowed(controls_allowed)
-          if fwd_brake:
-            send = False  # block openpilot brake msg when fwd'ing stock msg
-          elif controls_allowed:
-            send = self.MAX_BRAKE >= brake >= 0
-          else:
-            send = brake == 0
-          self.assertEqual(send, self._tx(self._send_brake_msg(brake)))
-    self.safety.set_honda_fwd_brake(False)
-
-  def test_tx_hook_on_interceptor_pressed(self):
-    for mode in [UNSAFE_MODE.DEFAULT, UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS]:
-      self.safety.set_unsafe_mode(mode)
-      # gas_interceptor_prev > INTERCEPTOR_THRESHOLD
-      self._rx(self._interceptor_msg(self.INTERCEPTOR_THRESHOLD + 1, 0x201))
-      self._rx(self._interceptor_msg(self.INTERCEPTOR_THRESHOLD + 1, 0x201))
-      allow_ctrl = mode == UNSAFE_MODE.DISABLE_DISENGAGE_ON_GAS
-
+    # TODO: add back in once alternative brake checksum/counter validation is added
+    # def test_alt_brake_rx_hook(self):
+    #   self.safety.set_honda_alt_brake_msg(1)
+    #   self.safety.set_controls_allowed(1)
+    #   to_push = self._alt_brake_msg(0)
+    #   self.assertTrue(self._rx(to_push))
+    #   to_push[0].RDLR = to_push[0].RDLR & 0xFFF0FFFF # invalidate checksum
+    #   self.assertFalse(self._rx(to_push))
+    #   self.assertFalse(self.safety.get_controls_allowed())
+    def test_alt_disengage_on_brake(self):
+      self.safety.set_honda_alt_brake_msg(1)
       self.safety.set_controls_allowed(1)
-      self.safety.set_honda_fwd_brake(False)
-      self.assertEqual(allow_ctrl, self._tx(self._send_brake_msg(self.MAX_BRAKE)))
-      self.assertEqual(allow_ctrl, self._tx(self._interceptor_msg(self.INTERCEPTOR_THRESHOLD, 0x200)))
-      self.assertEqual(allow_ctrl, self._tx(self._send_steer_msg(0x1000)))
+      self._rx(self._alt_brake_msg(1))
+      self.assertFalse(self.safety.get_controls_allowed())
 
-      # reset status
-      self.safety.set_controls_allowed(0)
-      self.safety.set_unsafe_mode(UNSAFE_MODE.DEFAULT)
-      self._tx(self._send_brake_msg(0))
-      self._tx(self._send_steer_msg(0))
-      self._tx(self._interceptor_msg(0, 0x200))
-      self.safety.set_gas_interceptor_detected(False)
+      self.safety.set_honda_alt_brake_msg(0)
+      self.safety.set_controls_allowed(1)
+      self._rx(self._alt_brake_msg(1))
+      self.assertTrue(self.safety.get_controls_allowed())
 
 
-
-class TestHondaNidecSafety(HondaPcmEnableBase, TestHondaNidecSafetyBase, unittest.TestCase):
+class TestHondaNidecSafety(HondaBaseTestCases.HondaPcmEnableBase, HondaBaseTestCases.TestHondaNidecSafetyBase):
   """
     Covers the Honda Nidec safety mode
   """
@@ -362,14 +398,14 @@ class TestHondaNidecSafety(HondaPcmEnableBase, TestHondaNidecSafetyBase, unittes
     pass
 
 
-class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.InterceptorSafetyTest, unittest.TestCase):
+class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.BaseTestCases.InterceptorSafetyTest):
   """
     Covers the Honda Nidec safety mode with a gas interceptor
   """
   pass
 
 
-class TestHondaNidecAltSafety(TestHondaNidecSafety, unittest.TestCase):
+class TestHondaNidecAltSafety(TestHondaNidecSafety):
   """
     Covers the Honda Nidec safety mode with alt SCM messages
   """
@@ -390,7 +426,7 @@ class TestHondaNidecAltSafety(TestHondaNidecSafety, unittest.TestCase):
     return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
 
 
-class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.InterceptorSafetyTest, unittest.TestCase):
+class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.BaseTestCases.InterceptorSafetyTest):
   """
     Covers the Honda Nidec safety mode with alt SCM messages and gas interceptor
   """
@@ -411,51 +447,7 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
 
 
-
-# ********************* Honda Bosch **********************
-
-
-class TestHondaBoschSafetyBase(HondaBase):
-  PT_BUS = 1
-  STEER_BUS = 0
-
-  TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
-
-  def setUp(self):
-    self.packer = CANPackerPanda("honda_accord_2018_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-
-  def _alt_brake_msg(self, brake):
-    values = {"BRAKE_PRESSED": brake, "COUNTER": self.cnt_brake % 4}
-    self.__class__.cnt_brake += 1
-    return self.packer.make_can_msg_panda("BRAKE_MODULE", self.PT_BUS, values)
-
-  def _send_brake_msg(self, brake):
-    pass
-
-  # TODO: add back in once alternative brake checksum/counter validation is added
-  # def test_alt_brake_rx_hook(self):
-  #   self.safety.set_honda_alt_brake_msg(1)
-  #   self.safety.set_controls_allowed(1)
-  #   to_push = self._alt_brake_msg(0)
-  #   self.assertTrue(self._rx(to_push))
-  #   to_push[0].RDLR = to_push[0].RDLR & 0xFFF0FFFF # invalidate checksum
-  #   self.assertFalse(self._rx(to_push))
-  #   self.assertFalse(self.safety.get_controls_allowed())
-  def test_alt_disengage_on_brake(self):
-    self.safety.set_honda_alt_brake_msg(1)
-    self.safety.set_controls_allowed(1)
-    self._rx(self._alt_brake_msg(1))
-    self.assertFalse(self.safety.get_controls_allowed())
-
-    self.safety.set_honda_alt_brake_msg(0)
-    self.safety.set_controls_allowed(1)
-    self._rx(self._alt_brake_msg(1))
-    self.assertTrue(self.safety.get_controls_allowed())
-
-
-class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase, unittest.TestCase):
+class TestHondaBoschSafety(HondaBaseTestCases.HondaPcmEnableBase, HondaBaseTestCases.TestHondaBoschSafetyBase):
   """
     Covers the Honda Bosch safety mode with stock longitudinal
   """
@@ -474,7 +466,7 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase, unittes
     self.assertTrue(self._tx(self._button_msg(Btn.RESUME)))
 
 
-class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase, unittest.TestCase):
+class TestHondaBoschLongSafety(HondaBaseTestCases.HondaButtonEnableBase, HondaBaseTestCases.TestHondaBoschSafetyBase):
   """
     Covers the Honda Bosch safety mode with longitudinal control
   """

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -59,7 +59,7 @@ def checksum(msg):
 
   return addr, t, ret, bus
 
-class TestHyundaiSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestHyundaiSafety(common.BaseTestCases.PandaSafetyTest):
   TX_MSGS = [[832, 0], [1265, 0], [1157, 0]]
   STANDSTILL_THRESHOLD = 30  # ~1kph
   RELAY_MALFUNCTION_ADDR = 832
@@ -223,7 +223,7 @@ class TestHyundaiSafety(common.PandaSafetyTest, unittest.TestCase):
       self.assertEqual(enabled, self._tx(self._button_msg(Buttons.CANCEL)))
 
 
-class TestHyundaiLegacySafety(TestHyundaiSafety, unittest.TestCase):
+class TestHyundaiLegacySafety(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpandasafety_py.libpandasafety
@@ -231,7 +231,7 @@ class TestHyundaiLegacySafety(TestHyundaiSafety, unittest.TestCase):
     self.safety.init_tests()
 
 
-class TestHyundaiLegacySafetyEV(TestHyundaiSafety, unittest.TestCase):
+class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpandasafety_py.libpandasafety
@@ -243,7 +243,7 @@ class TestHyundaiLegacySafetyEV(TestHyundaiSafety, unittest.TestCase):
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
 
 
-class TestHyundaiLegacySafetyHEV(TestHyundaiSafety, unittest.TestCase):
+class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpandasafety_py.libpandasafety
@@ -254,7 +254,7 @@ class TestHyundaiLegacySafetyHEV(TestHyundaiSafety, unittest.TestCase):
     values = {"CR_Vcu_AccPedDep_Pos": gas}
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
 
-class TestHyundaiLongitudinalSafety(TestHyundaiSafety, unittest.TestCase):
+class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
   TX_MSGS = [[832, 0], [1265, 0], [1157, 0], [1056, 0], [1057, 0], [1290, 0], [905, 0], [1186, 0], [909, 0], [1155, 0], [2000, 0]]
   cnt_button = 0
 

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -59,7 +59,7 @@ def checksum(msg):
 
   return addr, t, ret, bus
 
-class TestHyundaiSafety(common.PandaSafetyTest):
+class TestHyundaiSafety(common.PandaSafetyTest, unittest.TestCase):
   TX_MSGS = [[832, 0], [1265, 0], [1157, 0]]
   STANDSTILL_THRESHOLD = 30  # ~1kph
   RELAY_MALFUNCTION_ADDR = 832
@@ -223,7 +223,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
       self.assertEqual(enabled, self._tx(self._button_msg(Buttons.CANCEL)))
 
 
-class TestHyundaiLegacySafety(TestHyundaiSafety):
+class TestHyundaiLegacySafety(TestHyundaiSafety, unittest.TestCase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpandasafety_py.libpandasafety
@@ -231,7 +231,7 @@ class TestHyundaiLegacySafety(TestHyundaiSafety):
     self.safety.init_tests()
 
 
-class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
+class TestHyundaiLegacySafetyEV(TestHyundaiSafety, unittest.TestCase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpandasafety_py.libpandasafety
@@ -243,7 +243,7 @@ class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
 
 
-class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
+class TestHyundaiLegacySafetyHEV(TestHyundaiSafety, unittest.TestCase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")
     self.safety = libpandasafety_py.libpandasafety
@@ -254,7 +254,7 @@ class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
     values = {"CR_Vcu_AccPedDep_Pos": gas}
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
 
-class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
+class TestHyundaiLongitudinalSafety(TestHyundaiSafety, unittest.TestCase):
   TX_MSGS = [[832, 0], [1265, 0], [1157, 0], [1056, 0], [1057, 0], [1290, 0], [905, 0], [1186, 0], [909, 0], [1155, 0], [2000, 0]]
   cnt_button = 0
 

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -16,7 +16,7 @@ DRIVER_TORQUE_ALLOWANCE = 15
 DRIVER_TORQUE_FACTOR = 1
 
 
-class TestMazdaSafety(common.PandaSafetyTest):
+class TestMazdaSafety(common.PandaSafetyTest, unittest.TestCase):
 
   TX_MSGS = [[0x243, 0], [0x09d, 0], [0x440, 0]]
   STANDSTILL_THRESHOLD = .1

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -16,7 +16,7 @@ DRIVER_TORQUE_ALLOWANCE = 15
 DRIVER_TORQUE_FACTOR = 1
 
 
-class TestMazdaSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestMazdaSafety(common.BaseTestCases.PandaSafetyTest):
 
   TX_MSGS = [[0x243, 0], [0x09d, 0], [0x440, 0]]
   STANDSTILL_THRESHOLD = .1

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -15,7 +15,7 @@ def sign(a):
   return 1 if a > 0 else -1
 
 
-class TestNissanSafety(common.PandaSafetyTest):
+class TestNissanSafety(common.PandaSafetyTest, unittest.TestCase):
 
   TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x20b, 2], [0x280, 2]]
   STANDSTILL_THRESHOLD = 0
@@ -141,7 +141,7 @@ class TestNissanSafety(common.PandaSafetyTest):
         tx = self._tx(self._acc_button_cmd(**args))
         self.assertEqual(tx, should_tx)
 
-class TestNissanLeafSafety(TestNissanSafety):
+class TestNissanLeafSafety(TestNissanSafety, unittest.TestCase):
 
   def setUp(self):
     self.packer = CANPackerPanda("nissan_leaf_2018")

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -15,7 +15,7 @@ def sign(a):
   return 1 if a > 0 else -1
 
 
-class TestNissanSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestNissanSafety(common.BaseTestCases.PandaSafetyTest):
 
   TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x20b, 2], [0x280, 2]]
   STANDSTILL_THRESHOLD = 0
@@ -141,7 +141,7 @@ class TestNissanSafety(common.PandaSafetyTest, unittest.TestCase):
         tx = self._tx(self._acc_button_cmd(**args))
         self.assertEqual(tx, should_tx)
 
-class TestNissanLeafSafety(TestNissanSafety, unittest.TestCase):
+class TestNissanLeafSafety(TestNissanSafety):
 
   def setUp(self):
     self.packer = CANPackerPanda("nissan_leaf_2018")

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -17,7 +17,7 @@ DRIVER_TORQUE_ALLOWANCE = 60
 DRIVER_TORQUE_FACTOR = 10
 
 
-class TestSubaruSafety(common.PandaSafetyTest):
+class TestSubaruSafety(common.PandaSafetyTest, unittest.TestCase):
   cnt_gas = 0
   cnt_torque_driver = 0
   cnt_cruise = 0

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -17,7 +17,7 @@ DRIVER_TORQUE_ALLOWANCE = 60
 DRIVER_TORQUE_FACTOR = 10
 
 
-class TestSubaruSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestSubaruSafety(common.BaseTestCases.PandaSafetyTest):
   cnt_gas = 0
   cnt_torque_driver = 0
   cnt_cruise = 0

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -17,7 +17,7 @@ DRIVER_TORQUE_ALLOWANCE = 75
 DRIVER_TORQUE_FACTOR = 10
 
 
-class TestSubaruLegacySafety(common.PandaSafetyTest, unittest.TestCase):
+class TestSubaruLegacySafety(common.BaseTestCases.PandaSafetyTest):
   cnt_gas = 0
 
   TX_MSGS = [[0x161, 0], [0x164, 0]]

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -17,7 +17,7 @@ DRIVER_TORQUE_ALLOWANCE = 75
 DRIVER_TORQUE_FACTOR = 10
 
 
-class TestSubaruLegacySafety(common.PandaSafetyTest):
+class TestSubaruLegacySafety(common.PandaSafetyTest, unittest.TestCase):
   cnt_gas = 0
 
   TX_MSGS = [[0x161, 0], [0x164, 0]]

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -10,8 +10,8 @@ from panda.tests.safety.common import CANPackerPanda, make_msg, UNSAFE_MODE
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
 
-class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
-                       common.TorqueSteeringSafetyTest, unittest.TestCase):
+class TestToyotaSafety(common.BaseTestCases.PandaSafetyTest, common.BaseTestCases.InterceptorSafetyTest,
+                       common.BaseTestCases.TorqueSteeringSafetyTest):
 
   TX_MSGS = [[0x283, 0], [0x2E6, 0], [0x2E7, 0], [0x33E, 0], [0x344, 0], [0x365, 0], [0x366, 0], [0x4CB, 0],  # DSU bus 0
              [0x128, 1], [0x141, 1], [0x160, 1], [0x161, 1], [0x470, 1],  # DSU bus 1

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -11,7 +11,7 @@ MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
 
 class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
-                       common.TorqueSteeringSafetyTest):
+                       common.TorqueSteeringSafetyTest, unittest.TestCase):
 
   TX_MSGS = [[0x283, 0], [0x2E6, 0], [0x2E7, 0], [0x33E, 0], [0x344, 0], [0x365, 0], [0x366, 0], [0x4CB, 0],  # DSU bus 0
              [0x128, 1], [0x141, 1], [0x160, 1], [0x161, 1], [0x470, 1],  # DSU bus 1

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -25,7 +25,7 @@ MSG_GRA_ACC_01 = 0x12B  # TX by OP, ACC control buttons for cancel/resume
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenMqbSafety(common.PandaSafetyTest):
+class TestVolkswagenMqbSafety(common.PandaSafetyTest, unittest.TestCase):
   cnt_lh_eps_03 = 0
   cnt_esp_05 = 0
   cnt_tsk_06 = 0
@@ -247,7 +247,7 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
     self.assertTrue(self.safety.get_controls_allowed())
 
 
-class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
+class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety, unittest.TestCase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -25,222 +25,223 @@ MSG_GRA_ACC_01 = 0x12B  # TX by OP, ACC control buttons for cancel/resume
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenMqbSafetyBase(common.PandaSafetyTest):
-  cnt_lh_eps_03 = 0
-  cnt_esp_05 = 0
-  cnt_tsk_06 = 0
-  cnt_motor_20 = 0
-  cnt_hca_01 = 0
-  cnt_gra_acc_01 = 0
+class VolkswagenBaseTestCases:
+  class TestVolkswagenMqbSafetyBase(common.BaseTestCases.PandaSafetyTest):
+    cnt_lh_eps_03 = 0
+    cnt_esp_05 = 0
+    cnt_tsk_06 = 0
+    cnt_motor_20 = 0
+    cnt_hca_01 = 0
+    cnt_gra_acc_01 = 0
 
-  STANDSTILL_THRESHOLD = 1
-  RELAY_MALFUNCTION_ADDR = MSG_HCA_01
-  RELAY_MALFUNCTION_BUS = 0
+    STANDSTILL_THRESHOLD = 1
+    RELAY_MALFUNCTION_ADDR = MSG_HCA_01
+    RELAY_MALFUNCTION_BUS = 0
 
-  def _set_prev_torque(self, t):
-    self.safety.set_desired_torque_last(t)
-    self.safety.set_rt_torque_last(t)
+    def _set_prev_torque(self, t):
+      self.safety.set_desired_torque_last(t)
+      self.safety.set_rt_torque_last(t)
 
-  # Wheel speeds _esp_19_msg
-  def _speed_msg(self, speed):
-    values = {"ESP_%s_Radgeschw_02" % s: speed for s in ["HL", "HR", "VL", "VR"]}
-    return self.packer.make_can_msg_panda("ESP_19", 0, values)
+    # Wheel speeds _esp_19_msg
+    def _speed_msg(self, speed):
+      values = {"ESP_%s_Radgeschw_02" % s: speed for s in ["HL", "HR", "VL", "VR"]}
+      return self.packer.make_can_msg_panda("ESP_19", 0, values)
 
-  # Brake light switch _esp_05_msg
-  def _brake_msg(self, brake):
-    values = {"ESP_Fahrer_bremst": brake, "COUNTER": self.cnt_esp_05 % 16}
-    self.__class__.cnt_esp_05 += 1
-    return self.packer.make_can_msg_panda("ESP_05", 0, values)
+    # Brake light switch _esp_05_msg
+    def _brake_msg(self, brake):
+      values = {"ESP_Fahrer_bremst": brake, "COUNTER": self.cnt_esp_05 % 16}
+      self.__class__.cnt_esp_05 += 1
+      return self.packer.make_can_msg_panda("ESP_05", 0, values)
 
-  # Driver throttle input
-  def _gas_msg(self, gas):
-    values = {"MO_Fahrpedalrohwert_01": gas, "COUNTER": self.cnt_motor_20 % 16}
-    self.__class__.cnt_motor_20 += 1
-    return self.packer.make_can_msg_panda("Motor_20", 0, values)
+    # Driver throttle input
+    def _gas_msg(self, gas):
+      values = {"MO_Fahrpedalrohwert_01": gas, "COUNTER": self.cnt_motor_20 % 16}
+      self.__class__.cnt_motor_20 += 1
+      return self.packer.make_can_msg_panda("Motor_20", 0, values)
 
-  # ACC engagement status
-  def _pcm_status_msg(self, enable):
-    values = {"TSK_Status": 3 if enable else 1, "COUNTER": self.cnt_tsk_06 % 16}
-    self.__class__.cnt_tsk_06 += 1
-    return self.packer.make_can_msg_panda("TSK_06", 0, values)
+    # ACC engagement status
+    def _pcm_status_msg(self, enable):
+      values = {"TSK_Status": 3 if enable else 1, "COUNTER": self.cnt_tsk_06 % 16}
+      self.__class__.cnt_tsk_06 += 1
+      return self.packer.make_can_msg_panda("TSK_06", 0, values)
 
-  # Driver steering input torque
-  def _lh_eps_03_msg(self, torque):
-    values = {"EPS_Lenkmoment": abs(torque), "EPS_VZ_Lenkmoment": torque < 0,
-              "COUNTER": self.cnt_lh_eps_03 % 16}
-    self.__class__.cnt_lh_eps_03 += 1
-    return self.packer.make_can_msg_panda("LH_EPS_03", 0, values)
+    # Driver steering input torque
+    def _lh_eps_03_msg(self, torque):
+      values = {"EPS_Lenkmoment": abs(torque), "EPS_VZ_Lenkmoment": torque < 0,
+                "COUNTER": self.cnt_lh_eps_03 % 16}
+      self.__class__.cnt_lh_eps_03 += 1
+      return self.packer.make_can_msg_panda("LH_EPS_03", 0, values)
 
-  # openpilot steering output torque
-  def _hca_01_msg(self, torque):
-    values = {"Assist_Torque": abs(torque), "Assist_VZ": torque < 0,
-              "COUNTER": self.cnt_hca_01 % 16}
-    self.__class__.cnt_hca_01 += 1
-    return self.packer.make_can_msg_panda("HCA_01", 0, values)
+    # openpilot steering output torque
+    def _hca_01_msg(self, torque):
+      values = {"Assist_Torque": abs(torque), "Assist_VZ": torque < 0,
+                "COUNTER": self.cnt_hca_01 % 16}
+      self.__class__.cnt_hca_01 += 1
+      return self.packer.make_can_msg_panda("HCA_01", 0, values)
 
-  # Cruise control buttons
-  def _gra_acc_01_msg(self, cancel=0, resume=0, _set=0):
-    values = {"GRA_Abbrechen": cancel, "GRA_Tip_Setzen": _set,
-              "GRA_Tip_Wiederaufnahme": resume, "COUNTER": self.cnt_gra_acc_01 % 16}
-    self.__class__.cnt_gra_acc_01 += 1
-    return self.packer.make_can_msg_panda("GRA_ACC_01", 0, values)
+    # Cruise control buttons
+    def _gra_acc_01_msg(self, cancel=0, resume=0, _set=0):
+      values = {"GRA_Abbrechen": cancel, "GRA_Tip_Setzen": _set,
+                "GRA_Tip_Wiederaufnahme": resume, "COUNTER": self.cnt_gra_acc_01 % 16}
+      self.__class__.cnt_gra_acc_01 += 1
+      return self.packer.make_can_msg_panda("GRA_ACC_01", 0, values)
 
-  def test_steer_safety_check(self):
-    for enabled in [0, 1]:
-      for t in range(-500, 500):
-        self.safety.set_controls_allowed(enabled)
-        self._set_prev_torque(t)
-        if abs(t) > MAX_STEER or (not enabled and abs(t) > 0):
-          self.assertFalse(self._tx(self._hca_01_msg(t)))
-        else:
+    def test_steer_safety_check(self):
+      for enabled in [0, 1]:
+        for t in range(-500, 500):
+          self.safety.set_controls_allowed(enabled)
+          self._set_prev_torque(t)
+          if abs(t) > MAX_STEER or (not enabled and abs(t) > 0):
+            self.assertFalse(self._tx(self._hca_01_msg(t)))
+          else:
+            self.assertTrue(self._tx(self._hca_01_msg(t)))
+
+    def test_non_realtime_limit_up(self):
+      self.safety.set_torque_driver(0, 0)
+      self.safety.set_controls_allowed(True)
+
+      self._set_prev_torque(0)
+      self.assertTrue(self._tx(self._hca_01_msg(MAX_RATE_UP)))
+      self._set_prev_torque(0)
+      self.assertTrue(self._tx(self._hca_01_msg(-MAX_RATE_UP)))
+
+      self._set_prev_torque(0)
+      self.assertFalse(self._tx(self._hca_01_msg(MAX_RATE_UP + 1)))
+      self.safety.set_controls_allowed(True)
+      self._set_prev_torque(0)
+      self.assertFalse(self._tx(self._hca_01_msg(-MAX_RATE_UP - 1)))
+
+    def test_non_realtime_limit_down(self):
+      self.safety.set_torque_driver(0, 0)
+      self.safety.set_controls_allowed(True)
+
+    def test_against_torque_driver(self):
+      self.safety.set_controls_allowed(True)
+
+      for sign in [-1, 1]:
+        for t in np.arange(0, DRIVER_TORQUE_ALLOWANCE + 1, 1):
+          t *= -sign
+          self.safety.set_torque_driver(t, t)
+          self._set_prev_torque(MAX_STEER * sign)
+          self.assertTrue(self._tx(self._hca_01_msg(MAX_STEER * sign)))
+
+        self.safety.set_torque_driver(DRIVER_TORQUE_ALLOWANCE + 1, DRIVER_TORQUE_ALLOWANCE + 1)
+        self.assertFalse(self._tx(self._hca_01_msg(-MAX_STEER)))
+
+      # spot check some individual cases
+      for sign in [-1, 1]:
+        driver_torque = (DRIVER_TORQUE_ALLOWANCE + 10) * sign
+        torque_desired = (MAX_STEER - 10 * DRIVER_TORQUE_FACTOR) * sign
+        delta = 1 * sign
+        self._set_prev_torque(torque_desired)
+        self.safety.set_torque_driver(-driver_torque, -driver_torque)
+        self.assertTrue(self._tx(self._hca_01_msg(torque_desired)))
+        self._set_prev_torque(torque_desired + delta)
+        self.safety.set_torque_driver(-driver_torque, -driver_torque)
+        self.assertFalse(self._tx(self._hca_01_msg(torque_desired + delta)))
+
+        self._set_prev_torque(MAX_STEER * sign)
+        self.safety.set_torque_driver(-MAX_STEER * sign, -MAX_STEER * sign)
+        self.assertTrue(self._tx(self._hca_01_msg((MAX_STEER - MAX_RATE_DOWN) * sign)))
+        self._set_prev_torque(MAX_STEER * sign)
+        self.safety.set_torque_driver(-MAX_STEER * sign, -MAX_STEER * sign)
+        self.assertTrue(self._tx(self._hca_01_msg(0)))
+        self._set_prev_torque(MAX_STEER * sign)
+        self.safety.set_torque_driver(-MAX_STEER * sign, -MAX_STEER * sign)
+        self.assertFalse(self._tx(self._hca_01_msg((MAX_STEER - MAX_RATE_DOWN + 1) * sign)))
+
+    def test_realtime_limits(self):
+      self.safety.set_controls_allowed(True)
+
+      for sign in [-1, 1]:
+        self.safety.init_tests()
+        self._set_prev_torque(0)
+        self.safety.set_torque_driver(0, 0)
+        for t in np.arange(0, MAX_RT_DELTA, 1):
+          t *= sign
+          self.assertTrue(self._tx(self._hca_01_msg(t)))
+        self.assertFalse(self._tx(self._hca_01_msg(sign * (MAX_RT_DELTA + 1))))
+
+        self._set_prev_torque(0)
+        for t in np.arange(0, MAX_RT_DELTA, 1):
+          t *= sign
           self.assertTrue(self._tx(self._hca_01_msg(t)))
 
-  def test_non_realtime_limit_up(self):
-    self.safety.set_torque_driver(0, 0)
-    self.safety.set_controls_allowed(True)
+        # Increase timer to update rt_torque_last
+        self.safety.set_timer(RT_INTERVAL + 1)
+        self.assertTrue(self._tx(self._hca_01_msg(sign * (MAX_RT_DELTA - 1))))
+        self.assertTrue(self._tx(self._hca_01_msg(sign * (MAX_RT_DELTA + 1))))
 
-    self._set_prev_torque(0)
-    self.assertTrue(self._tx(self._hca_01_msg(MAX_RATE_UP)))
-    self._set_prev_torque(0)
-    self.assertTrue(self._tx(self._hca_01_msg(-MAX_RATE_UP)))
+    def test_torque_measurements(self):
+      self._rx(self._lh_eps_03_msg(50))
+      self._rx(self._lh_eps_03_msg(-50))
+      self._rx(self._lh_eps_03_msg(0))
+      self._rx(self._lh_eps_03_msg(0))
+      self._rx(self._lh_eps_03_msg(0))
+      self._rx(self._lh_eps_03_msg(0))
 
-    self._set_prev_torque(0)
-    self.assertFalse(self._tx(self._hca_01_msg(MAX_RATE_UP + 1)))
-    self.safety.set_controls_allowed(True)
-    self._set_prev_torque(0)
-    self.assertFalse(self._tx(self._hca_01_msg(-MAX_RATE_UP - 1)))
+      self.assertEqual(-50, self.safety.get_torque_driver_min())
+      self.assertEqual(50, self.safety.get_torque_driver_max())
 
-  def test_non_realtime_limit_down(self):
-    self.safety.set_torque_driver(0, 0)
-    self.safety.set_controls_allowed(True)
+      self._rx(self._lh_eps_03_msg(0))
+      self.assertEqual(0, self.safety.get_torque_driver_max())
+      self.assertEqual(-50, self.safety.get_torque_driver_min())
 
-  def test_against_torque_driver(self):
-    self.safety.set_controls_allowed(True)
+      self._rx(self._lh_eps_03_msg(0))
+      self.assertEqual(0, self.safety.get_torque_driver_max())
+      self.assertEqual(0, self.safety.get_torque_driver_min())
 
-    for sign in [-1, 1]:
-      for t in np.arange(0, DRIVER_TORQUE_ALLOWANCE + 1, 1):
-        t *= -sign
-        self.safety.set_torque_driver(t, t)
-        self._set_prev_torque(MAX_STEER * sign)
-        self.assertTrue(self._tx(self._hca_01_msg(MAX_STEER * sign)))
+    def test_rx_hook(self):
+      # checksum checks
+      # TODO: Would be ideal to check ESP_19 as well, but it has no checksum
+      # or counter, and I'm not sure if we can easily validate Panda's simple
+      # temporal reception-rate check here.
+      for msg in [MSG_LH_EPS_03, MSG_ESP_05, MSG_TSK_06, MSG_MOTOR_20]:
+        self.safety.set_controls_allowed(1)
+        if msg == MSG_LH_EPS_03:
+          to_push = self._lh_eps_03_msg(0)
+        if msg == MSG_ESP_05:
+          to_push = self._brake_msg(False)
+        if msg == MSG_TSK_06:
+          to_push = self._pcm_status_msg(True)
+        if msg == MSG_MOTOR_20:
+          to_push = self._gas_msg(0)
+        self.assertTrue(self._rx(to_push))
+        to_push[0].data[4] ^= 0xFF
+        self.assertFalse(self._rx(to_push))
+        self.assertFalse(self.safety.get_controls_allowed())
 
-      self.safety.set_torque_driver(DRIVER_TORQUE_ALLOWANCE + 1, DRIVER_TORQUE_ALLOWANCE + 1)
-      self.assertFalse(self._tx(self._hca_01_msg(-MAX_STEER)))
+      # counter
+      # reset wrong_counters to zero by sending valid messages
+      for i in range(MAX_WRONG_COUNTERS + 1):
+        self.__class__.cnt_lh_eps_03 += 1
+        self.__class__.cnt_esp_05 += 1
+        self.__class__.cnt_tsk_06 += 1
+        self.__class__.cnt_motor_20 += 1
+        if i < MAX_WRONG_COUNTERS:
+          self.safety.set_controls_allowed(1)
+          self._rx(self._lh_eps_03_msg(0))
+          self._rx(self._brake_msg(False))
+          self._rx(self._pcm_status_msg(True))
+          self._rx(self._gas_msg(0))
+        else:
+          self.assertFalse(self._rx(self._lh_eps_03_msg(0)))
+          self.assertFalse(self._rx(self._brake_msg(False)))
+          self.assertFalse(self._rx(self._pcm_status_msg(True)))
+          self.assertFalse(self._rx(self._gas_msg(0)))
+          self.assertFalse(self.safety.get_controls_allowed())
 
-    # spot check some individual cases
-    for sign in [-1, 1]:
-      driver_torque = (DRIVER_TORQUE_ALLOWANCE + 10) * sign
-      torque_desired = (MAX_STEER - 10 * DRIVER_TORQUE_FACTOR) * sign
-      delta = 1 * sign
-      self._set_prev_torque(torque_desired)
-      self.safety.set_torque_driver(-driver_torque, -driver_torque)
-      self.assertTrue(self._tx(self._hca_01_msg(torque_desired)))
-      self._set_prev_torque(torque_desired + delta)
-      self.safety.set_torque_driver(-driver_torque, -driver_torque)
-      self.assertFalse(self._tx(self._hca_01_msg(torque_desired + delta)))
-
-      self._set_prev_torque(MAX_STEER * sign)
-      self.safety.set_torque_driver(-MAX_STEER * sign, -MAX_STEER * sign)
-      self.assertTrue(self._tx(self._hca_01_msg((MAX_STEER - MAX_RATE_DOWN) * sign)))
-      self._set_prev_torque(MAX_STEER * sign)
-      self.safety.set_torque_driver(-MAX_STEER * sign, -MAX_STEER * sign)
-      self.assertTrue(self._tx(self._hca_01_msg(0)))
-      self._set_prev_torque(MAX_STEER * sign)
-      self.safety.set_torque_driver(-MAX_STEER * sign, -MAX_STEER * sign)
-      self.assertFalse(self._tx(self._hca_01_msg((MAX_STEER - MAX_RATE_DOWN + 1) * sign)))
-
-  def test_realtime_limits(self):
-    self.safety.set_controls_allowed(True)
-
-    for sign in [-1, 1]:
-      self.safety.init_tests()
-      self._set_prev_torque(0)
-      self.safety.set_torque_driver(0, 0)
-      for t in np.arange(0, MAX_RT_DELTA, 1):
-        t *= sign
-        self.assertTrue(self._tx(self._hca_01_msg(t)))
-      self.assertFalse(self._tx(self._hca_01_msg(sign * (MAX_RT_DELTA + 1))))
-
-      self._set_prev_torque(0)
-      for t in np.arange(0, MAX_RT_DELTA, 1):
-        t *= sign
-        self.assertTrue(self._tx(self._hca_01_msg(t)))
-
-      # Increase timer to update rt_torque_last
-      self.safety.set_timer(RT_INTERVAL + 1)
-      self.assertTrue(self._tx(self._hca_01_msg(sign * (MAX_RT_DELTA - 1))))
-      self.assertTrue(self._tx(self._hca_01_msg(sign * (MAX_RT_DELTA + 1))))
-
-  def test_torque_measurements(self):
-    self._rx(self._lh_eps_03_msg(50))
-    self._rx(self._lh_eps_03_msg(-50))
-    self._rx(self._lh_eps_03_msg(0))
-    self._rx(self._lh_eps_03_msg(0))
-    self._rx(self._lh_eps_03_msg(0))
-    self._rx(self._lh_eps_03_msg(0))
-
-    self.assertEqual(-50, self.safety.get_torque_driver_min())
-    self.assertEqual(50, self.safety.get_torque_driver_max())
-
-    self._rx(self._lh_eps_03_msg(0))
-    self.assertEqual(0, self.safety.get_torque_driver_max())
-    self.assertEqual(-50, self.safety.get_torque_driver_min())
-
-    self._rx(self._lh_eps_03_msg(0))
-    self.assertEqual(0, self.safety.get_torque_driver_max())
-    self.assertEqual(0, self.safety.get_torque_driver_min())
-
-  def test_rx_hook(self):
-    # checksum checks
-    # TODO: Would be ideal to check ESP_19 as well, but it has no checksum
-    # or counter, and I'm not sure if we can easily validate Panda's simple
-    # temporal reception-rate check here.
-    for msg in [MSG_LH_EPS_03, MSG_ESP_05, MSG_TSK_06, MSG_MOTOR_20]:
-      self.safety.set_controls_allowed(1)
-      if msg == MSG_LH_EPS_03:
-        to_push = self._lh_eps_03_msg(0)
-      if msg == MSG_ESP_05:
-        to_push = self._brake_msg(False)
-      if msg == MSG_TSK_06:
-        to_push = self._pcm_status_msg(True)
-      if msg == MSG_MOTOR_20:
-        to_push = self._gas_msg(0)
-      self.assertTrue(self._rx(to_push))
-      to_push[0].data[4] ^= 0xFF
-      self.assertFalse(self._rx(to_push))
-      self.assertFalse(self.safety.get_controls_allowed())
-
-    # counter
-    # reset wrong_counters to zero by sending valid messages
-    for i in range(MAX_WRONG_COUNTERS + 1):
-      self.__class__.cnt_lh_eps_03 += 1
-      self.__class__.cnt_esp_05 += 1
-      self.__class__.cnt_tsk_06 += 1
-      self.__class__.cnt_motor_20 += 1
-      if i < MAX_WRONG_COUNTERS:
+      # restore counters for future tests with a couple of good messages
+      for i in range(2):
         self.safety.set_controls_allowed(1)
         self._rx(self._lh_eps_03_msg(0))
         self._rx(self._brake_msg(False))
         self._rx(self._pcm_status_msg(True))
         self._rx(self._gas_msg(0))
-      else:
-        self.assertFalse(self._rx(self._lh_eps_03_msg(0)))
-        self.assertFalse(self._rx(self._brake_msg(False)))
-        self.assertFalse(self._rx(self._pcm_status_msg(True)))
-        self.assertFalse(self._rx(self._gas_msg(0)))
-        self.assertFalse(self.safety.get_controls_allowed())
-
-    # restore counters for future tests with a couple of good messages
-    for i in range(2):
-      self.safety.set_controls_allowed(1)
-      self._rx(self._lh_eps_03_msg(0))
-      self._rx(self._brake_msg(False))
-      self._rx(self._pcm_status_msg(True))
-      self._rx(self._gas_msg(0))
-    self.assertTrue(self.safety.get_controls_allowed())
+      self.assertTrue(self.safety.get_controls_allowed())
 
 
-class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafetyBase, unittest.TestCase):
+class TestVolkswagenMqbStockSafety(VolkswagenBaseTestCases.TestVolkswagenMqbSafetyBase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -25,7 +25,7 @@ MSG_GRA_ACC_01 = 0x12B  # TX by OP, ACC control buttons for cancel/resume
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenMqbSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestVolkswagenMqbSafetyBase(common.PandaSafetyTest):
   cnt_lh_eps_03 = 0
   cnt_esp_05 = 0
   cnt_tsk_06 = 0
@@ -36,13 +36,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest, unittest.TestCase):
   STANDSTILL_THRESHOLD = 1
   RELAY_MALFUNCTION_ADDR = MSG_HCA_01
   RELAY_MALFUNCTION_BUS = 0
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestVolkswagenMqbSafety":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
@@ -247,7 +240,7 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest, unittest.TestCase):
     self.assertTrue(self.safety.get_controls_allowed())
 
 
-class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety, unittest.TestCase):
+class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafetyBase, unittest.TestCase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -33,7 +33,7 @@ def volkswagen_pq_checksum(msg, addr, len_msg):
     checksum ^= i
   return checksum
 
-class TestVolkswagenPqSafety(common.PandaSafetyTest, unittest.TestCase):
+class TestVolkswagenPqSafety(common.BaseTestCases.PandaSafetyTest):
   cruise_engaged = False
   cnt_lenkhilfe_3 = 0
   cnt_hca_1 = 0

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -33,7 +33,7 @@ def volkswagen_pq_checksum(msg, addr, len_msg):
     checksum ^= i
   return checksum
 
-class TestVolkswagenPqSafety(common.PandaSafetyTest):
+class TestVolkswagenPqSafety(common.PandaSafetyTest, unittest.TestCase):
   cruise_engaged = False
   cnt_lenkhilfe_3 = 0
   cnt_hca_1 = 0


### PR DESCRIPTION
We were calling `common.InterceptorSafetyTest.setUpClass()` from a Honda test, however its `setUpClass` checks if the class name is itself and if so, then skip the test. However, when calling from a child `cls.__name__` was always the parent, so it just skipped those tests.