### PR TITLE
sample_t: fixup comments

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -320,7 +320,7 @@ int to_signed(int d, int bits) {
   return d_signed;
 }
 
-// given a new sample, update the smaple_t struct
+// given a new sample, update the sample_t struct
 void update_sample(struct sample_t *sample, int sample_new) {
   int sample_size = sizeof(sample->values) / sizeof(sample->values[0]);
   for (int i = sample_size - 1; i > 0; i--) {

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -7,7 +7,7 @@
 const int MAX_WRONG_COUNTERS = 5;
 const uint8_t MAX_MISSED_MSGS = 10U;
 
-// sample struct that keeps 3 samples in memory
+// sample struct that keeps 6 samples in memory
 struct sample_t {
   int values[6];
   int min;
@@ -118,14 +118,14 @@ int cruise_button_prev = 0;
 // for safety modes with torque steering control
 int desired_torque_last = 0;       // last desired steer torque
 int rt_torque_last = 0;            // last desired torque for real time check
-struct sample_t torque_meas;       // last 3 motor torques produced by the eps
-struct sample_t torque_driver;     // last 3 driver torques measured
+struct sample_t torque_meas;       // last 6 motor torques produced by the eps
+struct sample_t torque_driver;     // last 6 driver torques measured
 uint32_t ts_last = 0;
 
 // for safety modes with angle steering control
 uint32_t ts_angle_last = 0;
 int desired_angle_last = 0;
-struct sample_t angle_meas;         // last 3 steer angles
+struct sample_t angle_meas;         // last 6 steer angles
 
 // This can be set with a USB command
 // It enables features that allow alternative experiences, like not disengaging on gas press


### PR DESCRIPTION
Size was changed in this commit, but comments never updated: https://github.com/commaai/panda/commit/bf70f5159649a581a023e0c271ea4df53eacc2e9