### PR TITLE
Honda: fix missing interceptor tests

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -60,9 +60,6 @@ class InterceptorSafetyTest(PandaSafetyTestBase):
       cls.safety = None
       raise unittest.SkipTest
 
-    # make sure interceptor is detected
-    cls._rx(cls._interceptor_msg(0, 0x201)) # pylint: disable=no-value-for-parameter
-
   @abc.abstractmethod
   def _interceptor_msg(self, gas, addr):
     pass

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -379,7 +379,6 @@ class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.InterceptorSa
   """
     Covers the Honda Nidec safety mode with a gas interceptor
   """
-  pass
 
 
 class TestHondaNidecAltSafety(TestHondaNidecSafety):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -379,9 +379,7 @@ class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.InterceptorSa
   """
     Covers the Honda Nidec safety mode with a gas interceptor
   """
-  def setUp(self):
-    TestHondaNidecSafety.setUpClass()
-    common.InterceptorSafetyTest.setUpClass()
+  pass
 
 
 class TestHondaNidecAltSafety(TestHondaNidecSafety):
@@ -414,7 +412,6 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     self.safety = libpandasafety_py.libpandasafety
     self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
     self.safety.init_tests_honda()
-    common.InterceptorSafetyTest.setUpClass()
 
   def _acc_state_msg(self, main_on):
     values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -379,6 +379,7 @@ class TestHondaNidecInterceptorSafety(TestHondaNidecSafety, common.InterceptorSa
   """
     Covers the Honda Nidec safety mode with a gas interceptor
   """
+  pass
 
 
 class TestHondaNidecAltSafety(TestHondaNidecSafety):


### PR DESCRIPTION
We were calling `common.InterceptorSafetyTest.setUpClass()` from a Honda test, however its `setUpClass` checks if the class name is itself and if so, then skip the test. However, when calling from a child `cls.__name__` was always the parent, so it just skipped those tests.