### PR TITLE
safety tests: rename gas/brake message functions

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -266,7 +266,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
       raise unittest.SkipTest
 
   @abc.abstractmethod
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     pass
 
   @abc.abstractmethod
@@ -274,7 +274,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
     pass
 
   @abc.abstractmethod
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     pass
 
   @abc.abstractmethod
@@ -332,36 +332,36 @@ class PandaSafetyTest(PandaSafetyTestBase):
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())
     for pressed in [self.GAS_PRESSED_THRESHOLD + 1, 0]:
-      self._rx(self._gas_msg(pressed))
+      self._rx(self._user_gas_msg(pressed))
       self.assertEqual(bool(pressed), self.safety.get_gas_pressed_prev())
 
   def test_allow_engage_with_gas_pressed(self):
-    self._rx(self._gas_msg(1))
+    self._rx(self._user_gas_msg(1))
     self.safety.set_controls_allowed(True)
-    self._rx(self._gas_msg(1))
+    self._rx(self._user_gas_msg(1))
     self.assertTrue(self.safety.get_controls_allowed())
-    self._rx(self._gas_msg(1))
+    self._rx(self._user_gas_msg(1))
     self.assertTrue(self.safety.get_controls_allowed())
 
   def test_disengage_on_gas(self):
-    self._rx(self._gas_msg(0))
+    self._rx(self._user_gas_msg(0))
     self.safety.set_controls_allowed(True)
-    self._rx(self._gas_msg(self.GAS_PRESSED_THRESHOLD + 1))
+    self._rx(self._user_gas_msg(self.GAS_PRESSED_THRESHOLD + 1))
     self.assertFalse(self.safety.get_controls_allowed())
 
   def test_alternative_experience_no_disengage_on_gas(self):
-    self._rx(self._gas_msg(0))
+    self._rx(self._user_gas_msg(0))
     self.safety.set_controls_allowed(True)
     self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS)
-    self._rx(self._gas_msg(self.GAS_PRESSED_THRESHOLD + 1))
+    self._rx(self._user_gas_msg(self.GAS_PRESSED_THRESHOLD + 1))
     self.assertTrue(self.safety.get_controls_allowed())
 
   def test_prev_brake(self):
     self.assertFalse(self.safety.get_brake_pressed_prev())
     for pressed in [True, False]:
-      self._rx(self._brake_msg(not pressed))
+      self._rx(self._user_brake_msg(not pressed))
       self.assertEqual(not pressed, self.safety.get_brake_pressed_prev())
-      self._rx(self._brake_msg(pressed))
+      self._rx(self._user_brake_msg(pressed))
       self.assertEqual(pressed, self.safety.get_brake_pressed_prev())
 
   def test_enable_control_allowed_from_cruise(self):
@@ -385,26 +385,26 @@ class PandaSafetyTest(PandaSafetyTestBase):
   def test_allow_brake_at_zero_speed(self):
     # Brake was already pressed
     self._rx(self._speed_msg(0))
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.safety.set_controls_allowed(1)
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.assertTrue(self.safety.get_controls_allowed())
-    self._rx(self._brake_msg(0))
+    self._rx(self._user_brake_msg(0))
     self.assertTrue(self.safety.get_controls_allowed())
     # rising edge of brake should disengage
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.assertFalse(self.safety.get_controls_allowed())
-    self._rx(self._brake_msg(0))  # reset no brakes
+    self._rx(self._user_brake_msg(0))  # reset no brakes
 
   def test_not_allow_brake_when_moving(self):
     # Brake was already pressed
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.safety.set_controls_allowed(1)
     self._rx(self._speed_msg(self.STANDSTILL_THRESHOLD))
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.assertTrue(self.safety.get_controls_allowed())
     self._rx(self._speed_msg(self.STANDSTILL_THRESHOLD + 1))
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.assertFalse(self.safety.get_controls_allowed())
     self._rx(self._speed_msg(0))
 

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -10,13 +10,11 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
-
 class ALTERNATIVE_EXPERIENCE:
   DEFAULT = 0
   DISABLE_DISENGAGE_ON_GAS = 1
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
-
 
 def package_can_msg(msg):
   addr, _, dat, bus = msg
@@ -29,17 +27,8 @@ def package_can_msg(msg):
 
   return ret
 
-
-def set_up_test(cls, dbc, safety_mode, safety_param):
-  cls.packer = CANPackerPanda(dbc)
-  cls.safety = libpandasafety_py.libpandasafety
-  cls.safety.set_safety_hooks(safety_mode, safety_param)
-  cls.safety.init_tests_honda()
-
-
 def make_msg(bus, addr, length=8):
   return package_can_msg([addr, 0, b'\x00' * length, bus])
-
 
 class CANPackerPanda(CANPacker):
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=-1, fix_checksum=None):
@@ -47,7 +36,6 @@ class CANPackerPanda(CANPacker):
     if fix_checksum is not None:
       msg = fix_checksum(msg)
     return package_can_msg(msg)
-
 
 class PandaSafetyTestBase(unittest.TestCase):
   @classmethod

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -10,11 +10,13 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
+
 class ALTERNATIVE_EXPERIENCE:
   DEFAULT = 0
   DISABLE_DISENGAGE_ON_GAS = 1
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
+
 
 def package_can_msg(msg):
   addr, _, dat, bus = msg
@@ -27,8 +29,17 @@ def package_can_msg(msg):
 
   return ret
 
+
+def set_up_test(cls, dbc, safety_mode, safety_param):
+  cls.packer = CANPackerPanda(dbc)
+  cls.safety = libpandasafety_py.libpandasafety
+  cls.safety.set_safety_hooks(safety_mode, safety_param)
+  cls.safety.init_tests_honda()
+
+
 def make_msg(bus, addr, length=8):
   return package_can_msg([addr, 0, b'\x00' * length, bus])
+
 
 class CANPackerPanda(CANPacker):
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=-1, fix_checksum=None):
@@ -36,6 +47,7 @@ class CANPackerPanda(CANPacker):
     if fix_checksum is not None:
       msg = fix_checksum(msg)
     return package_can_msg(msg)
+
 
 class PandaSafetyTestBase(unittest.TestCase):
   @classmethod

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -10,11 +10,13 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
+
 class ALTERNATIVE_EXPERIENCE:
   DEFAULT = 0
   DISABLE_DISENGAGE_ON_GAS = 1
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
+
 
 def package_can_msg(msg):
   addr, _, dat, bus = msg
@@ -27,8 +29,10 @@ def package_can_msg(msg):
 
   return ret
 
+
 def make_msg(bus, addr, length=8):
   return package_can_msg([addr, 0, b'\x00' * length, bus])
+
 
 class CANPackerPanda(CANPacker):
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=-1, fix_checksum=None):
@@ -36,6 +40,7 @@ class CANPackerPanda(CANPacker):
     if fix_checksum is not None:
       msg = fix_checksum(msg)
     return package_can_msg(msg)
+
 
 class PandaSafetyTestBase(unittest.TestCase):
   @classmethod
@@ -49,6 +54,7 @@ class PandaSafetyTestBase(unittest.TestCase):
 
   def _tx(self, msg):
     return self.safety.safety_tx_hook(msg)
+
 
 class InterceptorSafetyTest(PandaSafetyTestBase):
 

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -10,11 +10,13 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
+
 class ALTERNATIVE_EXPERIENCE:
   DEFAULT = 0
   DISABLE_DISENGAGE_ON_GAS = 1
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
+
 
 def package_can_msg(msg):
   addr, _, dat, bus = msg
@@ -27,8 +29,10 @@ def package_can_msg(msg):
 
   return ret
 
+
 def make_msg(bus, addr, length=8):
   return package_can_msg([addr, 0, b'\x00' * length, bus])
+
 
 class CANPackerPanda(CANPacker):
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=-1, fix_checksum=None):
@@ -37,12 +41,25 @@ class CANPackerPanda(CANPacker):
       msg = fix_checksum(msg)
     return package_can_msg(msg)
 
+
 class PandaSafetyTestBase(unittest.TestCase):
+
+  SAFETY_PARAM = 0
+
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "PandaSafetyTestBase":
       cls.safety = None
       raise unittest.SkipTest
+
+  def setUp(self):
+    self.packer = CANPackerPanda(self.DBC)
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(self.SAFETY_MODE, self.SAFETY_PARAM)
+    if 'Honda' in self.__class__.__name__:
+      self.safety._init_tests_honda()
+    else:
+      self.safety.init_tests()
 
   def _rx(self, msg):
     return self.safety.safety_rx_hook(msg)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -10,13 +10,11 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
-
 class ALTERNATIVE_EXPERIENCE:
   DEFAULT = 0
   DISABLE_DISENGAGE_ON_GAS = 1
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
-
 
 def package_can_msg(msg):
   addr, _, dat, bus = msg
@@ -29,10 +27,8 @@ def package_can_msg(msg):
 
   return ret
 
-
 def make_msg(bus, addr, length=8):
   return package_can_msg([addr, 0, b'\x00' * length, bus])
-
 
 class CANPackerPanda(CANPacker):
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=-1, fix_checksum=None):
@@ -41,25 +37,12 @@ class CANPackerPanda(CANPacker):
       msg = fix_checksum(msg)
     return package_can_msg(msg)
 
-
 class PandaSafetyTestBase(unittest.TestCase):
-
-  SAFETY_PARAM = 0
-
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "PandaSafetyTestBase":
       cls.safety = None
       raise unittest.SkipTest
-
-  def setUp(self):
-    self.packer = CANPackerPanda(self.DBC)
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(self.SAFETY_MODE, self.SAFETY_PARAM)
-    if 'Honda' in self.__class__.__name__:
-      self.safety._init_tests_honda()
-    else:
-      self.safety.init_tests()
 
   def _rx(self, msg):
     return self.safety.safety_rx_hook(msg)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -10,13 +10,11 @@ from panda.tests.safety import libpandasafety_py
 
 MAX_WRONG_COUNTERS = 5
 
-
 class ALTERNATIVE_EXPERIENCE:
   DEFAULT = 0
   DISABLE_DISENGAGE_ON_GAS = 1
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
-
 
 def package_can_msg(msg):
   addr, _, dat, bus = msg
@@ -29,10 +27,8 @@ def package_can_msg(msg):
 
   return ret
 
-
 def make_msg(bus, addr, length=8):
   return package_can_msg([addr, 0, b'\x00' * length, bus])
-
 
 class CANPackerPanda(CANPacker):
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=-1, fix_checksum=None):
@@ -40,7 +36,6 @@ class CANPackerPanda(CANPacker):
     if fix_checksum is not None:
       msg = fix_checksum(msg)
     return package_can_msg(msg)
-
 
 class PandaSafetyTestBase(unittest.TestCase):
   @classmethod
@@ -54,7 +49,6 @@ class PandaSafetyTestBase(unittest.TestCase):
 
   def _tx(self, msg):
     return self.safety.safety_tx_hook(msg)
-
 
 class InterceptorSafetyTest(PandaSafetyTestBase):
 

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -56,7 +56,7 @@ void set_timer(uint32_t t);
 int safety_rx_hook(CANPacket_t *to_send);
 int safety_tx_hook(CANPacket_t *to_push);
 int safety_fwd_hook(int bus_num, CANPacket_t *to_fwd);
-int set_safety_hooks(uint16_t  mode, int16_t param);
+int set_safety_hooks(uint16_t mode, int16_t param);
 
 void safety_tick_current_rx_checks();
 bool addr_checks_valid();

--- a/tests/safety/libpandasafety_py.py
+++ b/tests/safety/libpandasafety_py.py
@@ -56,7 +56,7 @@ void set_timer(uint32_t t);
 int safety_rx_hook(CANPacket_t *to_send);
 int safety_tx_hook(CANPacket_t *to_push);
 int safety_fwd_hook(int bus_num, CANPacket_t *to_fwd);
-int set_safety_hooks(uint16_t mode, int16_t param);
+int set_safety_hooks(uint16_t  mode, int16_t param);
 
 void safety_tick_current_rx_checks();
 bool addr_checks_valid();

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -45,12 +45,12 @@ class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest
     values = {"SPEED_LEFT": speed, "SPEED_RIGHT": speed}
     return self.packer.make_can_msg_panda("SPEED_1", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"ACCEL_134": gas, "COUNTER": self.cnt_gas % 16}
     self.__class__.cnt_gas += 1
     return self.packer.make_can_msg_panda("ACCEL_GAS_134", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"BRAKE_PRESSED_2": 5 if brake else 0,
               "COUNTER": self.cnt_brake % 16}
     self.__class__.cnt_brake += 1

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import unittest
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda
+from panda.tests.safety.common import set_up_test
+
 
 class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest):
   TX_MSGS = [[571, 0], [658, 0], [678, 0]]
@@ -26,10 +26,7 @@ class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest
   cnt_brake = 0
 
   def setUp(self):
-    self.packer = CANPackerPanda("chrysler_pacifica_2017_hybrid")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_CHRYSLER, 0)
-    self.safety.init_tests()
+    set_up_test(self, "chrysler_pacifica_2017_hybrid", Panda.SAFETY_CHRYSLER, 0)
 
   def _button_msg(self, cancel):
     values = {"ACC_CANCEL": cancel}

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 import unittest
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import set_up_test
-
+from panda.tests.safety.common import CANPackerPanda
 
 class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest):
   TX_MSGS = [[571, 0], [658, 0], [678, 0]]
@@ -26,7 +26,10 @@ class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest
   cnt_brake = 0
 
   def setUp(self):
-    set_up_test(self, "chrysler_pacifica_2017_hybrid", Panda.SAFETY_CHRYSLER, 0)
+    self.packer = CANPackerPanda("chrysler_pacifica_2017_hybrid")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_CHRYSLER, 0)
+    self.safety.init_tests()
 
   def _button_msg(self, cancel):
     values = {"ACC_CANCEL": cancel}

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -65,11 +65,11 @@ class TestGmSafety(common.PandaSafetyTest):
     values = {"ACCButtons": buttons}
     return self.packer.make_can_msg_panda("ASCMSteeringButton", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"Brake_Pressed": 1 if brake else 0}
     return self.packer.make_can_msg_panda("ECMEngineStatus", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"AcceleratorPedal2": 1 if gas else 0}
     return self.packer.make_can_msg_panda("AcceleratorPedal2", 0, values)
 
@@ -222,10 +222,10 @@ class TestGmSafety(common.PandaSafetyTest):
       if pedal == 'brake':
         # brake_pressed_prev and vehicle_moving
         self._rx(self._speed_msg(100))
-        self._rx(self._brake_msg(MAX_BRAKE))
+        self._rx(self._user_brake_msg(MAX_BRAKE))
       elif pedal == 'gas':
         # gas_pressed_prev
-        self._rx(self._gas_msg(MAX_GAS))
+        self._rx(self._user_gas_msg(MAX_GAS))
 
       self.safety.set_controls_allowed(1)
       self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
@@ -238,9 +238,9 @@ class TestGmSafety(common.PandaSafetyTest):
       self._tx(self._torque_msg(0))
       if pedal == 'brake':
         self._rx(self._speed_msg(0))
-        self._rx(self._brake_msg(0))
+        self._rx(self._user_brake_msg(0))
       elif pedal == 'gas':
-        self._rx(self._gas_msg(0))
+        self._rx(self._user_gas_msg(0))
 
   def test_tx_hook_on_pedal_pressed_on_alternative_gas_experience(self):
     for pedal in ['brake', 'gas']:
@@ -248,11 +248,11 @@ class TestGmSafety(common.PandaSafetyTest):
       if pedal == 'brake':
         # brake_pressed_prev and vehicle_moving
         self._rx(self._speed_msg(100))
-        self._rx(self._brake_msg(MAX_BRAKE))
+        self._rx(self._user_brake_msg(MAX_BRAKE))
         allow_ctrl = False
       elif pedal == 'gas':
         # gas_pressed_prev
-        self._rx(self._gas_msg(MAX_GAS))
+        self._rx(self._user_gas_msg(MAX_GAS))
         allow_ctrl = True
 
       self.safety.set_controls_allowed(1)
@@ -267,9 +267,9 @@ class TestGmSafety(common.PandaSafetyTest):
       self._tx(self._torque_msg(0))
       if pedal == 'brake':
         self._rx(self._speed_msg(0))
-        self._rx(self._brake_msg(0))
+        self._rx(self._user_brake_msg(0))
       elif pedal == 'gas':
-        self._rx(self._gas_msg(0))
+        self._rx(self._user_gas_msg(0))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -3,9 +3,8 @@ import unittest
 from typing import Dict, List
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import CANPackerPanda, ALTERNATIVE_EXPERIENCE, set_up_test
 
 MAX_RATE_UP = 7
 MAX_RATE_DOWN = 17
@@ -38,11 +37,8 @@ class TestGmSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP: Dict[int, int] = {}
 
   def setUp(self):
-    self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
+    set_up_test(self, "gm_global_a_powertrain_generated", Panda.SAFETY_GM, 0)
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_GM, 0)
-    self.safety.init_tests()
 
   # override these tests from PandaSafetyTest, GM uses button enable
   def test_disable_control_allowed_from_cruise(self):

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -3,8 +3,9 @@ import unittest
 from typing import Dict, List
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, ALTERNATIVE_EXPERIENCE, set_up_test
+from panda.tests.safety.common import CANPackerPanda, ALTERNATIVE_EXPERIENCE
 
 MAX_RATE_UP = 7
 MAX_RATE_DOWN = 17
@@ -37,8 +38,11 @@ class TestGmSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP: Dict[int, int] = {}
 
   def setUp(self):
-    set_up_test(self, "gm_global_a_powertrain_generated", Panda.SAFETY_GM, 0)
+    self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_GM, 0)
+    self.safety.init_tests()
 
   # override these tests from PandaSafetyTest, GM uses button enable
   def test_disable_control_allowed_from_cruise(self):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -91,7 +91,7 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
       if msg == "btn":
         to_push = self._button_msg(Btn.SET)
       if msg == "gas":
-        to_push = self._gas_msg(0)
+        to_push = self._user_gas_msg(0)
       if msg == "speed":
         to_push = self._speed_msg(0)
       self.assertTrue(self._rx(to_push))
@@ -113,11 +113,11 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
         self.safety.set_controls_allowed(1)
         self._rx(self._button_msg(Btn.SET))
         self._rx(self._speed_msg(0))
-        self._rx(self._gas_msg(0))
+        self._rx(self._user_gas_msg(0))
       else:
         self.assertFalse(self._rx(self._button_msg(Btn.SET)))
         self.assertFalse(self._rx(self._speed_msg(0)))
-        self.assertFalse(self._rx(self._gas_msg(0)))
+        self.assertFalse(self._rx(self._user_gas_msg(0)))
         self.assertFalse(self.safety.get_controls_allowed())
 
     # restore counters for future tests with a couple of good messages
@@ -125,7 +125,7 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
       self.safety.set_controls_allowed(1)
       self._rx(self._button_msg(Btn.SET))
       self._rx(self._speed_msg(0))
-      self._rx(self._gas_msg(0))
+      self._rx(self._user_gas_msg(0))
     self._rx(self._button_msg(Btn.SET, main_on=True))
     self.assertTrue(self.safety.get_controls_allowed())
 
@@ -137,10 +137,10 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
         if pedal == 'brake':
           # brake_pressed_prev and vehicle_moving
           self._rx(self._speed_msg(100))
-          self._rx(self._brake_msg(1))
+          self._rx(self._user_brake_msg(1))
         elif pedal == 'gas':
           # gas_pressed_prev
-          self._rx(self._gas_msg(1))
+          self._rx(self._user_gas_msg(1))
           allow_ctrl = mode == ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS
 
         self.safety.set_controls_allowed(1)
@@ -158,9 +158,9 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
         self._tx(self._send_steer_msg(0))
         if pedal == 'brake':
           self._rx(self._speed_msg(0))
-          self._rx(self._brake_msg(0))
+          self._rx(self._user_brake_msg(0))
         elif pedal == 'gas':
-          self._rx(self._gas_msg(0))
+          self._rx(self._user_gas_msg(0))
 
 
 class HondaPcmEnableBase(common.PandaSafetyTest):
@@ -251,10 +251,10 @@ class HondaBase(common.PandaSafetyTest):
     self.__class__.cnt_button += 1
     return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     return self._powertrain_data_msg(brake_pressed=brake)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     return self._powertrain_data_msg(gas_pressed=gas)
 
   def _send_steer_msg(self, steer):
@@ -267,7 +267,7 @@ class HondaBase(common.PandaSafetyTest):
 
   def test_disengage_on_brake(self):
     self.safety.set_controls_allowed(1)
-    self._rx(self._brake_msg(1))
+    self._rx(self._user_brake_msg(1))
     self.assertFalse(self.safety.get_controls_allowed())
 
   def test_steer_safety_check(self):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -288,17 +288,14 @@ class TestHondaNidecSafetyBase(HondaBase):
 
   INTERCEPTOR_THRESHOLD = 344
 
+  DBC = "honda_civic_touring_2016_can_generated"
+  SAFETY_MODE = Panda.SAFETY_HONDA_NIDEC
+
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "TestHondaNidecSafetyBase":
       cls.safety = None
       raise unittest.SkipTest
-
-  def setUp(self):
-    self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
-    self.safety.init_tests_honda()
 
   # Honda gas gains are the different
   def _interceptor_msg(self, gas, addr):
@@ -398,11 +395,9 @@ class TestHondaNidecAltSafety(TestHondaNidecSafety):
   """
     Covers the Honda Nidec safety mode with alt SCM messages
   """
-  def setUp(self):
-    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
-    self.safety.init_tests_honda()
+
+  DBC = "acura_ilx_2016_can_generated"
+  SAFETY_PARAM = Panda.FLAG_HONDA_NIDEC_ALT
 
   def _acc_state_msg(self, main_on):
     values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
@@ -419,11 +414,6 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
   """
     Covers the Honda Nidec safety mode with alt SCM messages and gas interceptor
   """
-  def setUp(self):
-    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
-    self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
     values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
@@ -447,16 +437,15 @@ class TestHondaBoschSafetyBase(HondaBase):
   TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
+  DBC = "honda_accord_2018_can_generated"
+  SAFETY_MODE = Panda.SAFETY_HONDA_BOSCH
+
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "TestHondaBoschSafetyBase":
       cls.packer = None
       cls.safety = None
       raise unittest.SkipTest
-
-  def setUp(self):
-    self.packer = CANPackerPanda("honda_accord_2018_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
 
   def _alt_brake_msg(self, brake):
     values = {"BRAKE_PRESSED": brake, "COUNTER": self.cnt_brake % 4}
@@ -491,10 +480,6 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
   """
     Covers the Honda Bosch safety mode with stock longitudinal
   """
-  def setUp(self):
-    super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, 0)
-    self.safety.init_tests_honda()
 
   def test_spam_cancel_safety_check(self):
     self.safety.set_controls_allowed(0)
@@ -518,10 +503,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
-  def setUp(self):
-    super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
-    self.safety.init_tests_honda()
+  SAFETY_PARAM = Panda.FLAG_HONDA_BOSCH_LONG
 
   def _send_gas_brake_msg(self, gas, accel):
     values = {

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -8,12 +8,14 @@ from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
 
+
 class Btn:
   NONE = 0
   MAIN = 1
   CANCEL = 2
   SET = 3
   RESUME = 4
+
 
 HONDA_NIDEC = 0
 HONDA_BOSCH = 1

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -288,14 +288,17 @@ class TestHondaNidecSafetyBase(HondaBase):
 
   INTERCEPTOR_THRESHOLD = 344
 
-  DBC = "honda_civic_touring_2016_can_generated"
-  SAFETY_MODE = Panda.SAFETY_HONDA_NIDEC
-
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "TestHondaNidecSafetyBase":
       cls.safety = None
       raise unittest.SkipTest
+
+  def setUp(self):
+    self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
+    self.safety.init_tests_honda()
 
   # Honda gas gains are the different
   def _interceptor_msg(self, gas, addr):
@@ -395,9 +398,11 @@ class TestHondaNidecAltSafety(TestHondaNidecSafety):
   """
     Covers the Honda Nidec safety mode with alt SCM messages
   """
-
-  DBC = "acura_ilx_2016_can_generated"
-  SAFETY_PARAM = Panda.FLAG_HONDA_NIDEC_ALT
+  def setUp(self):
+    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
+    self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
     values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
@@ -414,6 +419,11 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
   """
     Covers the Honda Nidec safety mode with alt SCM messages and gas interceptor
   """
+  def setUp(self):
+    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
+    self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
     values = {"MAIN_ON": main_on, "COUNTER": self.cnt_acc_state % 4}
@@ -437,15 +447,16 @@ class TestHondaBoschSafetyBase(HondaBase):
   TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
-  DBC = "honda_accord_2018_can_generated"
-  SAFETY_MODE = Panda.SAFETY_HONDA_BOSCH
-
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "TestHondaBoschSafetyBase":
       cls.packer = None
       cls.safety = None
       raise unittest.SkipTest
+
+  def setUp(self):
+    self.packer = CANPackerPanda("honda_accord_2018_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
 
   def _alt_brake_msg(self, brake):
     values = {"BRAKE_PRESSED": brake, "COUNTER": self.cnt_brake % 4}
@@ -480,6 +491,10 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
   """
     Covers the Honda Bosch safety mode with stock longitudinal
   """
+  def setUp(self):
+    super().setUp()
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, 0)
+    self.safety.init_tests_honda()
 
   def test_spam_cancel_safety_check(self):
     self.safety.set_controls_allowed(0)
@@ -503,7 +518,10 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
-  SAFETY_PARAM = Panda.FLAG_HONDA_BOSCH_LONG
+  def setUp(self):
+    super().setUp()
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
+    self.safety.init_tests_honda()
 
   def _send_gas_brake_msg(self, gas, accel):
     values = {

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -4,9 +4,8 @@ import numpy as np
 from typing import Optional
 
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import make_msg, set_up_test, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
 
 class Btn:
   NONE = 0
@@ -295,9 +294,7 @@ class TestHondaNidecSafetyBase(HondaBase):
       raise unittest.SkipTest
 
   def setUp(self):
-    self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
+    set_up_test(self, "honda_civic_touring_2016_can_generated", Panda.SAFETY_HONDA_NIDEC, 0)
     self.safety.init_tests_honda()
 
   # Honda gas gains are the different
@@ -399,9 +396,7 @@ class TestHondaNidecAltSafety(TestHondaNidecSafety):
     Covers the Honda Nidec safety mode with alt SCM messages
   """
   def setUp(self):
-    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
+    set_up_test(self, "acura_ilx_2016_can_generated", Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_NIDEC)
     self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
@@ -420,9 +415,7 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     Covers the Honda Nidec safety mode with alt SCM messages and gas interceptor
   """
   def setUp(self):
-    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
+    set_up_test(self, "acura_ilx_2016_can_generated", Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
     self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
@@ -434,7 +427,6 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     values = {"CRUISE_BUTTONS": buttons, "MAIN_ON": main_on, "COUNTER": self.cnt_button % 4}
     self.__class__.cnt_button += 1
     return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
-
 
 
 # ********************* Honda Bosch **********************
@@ -453,10 +445,6 @@ class TestHondaBoschSafetyBase(HondaBase):
       cls.packer = None
       cls.safety = None
       raise unittest.SkipTest
-
-  def setUp(self):
-    self.packer = CANPackerPanda("honda_accord_2018_can_generated")
-    self.safety = libpandasafety_py.libpandasafety
 
   def _alt_brake_msg(self, brake):
     values = {"BRAKE_PRESSED": brake, "COUNTER": self.cnt_brake % 4}
@@ -492,8 +480,7 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
     Covers the Honda Bosch safety mode with stock longitudinal
   """
   def setUp(self):
-    super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, 0)
+    set_up_test(self, "honda_accord_2018_can_generated", Panda.SAFETY_HONDA_BOSCH, 0)
     self.safety.init_tests_honda()
 
   def test_spam_cancel_safety_check(self):
@@ -519,9 +506,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
   def setUp(self):
-    super().setUp()
-    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
-    self.safety.init_tests_honda()
+    set_up_test(self, "honda_accord_2018_can_generated", Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
 
   def _send_gas_brake_msg(self, gas, accel):
     values = {

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -4,8 +4,9 @@ import numpy as np
 from typing import Optional
 
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import make_msg, set_up_test, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
 
 class Btn:
   NONE = 0
@@ -294,7 +295,9 @@ class TestHondaNidecSafetyBase(HondaBase):
       raise unittest.SkipTest
 
   def setUp(self):
-    set_up_test(self, "honda_civic_touring_2016_can_generated", Panda.SAFETY_HONDA_NIDEC, 0)
+    self.packer = CANPackerPanda("honda_civic_touring_2016_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
     self.safety.init_tests_honda()
 
   # Honda gas gains are the different
@@ -396,7 +399,9 @@ class TestHondaNidecAltSafety(TestHondaNidecSafety):
     Covers the Honda Nidec safety mode with alt SCM messages
   """
   def setUp(self):
-    set_up_test(self, "acura_ilx_2016_can_generated", Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_NIDEC)
+    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
     self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
@@ -415,7 +420,9 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     Covers the Honda Nidec safety mode with alt SCM messages and gas interceptor
   """
   def setUp(self):
-    set_up_test(self, "acura_ilx_2016_can_generated", Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
+    self.packer = CANPackerPanda("acura_ilx_2016_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, Panda.FLAG_HONDA_NIDEC_ALT)
     self.safety.init_tests_honda()
 
   def _acc_state_msg(self, main_on):
@@ -427,6 +434,7 @@ class TestHondaNidecAltInterceptorSafety(TestHondaNidecSafety, common.Intercepto
     values = {"CRUISE_BUTTONS": buttons, "MAIN_ON": main_on, "COUNTER": self.cnt_button % 4}
     self.__class__.cnt_button += 1
     return self.packer.make_can_msg_panda("SCM_BUTTONS", self.PT_BUS, values)
+
 
 
 # ********************* Honda Bosch **********************
@@ -445,6 +453,10 @@ class TestHondaBoschSafetyBase(HondaBase):
       cls.packer = None
       cls.safety = None
       raise unittest.SkipTest
+
+  def setUp(self):
+    self.packer = CANPackerPanda("honda_accord_2018_can_generated")
+    self.safety = libpandasafety_py.libpandasafety
 
   def _alt_brake_msg(self, brake):
     values = {"BRAKE_PRESSED": brake, "COUNTER": self.cnt_brake % 4}
@@ -480,7 +492,8 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
     Covers the Honda Bosch safety mode with stock longitudinal
   """
   def setUp(self):
-    set_up_test(self, "honda_accord_2018_can_generated", Panda.SAFETY_HONDA_BOSCH, 0)
+    super().setUp()
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, 0)
     self.safety.init_tests_honda()
 
   def test_spam_cancel_safety_check(self):
@@ -506,7 +519,9 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
 
   def setUp(self):
-    set_up_test(self, "honda_accord_2018_can_generated", Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
+    super().setUp()
+    self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, Panda.FLAG_HONDA_BOSCH_LONG)
+    self.safety.init_tests_honda()
 
   def _send_gas_brake_msg(self, gas, accel):
     values = {

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -8,14 +8,12 @@ from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
 
-
 class Btn:
   NONE = 0
   MAIN = 1
   CANCEL = 2
   SET = 3
   RESUME = 4
-
 
 HONDA_NIDEC = 0
 HONDA_BOSCH = 1

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -82,12 +82,12 @@ class TestHyundaiSafety(common.PandaSafetyTest):
     values = {"CF_Clu_CruiseSwState": buttons}
     return self.packer.make_can_msg_panda("CLU11", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"CF_Ems_AclAct": gas, "AliveCounter": self.cnt_gas % 4}
     self.__class__.cnt_gas += 1
     return self.packer.make_can_msg_panda("EMS16", 0, values, fix_checksum=checksum)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"DriverBraking": brake, "AliveCounterTCS": self.cnt_brake % 8}
     self.__class__.cnt_brake += 1
     return self.packer.make_can_msg_panda("TCS13", 0, values, fix_checksum=checksum)
@@ -238,7 +238,7 @@ class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
     self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 1)
     self.safety.init_tests()
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"Accel_Pedal_Pos": gas}
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
 
@@ -250,7 +250,7 @@ class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
     self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 2)
     self.safety.init_tests()
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"CR_Vcu_AccPedDep_Pos": gas}
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
 

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -285,7 +285,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.__class__.cnt_button += 1
     return self.packer.make_can_msg_panda("CLU11", 0, values)
 
-  def _send_accel_msg(self, accel, aeb_req=False, aeb_decel=0):
+  def _accel_control_msg(self, accel, aeb_req=False, aeb_decel=0):
     values = {
       "aReqRaw": accel,
       "aReqValue": accel,
@@ -311,9 +311,9 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.assertFalse(self._tx(self._send_fca11_msg(aeb_decel=1.0)))
 
   def test_no_aeb_scc12(self):
-    self.assertTrue(self._tx(self._send_accel_msg(0)))
-    self.assertFalse(self._tx(self._send_accel_msg(0, aeb_req=True)))
-    self.assertFalse(self._tx(self._send_accel_msg(0, aeb_decel=1.0)))
+    self.assertTrue(self._tx(self._accel_control_msg(0)))
+    self.assertFalse(self._tx(self._accel_control_msg(0, aeb_req=True)))
+    self.assertFalse(self._tx(self._accel_control_msg(0, aeb_decel=1.0)))
 
   def test_set_resume_buttons(self):
     """
@@ -341,7 +341,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
         accel = round(accel, 2) # floats might not hit exact boundary conditions without rounding
         self.safety.set_controls_allowed(controls_allowed)
         send = MIN_ACCEL <= accel <= MAX_ACCEL if controls_allowed else accel == 0
-        self.assertEqual(send, self._tx(self._send_accel_msg(accel)), (controls_allowed, accel))
+        self.assertEqual(send, self._tx(self._accel_control_msg(accel)), (controls_allowed, accel))
 
   def test_diagnostics(self):
     tester_present = common.package_can_msg((0x7d0, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 0))

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -2,9 +2,8 @@
 import unittest
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, make_msg
+from panda.tests.safety.common import make_msg, set_up_test
 
 MAX_RATE_UP = 3
 MAX_RATE_DOWN = 7
@@ -19,11 +18,13 @@ DRIVER_TORQUE_FACTOR = 2
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
 
+
 class Buttons:
   NONE = 0
   RESUME = 1
   SET = 2
   CANCEL = 4
+
 
 # 4 bit checkusm used in some hyundai messages
 # lives outside the can packer because we never send this msg
@@ -73,10 +74,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
   cnt_cruise = 0
 
   def setUp(self):
-    self.packer = CANPackerPanda("hyundai_kia_generic")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, 0)
-    self.safety.init_tests()
+    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI, 0)
 
   def _button_msg(self, buttons):
     values = {"CF_Clu_CruiseSwState": buttons}
@@ -225,18 +223,12 @@ class TestHyundaiSafety(common.PandaSafetyTest):
 
 class TestHyundaiLegacySafety(TestHyundaiSafety):
   def setUp(self):
-    self.packer = CANPackerPanda("hyundai_kia_generic")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 0)
-    self.safety.init_tests()
+    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI_LEGACY, 0)
 
 
 class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
   def setUp(self):
-    self.packer = CANPackerPanda("hyundai_kia_generic")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 1)
-    self.safety.init_tests()
+    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI_LEGACY, 1)
 
   def _user_gas_msg(self, gas):
     values = {"Accel_Pedal_Pos": gas}
@@ -245,24 +237,19 @@ class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
 
 class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
   def setUp(self):
-    self.packer = CANPackerPanda("hyundai_kia_generic")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 2)
-    self.safety.init_tests()
+    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI_LEGACY, 2)
 
   def _user_gas_msg(self, gas):
     values = {"CR_Vcu_AccPedDep_Pos": gas}
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
+
 
 class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
   TX_MSGS = [[832, 0], [1265, 0], [1157, 0], [1056, 0], [1057, 0], [1290, 0], [905, 0], [1186, 0], [909, 0], [1155, 0], [2000, 0]]
   cnt_button = 0
 
   def setUp(self):
-    self.packer = CANPackerPanda("hyundai_kia_generic")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_LONG)
-    self.safety.init_tests()
+    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_LONG)
 
   # override these tests from PandaSafetyTest, hyundai longitudinal uses button enable
   def test_disable_control_allowed_from_cruise(self):
@@ -355,7 +342,6 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.assertFalse(self.safety.get_relay_malfunction())
     self._rx(make_msg(0, 1057, 8))
     self.assertTrue(self.safety.get_relay_malfunction())
-
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -285,7 +285,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.__class__.cnt_button += 1
     return self.packer.make_can_msg_panda("CLU11", 0, values)
 
-  def _accel_cmd_msg(self, accel, aeb_req=False, aeb_decel=0):
+  def _send_accel_msg(self, accel, aeb_req=False, aeb_decel=0):
     values = {
       "aReqRaw": accel,
       "aReqValue": accel,
@@ -311,9 +311,9 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.assertFalse(self._tx(self._send_fca11_msg(aeb_decel=1.0)))
 
   def test_no_aeb_scc12(self):
-    self.assertTrue(self._tx(self._accel_cmd_msg(0)))
-    self.assertFalse(self._tx(self._accel_cmd_msg(0, aeb_req=True)))
-    self.assertFalse(self._tx(self._accel_cmd_msg(0, aeb_decel=1.0)))
+    self.assertTrue(self._tx(self._send_accel_msg(0)))
+    self.assertFalse(self._tx(self._send_accel_msg(0, aeb_req=True)))
+    self.assertFalse(self._tx(self._send_accel_msg(0, aeb_decel=1.0)))
 
   def test_set_resume_buttons(self):
     """
@@ -341,7 +341,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
         accel = round(accel, 2) # floats might not hit exact boundary conditions without rounding
         self.safety.set_controls_allowed(controls_allowed)
         send = MIN_ACCEL <= accel <= MAX_ACCEL if controls_allowed else accel == 0
-        self.assertEqual(send, self._tx(self._accel_cmd_msg(accel)), (controls_allowed, accel))
+        self.assertEqual(send, self._tx(self._send_accel_msg(accel)), (controls_allowed, accel))
 
   def test_diagnostics(self):
     tester_present = common.package_can_msg((0x7d0, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 0))

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -2,8 +2,9 @@
 import unittest
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import make_msg, set_up_test
+from panda.tests.safety.common import CANPackerPanda, make_msg
 
 MAX_RATE_UP = 3
 MAX_RATE_DOWN = 7
@@ -18,13 +19,11 @@ DRIVER_TORQUE_FACTOR = 2
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
 
-
 class Buttons:
   NONE = 0
   RESUME = 1
   SET = 2
   CANCEL = 4
-
 
 # 4 bit checkusm used in some hyundai messages
 # lives outside the can packer because we never send this msg
@@ -74,7 +73,10 @@ class TestHyundaiSafety(common.PandaSafetyTest):
   cnt_cruise = 0
 
   def setUp(self):
-    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI, 0)
+    self.packer = CANPackerPanda("hyundai_kia_generic")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, 0)
+    self.safety.init_tests()
 
   def _button_msg(self, buttons):
     values = {"CF_Clu_CruiseSwState": buttons}
@@ -223,12 +225,18 @@ class TestHyundaiSafety(common.PandaSafetyTest):
 
 class TestHyundaiLegacySafety(TestHyundaiSafety):
   def setUp(self):
-    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI_LEGACY, 0)
+    self.packer = CANPackerPanda("hyundai_kia_generic")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 0)
+    self.safety.init_tests()
 
 
 class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
   def setUp(self):
-    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI_LEGACY, 1)
+    self.packer = CANPackerPanda("hyundai_kia_generic")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 1)
+    self.safety.init_tests()
 
   def _user_gas_msg(self, gas):
     values = {"Accel_Pedal_Pos": gas}
@@ -237,19 +245,24 @@ class TestHyundaiLegacySafetyEV(TestHyundaiSafety):
 
 class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
   def setUp(self):
-    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI_LEGACY, 2)
+    self.packer = CANPackerPanda("hyundai_kia_generic")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_LEGACY, 2)
+    self.safety.init_tests()
 
   def _user_gas_msg(self, gas):
     values = {"CR_Vcu_AccPedDep_Pos": gas}
     return self.packer.make_can_msg_panda("E_EMS11", 0, values, fix_checksum=checksum)
-
 
 class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
   TX_MSGS = [[832, 0], [1265, 0], [1157, 0], [1056, 0], [1057, 0], [1290, 0], [905, 0], [1186, 0], [909, 0], [1155, 0], [2000, 0]]
   cnt_button = 0
 
   def setUp(self):
-    set_up_test(self, "hyundai_kia_generic", Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_LONG)
+    self.packer = CANPackerPanda("hyundai_kia_generic")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI, Panda.FLAG_HYUNDAI_LONG)
+    self.safety.init_tests()
 
   # override these tests from PandaSafetyTest, hyundai longitudinal uses button enable
   def test_disable_control_allowed_from_cruise(self):
@@ -342,6 +355,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.assertFalse(self.safety.get_relay_malfunction())
     self._rx(make_msg(0, 1057, 8))
     self.assertTrue(self.safety.get_relay_malfunction())
+
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -285,7 +285,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.__class__.cnt_button += 1
     return self.packer.make_can_msg_panda("CLU11", 0, values)
 
-  def _accel_control_msg(self, accel, aeb_req=False, aeb_decel=0):
+  def _accel_cmd_msg(self, accel, aeb_req=False, aeb_decel=0):
     values = {
       "aReqRaw": accel,
       "aReqValue": accel,
@@ -311,9 +311,9 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     self.assertFalse(self._tx(self._send_fca11_msg(aeb_decel=1.0)))
 
   def test_no_aeb_scc12(self):
-    self.assertTrue(self._tx(self._accel_control_msg(0)))
-    self.assertFalse(self._tx(self._accel_control_msg(0, aeb_req=True)))
-    self.assertFalse(self._tx(self._accel_control_msg(0, aeb_decel=1.0)))
+    self.assertTrue(self._tx(self._accel_cmd_msg(0)))
+    self.assertFalse(self._tx(self._accel_cmd_msg(0, aeb_req=True)))
+    self.assertFalse(self._tx(self._accel_cmd_msg(0, aeb_decel=1.0)))
 
   def test_set_resume_buttons(self):
     """
@@ -341,7 +341,7 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
         accel = round(accel, 2) # floats might not hit exact boundary conditions without rounding
         self.safety.set_controls_allowed(controls_allowed)
         send = MIN_ACCEL <= accel <= MAX_ACCEL if controls_allowed else accel == 0
-        self.assertEqual(send, self._tx(self._accel_control_msg(accel)), (controls_allowed, accel))
+        self.assertEqual(send, self._tx(self._accel_cmd_msg(accel)), (controls_allowed, accel))
 
   def test_diagnostics(self):
     tester_present = common.package_can_msg((0x7d0, 0, b"\x02\x3E\x80\x00\x00\x00\x00\x00", 0))

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -47,11 +47,11 @@ class TestMazdaSafety(common.PandaSafetyTest):
     values = {"SPEED": speed}
     return self.packer.make_can_msg_panda("ENGINE_DATA", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"BRAKE_ON": brake}
     return self.packer.make_can_msg_panda("PEDALS", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"PEDAL_GAS": gas}
     return self.packer.make_can_msg_panda("ENGINE_DATA", 0, values)
 

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import unittest
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import set_up_test
+from panda.tests.safety.common import CANPackerPanda
 
 MAX_RATE_UP = 10
 MAX_RATE_DOWN = 25
@@ -25,7 +26,10 @@ class TestMazdaSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    set_up_test(self, "mazda_2017", Panda.SAFETY_MAZDA, 0)
+    self.packer = CANPackerPanda("mazda_2017")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_MAZDA, 0)
+    self.safety.init_tests()
 
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_MOTOR": torque}

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 import unittest
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda
+from panda.tests.safety.common import set_up_test
 
 MAX_RATE_UP = 10
 MAX_RATE_DOWN = 25
@@ -26,10 +25,7 @@ class TestMazdaSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("mazda_2017")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_MAZDA, 0)
-    self.safety.init_tests()
+    set_up_test(self, "mazda_2017", Panda.SAFETY_MAZDA, 0)
 
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_MOTOR": torque}

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -56,11 +56,11 @@ class TestNissanSafety(common.PandaSafetyTest):
     values = {"WHEEL_SPEED_%s" % s: speed * 3.6 for s in ["RR", "RL"]}
     return self.packer.make_can_msg_panda("WHEEL_SPEEDS_REAR", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"USER_BRAKE_PRESSED": brake}
     return self.packer.make_can_msg_panda("DOORS_LIGHTS", 1, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"GAS_PEDAL": gas}
     return self.packer.make_can_msg_panda("GAS_PEDAL", 0, values)
 
@@ -149,11 +149,11 @@ class TestNissanLeafSafety(TestNissanSafety):
     self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, 0)
     self.safety.init_tests()
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"USER_BRAKE_PRESSED": brake}
     return self.packer.make_can_msg_panda("CRUISE_THROTTLE", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"GAS_PEDAL": gas}
     return self.packer.make_can_msg_panda("CRUISE_THROTTLE", 0, values)
 

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -2,9 +2,8 @@
 import unittest
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda
+from panda.tests.safety.common import set_up_test
 
 ANGLE_DELTA_BP = [0., 5., 15.]
 ANGLE_DELTA_V = [5., .8, .15]     # windup limit
@@ -26,10 +25,7 @@ class TestNissanSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("nissan_x_trail_2017")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, 0)
-    self.safety.init_tests()
+    set_up_test(self, "nissan_x_trail_2017", Panda.SAFETY_NISSAN, 0)
 
   def _angle_meas_msg(self, angle):
     values = {"STEER_ANGLE": angle}
@@ -141,13 +137,11 @@ class TestNissanSafety(common.PandaSafetyTest):
         tx = self._tx(self._acc_button_cmd(**args))
         self.assertEqual(tx, should_tx)
 
+
 class TestNissanLeafSafety(TestNissanSafety):
 
   def setUp(self):
-    self.packer = CANPackerPanda("nissan_leaf_2018")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, 0)
-    self.safety.init_tests()
+    set_up_test(self, "nissan_leaf_2018", Panda.SAFETY_NISSAN, 0)
 
   def _user_brake_msg(self, brake):
     values = {"USER_BRAKE_PRESSED": brake}

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -2,8 +2,9 @@
 import unittest
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import set_up_test
+from panda.tests.safety.common import CANPackerPanda
 
 ANGLE_DELTA_BP = [0., 5., 15.]
 ANGLE_DELTA_V = [5., .8, .15]     # windup limit
@@ -25,7 +26,10 @@ class TestNissanSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    set_up_test(self, "nissan_x_trail_2017", Panda.SAFETY_NISSAN, 0)
+    self.packer = CANPackerPanda("nissan_x_trail_2017")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, 0)
+    self.safety.init_tests()
 
   def _angle_meas_msg(self, angle):
     values = {"STEER_ANGLE": angle}
@@ -137,11 +141,13 @@ class TestNissanSafety(common.PandaSafetyTest):
         tx = self._tx(self._acc_button_cmd(**args))
         self.assertEqual(tx, should_tx)
 
-
 class TestNissanLeafSafety(TestNissanSafety):
 
   def setUp(self):
-    set_up_test(self, "nissan_leaf_2018", Panda.SAFETY_NISSAN, 0)
+    self.packer = CANPackerPanda("nissan_leaf_2018")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_NISSAN, 0)
+    self.safety.init_tests()
 
   def _user_brake_msg(self, brake):
     values = {"USER_BRAKE_PRESSED": brake}

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -53,7 +53,7 @@ class TestSubaruSafety(common.PandaSafetyTest):
     self.__class__.cnt_speed += 1
     return self.packer.make_can_msg_panda("Wheel_Speeds", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"Brake": brake, "Counter": self.cnt_brake % 4}
     self.__class__.cnt_brake += 1
     return self.packer.make_can_msg_panda("Brake_Status", 0, values)
@@ -62,7 +62,7 @@ class TestSubaruSafety(common.PandaSafetyTest):
     values = {"LKAS_Output": torque}
     return self.packer.make_can_msg_panda("ES_LKAS", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"Throttle_Pedal": gas, "Counter": self.cnt_gas % 4}
     self.__class__.cnt_gas += 1
     return self.packer.make_can_msg_panda("Throttle", 0, values)

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -2,9 +2,8 @@
 import unittest
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda
+from panda.tests.safety.common import set_up_test
 
 MAX_RATE_UP = 50
 MAX_RATE_DOWN = 70
@@ -32,10 +31,7 @@ class TestSubaruSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("subaru_global_2017_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU, 0)
-    self.safety.init_tests()
+    set_up_test(self, "subaru_global_2017_generated", Panda.SAFETY_SUBARU, 0)
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -2,8 +2,9 @@
 import unittest
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import set_up_test
+from panda.tests.safety.common import CANPackerPanda
 
 MAX_RATE_UP = 50
 MAX_RATE_DOWN = 70
@@ -31,7 +32,10 @@ class TestSubaruSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    set_up_test(self, "subaru_global_2017_generated", Panda.SAFETY_SUBARU, 0)
+    self.packer = CANPackerPanda("subaru_global_2017_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU, 0)
+    self.safety.init_tests()
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -46,7 +46,7 @@ class TestSubaruLegacySafety(common.PandaSafetyTest):
     values = {s: speed*0.0592 for s in ["FR", "FL", "RR", "RL"]}
     return self.packer.make_can_msg_panda("Wheel_Speeds", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"Brake_Pedal": brake}
     return self.packer.make_can_msg_panda("Brake_Pedal", 0, values)
 
@@ -54,7 +54,7 @@ class TestSubaruLegacySafety(common.PandaSafetyTest):
     values = {"LKAS_Command": torque}
     return self.packer.make_can_msg_panda("ES_LKAS", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"Throttle_Pedal": gas, "Counter": self.cnt_gas % 4}
     self.__class__.cnt_gas += 1
     return self.packer.make_can_msg_panda("Throttle", 0, values)

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -2,8 +2,9 @@
 import unittest
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import set_up_test
+from panda.tests.safety.common import CANPackerPanda
 
 MAX_RATE_UP = 50
 MAX_RATE_DOWN = 70
@@ -27,7 +28,10 @@ class TestSubaruLegacySafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    set_up_test(self, "subaru_outback_2015_generated", Panda.SAFETY_SUBARU_LEGACY, 0)
+    self.packer = CANPackerPanda("subaru_outback_2015_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU_LEGACY, 0)
+    self.safety.init_tests()
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -2,9 +2,8 @@
 import unittest
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda
+from panda.tests.safety.common import set_up_test
 
 MAX_RATE_UP = 50
 MAX_RATE_DOWN = 70
@@ -28,10 +27,7 @@ class TestSubaruLegacySafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("subaru_outback_2015_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_SUBARU_LEGACY, 0)
-    self.safety.init_tests()
+    set_up_test(self, "subaru_outback_2015_generated", Panda.SAFETY_SUBARU_LEGACY, 0)
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -3,7 +3,8 @@ import unittest
 import numpy as np
 from panda import Panda
 import panda.tests.safety.common as common
-from panda.tests.safety.common import set_up_test
+from panda.tests.safety import libpandasafety_py
+from panda.tests.safety.common import CANPackerPanda
 
 ANGLE_DELTA_BP = [0., 5., 15.]
 ANGLE_DELTA_V = [5., .8, .15]     # windup limit
@@ -11,7 +12,6 @@ ANGLE_DELTA_VU = [5., 3.5, 0.4]   # unwind limit
 
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
-
 
 class CONTROL_LEVER_STATE:
   DN_1ST = 32
@@ -22,10 +22,8 @@ class CONTROL_LEVER_STATE:
   FWD = 1
   IDLE = 0
 
-
 def sign(a):
   return 1 if a > 0 else -1
-
 
 class TestTeslaSafety(common.PandaSafetyTest):
   STANDSTILL_THRESHOLD = 0
@@ -34,6 +32,7 @@ class TestTeslaSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
+    self.packer = None
     raise unittest.SkipTest
 
   def _angle_meas_msg(self, angle):
@@ -90,7 +89,10 @@ class TestTeslaSteeringSafety(TestTeslaSafety):
   FWD_BLACKLISTED_ADDRS = {2: [0x488]}
 
   def setUp(self):
-    set_up_test(self, "tesla_can", Panda.SAFETY_TESLA, 0)
+    self.packer = CANPackerPanda("tesla_can")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, 0)
+    self.safety.init_tests()
 
   def test_angle_cmd_when_enabled(self):
     # when controls are allowed, angle cmd rate limit is enforced
@@ -185,15 +187,16 @@ class TestTeslaLongitudinalSafety(TestTeslaSafety):
         send = (MIN_ACCEL <= min_accel <= MAX_ACCEL) and (MIN_ACCEL <= max_accel <= MAX_ACCEL)
         self.assertEqual(self._tx(self._long_control_msg(10, acc_val=4, accel_limits=[min_accel, max_accel])), send)
 
-
 class TestTeslaChassisLongitudinalSafety(TestTeslaLongitudinalSafety):
   TX_MSGS = [[0x488, 0], [0x45, 0], [0x45, 2], [0x2B9, 0]]
   RELAY_MALFUNCTION_ADDR = 0x488
   FWD_BLACKLISTED_ADDRS = {2: [0x2B9, 0x488]}
 
   def setUp(self):
-    set_up_test(self, "tesla_can", Panda.SAFETY_TESLA, Panda.FLAG_TESLA_LONG_CONTROL)
-
+    self.packer = CANPackerPanda("tesla_can")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, Panda.FLAG_TESLA_LONG_CONTROL)
+    self.safety.init_tests()
 
 class TestTeslaPTLongitudinalSafety(TestTeslaLongitudinalSafety):
   TX_MSGS = [[0x2BF, 0]]
@@ -201,8 +204,10 @@ class TestTeslaPTLongitudinalSafety(TestTeslaLongitudinalSafety):
   FWD_BLACKLISTED_ADDRS = {2: [0x2BF]}
 
   def setUp(self):
-    set_up_test(self, "tesla_powertrain", Panda.SAFETY_TESLA, Panda.FLAG_TESLA_LONG_CONTROL | Panda.FLAG_TESLA_POWERTRAIN)
-
+    self.packer = CANPackerPanda("tesla_powertrain")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_TESLA, Panda.FLAG_TESLA_LONG_CONTROL | Panda.FLAG_TESLA_POWERTRAIN)
+    self.safety.init_tests()
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -55,11 +55,11 @@ class TestTeslaSafety(common.PandaSafetyTest):
     values = {"DI_vehicleSpeed": speed / 0.447}
     return self.packer.make_can_msg_panda("DI_torque2", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"driverBrakeStatus": 2 if brake else 1}
     return self.packer.make_can_msg_panda("BrakeMessage", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"DI_pedalPos": gas}
     return self.packer.make_can_msg_panda("DI_torque1", 0, values)
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -59,11 +59,11 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     values = {("WHEEL_SPEED_%s" % n): speed for n in ["FR", "FL", "RR", "RL"]}
     return self.packer.make_can_msg_panda("WHEEL_SPEEDS", 0, values)
 
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"BRAKE_PRESSED": brake}
     return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
 
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     cruise_active = self.safety.get_controls_allowed()
     values = {"GAS_RELEASED": not gas, "CRUISE_ACTIVE": cruise_active}
     return self.packer.make_can_msg_panda("PCM_CRUISE", 0, values)

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -3,12 +3,12 @@ import unittest
 import numpy as np
 import random
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, make_msg, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import make_msg, set_up_test, ALTERNATIVE_EXPERIENCE
 
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
+
 
 class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
                        common.TorqueSteeringSafetyTest):
@@ -34,10 +34,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   EPS_SCALE = 0.73
 
   def setUp(self):
-    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, 73)
-    self.safety.init_tests()
+    set_up_test(self, "toyota_nodsu_pt_generated", Panda.SAFETY_TOYOTA, 73)
 
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_EPS": (torque/self.EPS_SCALE)}

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -33,11 +33,9 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conversative for rounding
   EPS_SCALE = 0.73
 
-  def setUp(self):
-    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, 73)
-    self.safety.init_tests()
+  DBC = 'toyota_nodsu_pt_generated'
+  SAFETY_MODE = Panda.SAFETY_TOYOTA
+  SAFETY_PARAM = 73
 
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_EPS": (torque/self.EPS_SCALE)}

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -51,7 +51,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     values = {"STEER_REQUEST": req, "STEER_REQUEST_2": req2, "STEER_ANGLE_CMD": angle_cmd}
     return self.packer.make_can_msg_panda("STEERING_LTA", 0, values)
 
-  def _accel_msg(self, accel):
+  def _accel_control_msg(self, accel):
     values = {"ACCEL_CMD": accel}
     return self.packer.make_can_msg_panda("ACC_CONTROL", 0, values)
 
@@ -105,7 +105,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
             should_tx = int(min_accel * 1000) <= int(accel * 1000) <= int(max_accel * 1000)
           else:
             should_tx = np.isclose(accel, 0, atol=0.0001)
-          self.assertEqual(should_tx, self._tx(self._accel_msg(accel)))
+          self.assertEqual(should_tx, self._tx(self._accel_control_msg(accel)))
 
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -3,12 +3,12 @@ import unittest
 import numpy as np
 import random
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import make_msg, set_up_test, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import CANPackerPanda, make_msg, ALTERNATIVE_EXPERIENCE
 
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
-
 
 class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
                        common.TorqueSteeringSafetyTest):
@@ -34,7 +34,10 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   EPS_SCALE = 0.73
 
   def setUp(self):
-    set_up_test(self, "toyota_nodsu_pt_generated", Panda.SAFETY_TOYOTA, 73)
+    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, 73)
+    self.safety.init_tests()
 
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_EPS": (torque/self.EPS_SCALE)}

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -33,9 +33,11 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conversative for rounding
   EPS_SCALE = 0.73
 
-  DBC = 'toyota_nodsu_pt_generated'
-  SAFETY_MODE = Panda.SAFETY_TOYOTA
-  SAFETY_PARAM = 73
+  def setUp(self):
+    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, 73)
+    self.safety.init_tests()
 
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_EPS": (torque/self.EPS_SCALE)}

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -51,7 +51,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     values = {"STEER_REQUEST": req, "STEER_REQUEST_2": req2, "STEER_ANGLE_CMD": angle_cmd}
     return self.packer.make_can_msg_panda("STEERING_LTA", 0, values)
 
-  def _accel_cmd_msg(self, accel):
+  def _accel_msg(self, accel):
     values = {"ACCEL_CMD": accel}
     return self.packer.make_can_msg_panda("ACC_CONTROL", 0, values)
 
@@ -105,7 +105,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
             should_tx = int(min_accel * 1000) <= int(accel * 1000) <= int(max_accel * 1000)
           else:
             should_tx = np.isclose(accel, 0, atol=0.0001)
-          self.assertEqual(should_tx, self._tx(self._accel_cmd_msg(accel)))
+          self.assertEqual(should_tx, self._tx(self._accel_msg(accel)))
 
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -51,7 +51,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     values = {"STEER_REQUEST": req, "STEER_REQUEST_2": req2, "STEER_ANGLE_CMD": angle_cmd}
     return self.packer.make_can_msg_panda("STEERING_LTA", 0, values)
 
-  def _accel_control_msg(self, accel):
+  def _accel_cmd_msg(self, accel):
     values = {"ACCEL_CMD": accel}
     return self.packer.make_can_msg_panda("ACC_CONTROL", 0, values)
 
@@ -105,7 +105,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
             should_tx = int(min_accel * 1000) <= int(accel * 1000) <= int(max_accel * 1000)
           else:
             should_tx = np.isclose(accel, 0, atol=0.0001)
-          self.assertEqual(should_tx, self._tx(self._accel_control_msg(accel)))
+          self.assertEqual(should_tx, self._tx(self._accel_cmd_msg(accel)))
 
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -54,13 +54,13 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("ESP_19", 0, values)
 
   # Brake light switch _esp_05_msg
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     values = {"ESP_Fahrer_bremst": brake, "COUNTER": self.cnt_esp_05 % 16}
     self.__class__.cnt_esp_05 += 1
     return self.packer.make_can_msg_panda("ESP_05", 0, values)
 
   # Driver throttle input
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"MO_Fahrpedalrohwert_01": gas, "COUNTER": self.cnt_motor_20 % 16}
     self.__class__.cnt_motor_20 += 1
     return self.packer.make_can_msg_panda("Motor_20", 0, values)
@@ -207,11 +207,11 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
       if msg == MSG_LH_EPS_03:
         to_push = self._lh_eps_03_msg(0)
       if msg == MSG_ESP_05:
-        to_push = self._brake_msg(False)
+        to_push = self._user_brake_msg(False)
       if msg == MSG_TSK_06:
         to_push = self._pcm_status_msg(True)
       if msg == MSG_MOTOR_20:
-        to_push = self._gas_msg(0)
+        to_push = self._user_gas_msg(0)
       self.assertTrue(self._rx(to_push))
       to_push[0].data[4] ^= 0xFF
       self.assertFalse(self._rx(to_push))
@@ -227,23 +227,23 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest):
       if i < MAX_WRONG_COUNTERS:
         self.safety.set_controls_allowed(1)
         self._rx(self._lh_eps_03_msg(0))
-        self._rx(self._brake_msg(False))
+        self._rx(self._user_brake_msg(False))
         self._rx(self._pcm_status_msg(True))
-        self._rx(self._gas_msg(0))
+        self._rx(self._user_gas_msg(0))
       else:
         self.assertFalse(self._rx(self._lh_eps_03_msg(0)))
-        self.assertFalse(self._rx(self._brake_msg(False)))
+        self.assertFalse(self._rx(self._user_brake_msg(False)))
         self.assertFalse(self._rx(self._pcm_status_msg(True)))
-        self.assertFalse(self._rx(self._gas_msg(0)))
+        self.assertFalse(self._rx(self._user_gas_msg(0)))
         self.assertFalse(self.safety.get_controls_allowed())
 
     # restore counters for future tests with a couple of good messages
     for i in range(2):
       self.safety.set_controls_allowed(1)
       self._rx(self._lh_eps_03_msg(0))
-      self._rx(self._brake_msg(False))
+      self._rx(self._user_brake_msg(False))
       self._rx(self._pcm_status_msg(True))
-      self._rx(self._gas_msg(0))
+      self._rx(self._user_gas_msg(0))
     self.assertTrue(self.safety.get_controls_allowed())
 
 

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -2,8 +2,9 @@
 import unittest
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import MAX_WRONG_COUNTERS, set_up_test
+from panda.tests.safety.common import CANPackerPanda, MAX_WRONG_COUNTERS
 
 MAX_RATE_UP = 4
 MAX_RATE_DOWN = 10
@@ -252,7 +253,10 @@ class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    set_up_test(self, "vw_mqb_2010", Panda.SAFETY_VOLKSWAGEN_MQB, 0)
+    self.packer = CANPackerPanda("vw_mqb_2010")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
+    self.safety.init_tests()
 
   def test_spam_cancel_safety_check(self):
     self.safety.set_controls_allowed(0)

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -2,9 +2,8 @@
 import unittest
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, MAX_WRONG_COUNTERS
+from panda.tests.safety.common import MAX_WRONG_COUNTERS, set_up_test
 
 MAX_RATE_UP = 4
 MAX_RATE_DOWN = 10
@@ -253,10 +252,7 @@ class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("vw_mqb_2010")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_MQB, 0)
-    self.safety.init_tests()
+    set_up_test(self, "vw_mqb_2010", Panda.SAFETY_VOLKSWAGEN_MQB, 0)
 
   def test_spam_cancel_safety_check(self):
     self.safety.set_controls_allowed(0)

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -63,7 +63,7 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("Bremse_1", 0, values)
 
   # Brake light switch (shared message Motor_2)
-  def _brake_msg(self, brake):
+  def _user_brake_msg(self, brake):
     # since this signal is used for engagement status, preserve current state
     return self._motor_2_msg(brake_pressed=brake, cruise_engaged=self.safety.get_controls_allowed())
 
@@ -100,7 +100,7 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("Motor_2", 0, values)
 
   # Driver throttle input (Motor_3)
-  def _gas_msg(self, gas):
+  def _user_gas_msg(self, gas):
     values = {"Fahrpedal_Rohsignal": gas}
     return self.packer.make_can_msg_panda("Motor_3", 0, values)
 

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -2,9 +2,8 @@
 import unittest
 import numpy as np
 from panda import Panda
-from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, MAX_WRONG_COUNTERS
+from panda.tests.safety.common import MAX_WRONG_COUNTERS, set_up_test
 
 MAX_RATE_UP = 4
 MAX_RATE_DOWN = 10
@@ -48,10 +47,7 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    self.packer = CANPackerPanda("vw_golf_mk4")
-    self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_PQ, 0)
-    self.safety.init_tests()
+    set_up_test(self, "vw_golf_mk4", Panda.SAFETY_VOLKSWAGEN_PQ, 0)
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -2,8 +2,9 @@
 import unittest
 import numpy as np
 from panda import Panda
+from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import MAX_WRONG_COUNTERS, set_up_test
+from panda.tests.safety.common import CANPackerPanda, MAX_WRONG_COUNTERS
 
 MAX_RATE_UP = 4
 MAX_RATE_DOWN = 10
@@ -47,7 +48,10 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest):
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
-    set_up_test(self, "vw_golf_mk4", Panda.SAFETY_VOLKSWAGEN_PQ, 0)
+    self.packer = CANPackerPanda("vw_golf_mk4")
+    self.safety = libpandasafety_py.libpandasafety
+    self.safety.set_safety_hooks(Panda.SAFETY_VOLKSWAGEN_PQ, 0)
+    self.safety.init_tests()
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)


### PR DESCRIPTION
When reviewing the safety code, every time I looked at these messages it took some mental brain power to remember what the messages were for (user or command). Adding user made it fairly obvious

Renamed `_brake_msg` to `_user_brake_msg`, and `_gas_msg` to `_user_gas_msg`