### PR TITLE
Honda: fix interceptor pressed mismatch

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -10,12 +10,11 @@ const CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5}, {0x194, 0, 4}, {0x1FA, 0, 8}, {0
 const CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}, {0x33DA, 0, 5}, {0x33DB, 0, 8}};  // Bosch
 const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 1, 8}, {0x1FA, 1, 8}, {0x30C, 1, 8}, {0x33D, 1, 5}, {0x33DA, 1, 5}, {0x33DB, 1, 8}, {0x39F, 1, 8}, {0x18DAB0F1, 1, 8}};  // Bosch w/ gas and brakes
 
-// panda interceptor threshold needs to be equal to openpilot threshold (1e-5)
-// If thresholds are mismatched, then if gas is in between the openpilot and panda thresholds in pre-enable,
-// then it is possible for panda to see the gas fall and rise, while openpilot believes it's still pressed, causing a controls mismatch
+// panda interceptor threshold needs to be equal to openpilot threshold (1e-5) to avoid controls mismatches
+// If thresholds are mismatched then it is possible for panda to see the gas fall and rise while openpilot is in the pre-enabled state
 // Threshold calculated from DBC gains: round((((1e-5 + 83.3) / 0.253984064) + ((1e-5 + 83.3) / 0.126992032)) / 2) = 492
 const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 492;
-#define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + ((GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2U ) / 2U) // avg between 2 tracks
+#define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + (GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2U)  // avg between 2 tracks
 const int HONDA_BOSCH_NO_GAS_VALUE = -30000; // value sent when not requesting gas
 const int HONDA_BOSCH_GAS_MAX = 2000;
 const int HONDA_BOSCH_ACCEL_MIN = -350; // max braking == -3.5m/s2

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -10,13 +10,11 @@ const CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5}, {0x194, 0, 4}, {0x1FA, 0, 8}, {0
 const CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}, {0x33DA, 0, 5}, {0x33DB, 0, 8}};  // Bosch
 const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 1, 8}, {0x1FA, 1, 8}, {0x30C, 1, 8}, {0x33D, 1, 5}, {0x33DA, 1, 5}, {0x33DB, 1, 8}, {0x39F, 1, 8}, {0x18DAB0F1, 1, 8}};  // Bosch w/ gas and brakes
 
-// Roughly calculated using the offsets in openpilot +5%:
-// In openpilot: ((gas1_norm + gas2_norm)/2) > 15
-// gas_norm1 = ((gain_dbc1*gas1) + offset_dbc)
-// gas_norm2 = ((gain_dbc2*gas2) + offset_dbc)
-// assuming that 2*(gain_dbc1*gas1) == (gain_dbc2*gas2)
-// In this safety: ((gas1 + (gas2/2))/2) > THRESHOLD
-const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 344;
+// panda interceptor threshold needs to be roughly equal to openpilot threshold (1e-5)
+// If thresholds are mismatched, then if gas is in between the openpilot and panda thresholds in pre-enable,
+// then it is possible for panda to see the gas fall and rise, while openpilot believes it's still pressed, causing a controls mismatch
+// Threshold calculated from DBC gains: round(((1e-5 + 83.3) / 0.253984064 + (1e-5 + 83.3) / 0.253984064) / 2) = 328
+const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 328;
 #define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + ((GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2U ) / 2U) // avg between 2 tracks
 const int HONDA_BOSCH_NO_GAS_VALUE = -30000; // value sent when not requesting gas
 const int HONDA_BOSCH_GAS_MAX = 2000;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -10,11 +10,11 @@ const CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5}, {0x194, 0, 4}, {0x1FA, 0, 8}, {0
 const CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}, {0x33DA, 0, 5}, {0x33DB, 0, 8}};  // Bosch
 const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 1, 8}, {0x1FA, 1, 8}, {0x30C, 1, 8}, {0x33D, 1, 5}, {0x33DA, 1, 5}, {0x33DB, 1, 8}, {0x39F, 1, 8}, {0x18DAB0F1, 1, 8}};  // Bosch w/ gas and brakes
 
-// panda interceptor threshold needs to be roughly equal to openpilot threshold (1e-5)
+// panda interceptor threshold needs to be equal to openpilot threshold (1e-5)
 // If thresholds are mismatched, then if gas is in between the openpilot and panda thresholds in pre-enable,
 // then it is possible for panda to see the gas fall and rise, while openpilot believes it's still pressed, causing a controls mismatch
-// Threshold calculated from DBC gains: round(((1e-5 + 83.3) / 0.253984064 + (1e-5 + 83.3) / 0.253984064) / 2) = 328
-const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 328;
+// Threshold calculated from DBC gains: round((((1e-5 + 83.3) / 0.253984064) + ((1e-5 + 83.3) / 0.126992032)) / 2) = 492
+const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 492;
 #define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + ((GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2U ) / 2U) // avg between 2 tracks
 const int HONDA_BOSCH_NO_GAS_VALUE = -30000; // value sent when not requesting gas
 const int HONDA_BOSCH_GAS_MAX = 2000;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -12,7 +12,7 @@ const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 
 
 // panda interceptor threshold needs to be equivalent to openpilot threshold to avoid controls mismatches
 // If thresholds are mismatched then it is possible for panda to see the gas fall and rise while openpilot is in the pre-enabled state
-// Threshold calculated from DBC gains: round((((1e-5 + 83.3) / 0.253984064) + ((1e-5 + 83.3) / 0.126992032)) / 2) = 492
+// Threshold calculated from DBC gains: round(((83.3 / 0.253984064) + (83.3 / 0.126992032)) / 2) = 492
 const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 492;
 #define HONDA_GET_INTERCEPTOR(msg) (((GET_BYTE((msg), 0) << 8) + GET_BYTE((msg), 1) + (GET_BYTE((msg), 2) << 8) + GET_BYTE((msg), 3)) / 2U)  // avg between 2 tracks
 const int HONDA_BOSCH_NO_GAS_VALUE = -30000; // value sent when not requesting gas

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -10,7 +10,7 @@ const CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5}, {0x194, 0, 4}, {0x1FA, 0, 8}, {0
 const CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}, {0x33DA, 0, 5}, {0x33DB, 0, 8}};  // Bosch
 const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 1, 8}, {0x1FA, 1, 8}, {0x30C, 1, 8}, {0x33D, 1, 5}, {0x33DA, 1, 5}, {0x33DB, 1, 8}, {0x39F, 1, 8}, {0x18DAB0F1, 1, 8}};  // Bosch w/ gas and brakes
 
-// panda interceptor threshold needs to be equivalent to openpilot threshold (1e-5) to avoid controls mismatches
+// panda interceptor threshold needs to be equivalent to openpilot threshold to avoid controls mismatches
 // If thresholds are mismatched then it is possible for panda to see the gas fall and rise while openpilot is in the pre-enabled state
 // Threshold calculated from DBC gains: round((((1e-5 + 83.3) / 0.253984064) + ((1e-5 + 83.3) / 0.126992032)) / 2) = 492
 const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 492;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -10,7 +10,7 @@ const CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5}, {0x194, 0, 4}, {0x1FA, 0, 8}, {0
 const CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5}, {0xE5, 0, 8}, {0x296, 1, 4}, {0x33D, 0, 5}, {0x33DA, 0, 5}, {0x33DB, 0, 8}};  // Bosch
 const CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5}, {0x1DF, 1, 8}, {0x1EF, 1, 8}, {0x1FA, 1, 8}, {0x30C, 1, 8}, {0x33D, 1, 5}, {0x33DA, 1, 5}, {0x33DB, 1, 8}, {0x39F, 1, 8}, {0x18DAB0F1, 1, 8}};  // Bosch w/ gas and brakes
 
-// panda interceptor threshold needs to be equal to openpilot threshold (1e-5) to avoid controls mismatches
+// panda interceptor threshold needs to be equivalent to openpilot threshold (1e-5) to avoid controls mismatches
 // If thresholds are mismatched then it is possible for panda to see the gas fall and rise while openpilot is in the pre-enabled state
 // Threshold calculated from DBC gains: round((((1e-5 + 83.3) / 0.253984064) + ((1e-5 + 83.3) / 0.126992032)) / 2) = 492
 const int HONDA_GAS_INTERCEPTOR_THRESHOLD = 492;

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -21,11 +21,10 @@ HONDA_BOSCH = 1
 
 def interceptor_msg(gas, addr):
   to_send = make_msg(0, addr, 6)
-  gas2 = gas * 2
   to_send[0].data[0] = (gas & 0xFF00) >> 8
   to_send[0].data[1] = gas & 0xFF
-  to_send[0].data[2] = (gas2 & 0xFF00) >> 8
-  to_send[0].data[3] = gas2 & 0xFF
+  to_send[0].data[2] = (gas & 0xFF00) >> 8
+  to_send[0].data[3] = gas & 0xFF
   return to_send
 
 

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -296,7 +296,7 @@ class TestHondaNidecSafetyBase(HondaBase):
   PT_BUS = 0
   STEER_BUS = 0
 
-  INTERCEPTOR_THRESHOLD = 344
+  INTERCEPTOR_THRESHOLD = 328
 
   @classmethod
   def setUpClass(cls):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -296,7 +296,7 @@ class TestHondaNidecSafetyBase(HondaBase):
   PT_BUS = 0
   STEER_BUS = 0
 
-  INTERCEPTOR_THRESHOLD = 328
+  INTERCEPTOR_THRESHOLD = 492
 
   @classmethod
   def setUpClass(cls):


### PR DESCRIPTION
If the panda interceptor threshold for gas pressed is higher than openpilot and if we're in between the thresholds, then in the pre-enable state, it is possible for the signal to fall below the panda threshold (so gas not pressed), then rise above the panda threshold (causing a rising edge of gas pressed). `controls_allowed` then gets set to 0, all while openpilot thinks the gas is pressed and is still in the pre-enabled state, then when the gas is released for openpilot we try to send messages and we get a controlsMismatch event.