### PR TITLE
GM: allow active regen bit when gas is pressed

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -202,12 +202,12 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
       if ((gas_regen != GM_MAX_REGEN)) {
         tx = 0;
       }
-      // Stock ECU keeps apply bit set when gas is pressed
-      if (!current_controls_allowed) {
-        bool apply = GET_BYTE(to_send, 0) & 1U;
-        if (apply) {
-          tx = 0;
-        }
+    }
+    // Need to allow apply bit in pre-enabled and overriding states
+    if (!controls_allowed) {
+      bool apply = GET_BYTE(to_send, 0) & 1U;
+      if (apply) {
+        tx = 0;
       }
     }
     if (gas_regen > GM_MAX_GAS) {

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -205,7 +205,7 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     }
     // Need to allow apply bit in pre-enabled and overriding states
     if (!controls_allowed) {
-      bool apply = GET_BIT(to_send, 0);
+      bool apply = GET_BIT(to_send, 0) != 0U;
       if (apply) {
         tx = 0;
       }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -199,7 +199,7 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     // value that corresponds to max regen.
     if (!current_controls_allowed || !longitudinal_allowed) {
       // Stock ECU sends max regen when not enabled
-      if ((gas_regen != GM_MAX_REGEN)) {
+      if (gas_regen != GM_MAX_REGEN) {
         tx = 0;
       }
     }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -198,7 +198,6 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     // Disabled message is !engaged with gas
     // value that corresponds to max regen.
     if (!current_controls_allowed || !longitudinal_allowed) {
-      bool apply = GET_BYTE(to_send, 0) & 1U;
       // Stock ECU sends max regen when not enabled
       if ((gas_regen != GM_MAX_REGEN)) {
         tx = 0;

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -205,7 +205,7 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     }
     // Need to allow apply bit in pre-enabled and overriding states
     if (!controls_allowed) {
-      bool apply = GET_BIT(to_send, 0) != 0U;
+      bool apply = GET_BIT(to_send, 0U) != 0U;
       if (apply) {
         tx = 0;
       }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -205,7 +205,7 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     }
     // Need to allow apply bit in pre-enabled and overriding states
     if (!controls_allowed) {
-      bool apply = GET_BYTE(to_send, 0) & 1U;
+      bool apply = GET_BIT(to_send, 0);
       if (apply) {
         tx = 0;
       }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -200,8 +200,15 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     if (!current_controls_allowed || !longitudinal_allowed) {
       bool apply = GET_BYTE(to_send, 0) & 1U;
       // Stock ECU sends max regen when not enabled
-      if (apply || (gas_regen != GM_MAX_REGEN)) {
+      if ((gas_regen != GM_MAX_REGEN)) {
         tx = 0;
+      }
+      // Stock ECU keeps apply bit set when gas is pressed
+      if (!current_controls_allowed) {
+        bool apply = GET_BYTE(to_send, 0) & 1U;
+        if (apply) {
+          tx = 0;
+        }
       }
     }
     if (gas_regen > GM_MAX_GAS) {


### PR DESCRIPTION
Stock GM ACC keeps the active bit set (`GasRegenCmdActive`) when the user is overriding with gas, however with the addition of `longitudinal_allowed`, panda would always block these messages until a fault occurs.

Might need to use `controls_allowed` instead, as if we disengage on accelerator, we also won't allow the apply bit, which some users report causes faults as well. Will test