### PR TITLE
update cppcheck to 2.13

### DIFF
--- a/tests/misra/coverage_table
+++ b/tests/misra/coverage_table
@@ -1,11 +1,11 @@
 1.1     
-1.2     
+1.2     X (Addon)
 1.3     X (Cppcheck)
 2.1     X (Cppcheck)
-2.2     X (Cppcheck)
-2.3     
-2.4     
-2.5     
+2.2     X (Addon)
+2.3     X (Addon)
+2.4     X (Addon)
+2.5     X (Addon)
 2.6     X (Cppcheck)
 2.7     X (Addon)
 3.1     X (Addon)
@@ -17,45 +17,45 @@
 5.3     X (Cppcheck)
 5.4     X (Addon)
 5.5     X (Addon)
-5.6     
-5.7     
-5.8     
-5.9     
+5.6     X (Addon)
+5.7     X (Addon)
+5.8     X (Addon)
+5.9     X (Addon)
 6.1     X (Addon)
 6.2     X (Addon)
 7.1     X (Addon)
 7.2     X (Addon)
 7.3     X (Addon)
 7.4     X (Addon)
-8.1     
+8.1     X (Addon)
 8.2     X (Addon)
 8.3     X (Cppcheck)
-8.4     
-8.5     
-8.6     
-8.7     
-8.8     
-8.9     
-8.10    
+8.4     X (Addon)
+8.5     X (Addon)
+8.6     X (Addon)
+8.7     X (Addon)
+8.8     X (Addon)
+8.9     X (Addon)
+8.10    X (Addon)
 8.11    X (Addon)
 8.12    X (Addon)
-8.13    
+8.13    X (Cppcheck)
 8.14    X (Addon)
-9.1     
+9.1     X (Cppcheck)
 9.2     X (Addon)
 9.3     X (Addon)
 9.4     X (Addon)
 9.5     X (Addon)
 10.1    X (Addon)
 10.2    X (Addon)
-10.3    
+10.3    X (Addon)
 10.4    X (Addon)
-10.5    
+10.5    X (Addon)
 10.6    X (Addon)
-10.7    
+10.7    X (Addon)
 10.8    X (Addon)
-11.1    
-11.2    
+11.1    X (Addon)
+11.2    X (Addon)
 11.3    X (Addon)
 11.4    X (Addon)
 11.5    X (Addon)
@@ -66,7 +66,7 @@
 12.1    X (Addon)
 12.2    X (Addon)
 12.3    X (Addon)
-12.4    
+12.4    X (Addon)
 13.1    X (Addon)
 13.2    X (Cppcheck)
 13.3    X (Addon)
@@ -75,7 +75,7 @@
 13.6    X (Addon)
 14.1    X (Addon)
 14.2    X (Addon)
-14.3    
+14.3    X (Cppcheck)
 14.4    X (Addon)
 15.1    X (Addon)
 15.2    X (Addon)
@@ -84,7 +84,7 @@
 15.5    X (Addon)
 15.6    X (Addon)
 15.7    X (Addon)
-16.1    
+16.1    X (Addon)
 16.2    X (Addon)
 16.3    X (Addon)
 16.4    X (Addon)
@@ -93,8 +93,8 @@
 16.7    X (Addon)
 17.1    X (Addon)
 17.2    X (Addon)
-17.3    
-17.4    
+17.3    X (Addon)
+17.4    X (Cppcheck)
 17.5    X (Cppcheck)
 17.6    X (Addon)
 17.7    X (Addon)
@@ -107,7 +107,7 @@
 18.6    X (Cppcheck)
 18.7    X (Addon)
 18.8    X (Addon)
-19.1    
+19.1    X (Cppcheck)
 19.2    X (Addon)
 20.1    X (Addon)
 20.2    X (Addon)
@@ -116,15 +116,15 @@
 20.5    X (Addon)
 20.6    X (Cppcheck)
 20.7    X (Addon)
-20.8    
-20.9    
+20.8    X (Addon)
+20.9    X (Addon)
 20.10   X (Addon)
-20.11   
-20.12   
+20.11   X (Addon)
+20.12   X (Addon)
 20.13   X (Addon)
 20.14   X (Addon)
 21.1    X (Addon)
-21.2    
+21.2    X (Addon)
 21.3    X (Addon)
 21.4    X (Addon)
 21.5    X (Addon)
@@ -135,9 +135,22 @@
 21.10   X (Addon)
 21.11   X (Addon)
 21.12   X (Addon)
+21.13   X (Cppcheck)
+21.14   X (Addon)
+21.15   X (Addon)
+21.16   X (Addon)
+21.17   X (Cppcheck)
+21.18   X (Cppcheck)
+21.19   X (Addon)
+21.20   X (Addon)
+21.21   X (Addon)
 22.1    X (Cppcheck)
 22.2    X (Cppcheck)
-22.3    
+22.3    X (Cppcheck)
 22.4    X (Cppcheck)
-22.5    
+22.5    X (Addon)
 22.6    X (Cppcheck)
+22.7    X (Addon)
+22.8    X (Addon)
+22.9    X (Addon)
+22.10   X (Addon)

--- a/tests/misra/install.sh
+++ b/tests/misra/install.sh
@@ -9,7 +9,8 @@ if [ ! -d "$CPPCHECK_DIR" ]; then
 fi
 
 cd $CPPCHECK_DIR
-git fetch --all
-git checkout 2.13.0
+VERS="2.13.0"
+git fetch origin $VERS
+git checkout $VERS
 make clean
 make MATCHCOMPILTER=yes CXXFLAGS="-O2" -j8

--- a/tests/misra/install.sh
+++ b/tests/misra/install.sh
@@ -9,8 +9,7 @@ if [ ! -d "$CPPCHECK_DIR" ]; then
 fi
 
 cd $CPPCHECK_DIR
-git fetch
-git checkout e1cff1d1ef92f6a1c6962e0e4153b7353ccad04c
-git -c user.name=a -c user.email="a@b.c" cherry-pick 7199dde1618b5166735f07619dcdb9f4eafdb557
+git fetch --all
+git checkout 2.12.0
 make clean
 make MATCHCOMPILTER=yes CXXFLAGS="-O2" -j8

--- a/tests/misra/install.sh
+++ b/tests/misra/install.sh
@@ -10,6 +10,6 @@ fi
 
 cd $CPPCHECK_DIR
 git fetch --all
-git checkout 2.12.0
+git checkout 2.13.0
 make clean
 make MATCHCOMPILTER=yes CXXFLAGS="-O2" -j8

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -11,3 +11,39 @@ misra-c2012-20.10
 
 # needed since not all of these suppressions are applicable to all builds
 unmatchedSuppression
+
+# new errors from updating cppcheck
+unusedFunction
+constParameterPointer
+constParameterCallback
+knownConditionTrueFalse
+
+misra-config
+misra-c2012-2.5
+misra-c2012-2.7
+misra-c2012-8.7
+misra-c2012-10.1
+misra-c2012-10.6
+misra-c2012-12.2
+misra-c2012-21.1
+misra-c2012-21.2
+misra-c2012-21.14
+misra-c2012-21.15
+misra-c2012-21.16
+
+misra-c2012-10.3
+misra-c2012-10.4
+misra-c2012-10.5
+misra-c2012-10.7
+misra-c2012-1.2
+misra-c2012-14.2
+misra-c2012-17.3
+misra-c2012-2.2
+misra-c2012-2.3
+misra-c2012-2.4
+misra-c2012-5.6
+misra-c2012-5.8
+misra-c2012-7.2
+misra-c2012-8.2
+misra-c2012-8.4
+misra-c2012-8.6

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -12,38 +12,41 @@ misra-c2012-20.10
 # needed since not all of these suppressions are applicable to all builds
 unmatchedSuppression
 
-# new errors from updating cppcheck
+# all of the below suppressions are from new checks introduced after updating
+# cppcheck from 2.5 -> 2.13. they are listed here to separate the update from
+# fixing the violations and all are intended to be removed soon after
+
 unusedFunction
 constParameterPointer
 constParameterCallback
 knownConditionTrueFalse
 
 misra-config
-misra-c2012-2.5
-misra-c2012-2.7
-misra-c2012-8.7
-misra-c2012-10.1
-misra-c2012-10.6
-misra-c2012-12.2
-misra-c2012-21.1
-misra-c2012-21.2
-misra-c2012-21.14
-misra-c2012-21.15
-misra-c2012-21.16
-
-misra-c2012-10.3
-misra-c2012-10.4
-misra-c2012-10.5
-misra-c2012-10.7
 misra-c2012-1.2
-misra-c2012-14.2
-misra-c2012-17.3
 misra-c2012-2.2
 misra-c2012-2.3
 misra-c2012-2.4
+misra-c2012-2.5
+misra-c2012-2.7
+misra-c2012-8.7
 misra-c2012-5.6
 misra-c2012-5.8
 misra-c2012-7.2
 misra-c2012-8.2
 misra-c2012-8.4
 misra-c2012-8.6
+misra-c2012-10.1
+misra-c2012-10.6
+misra-c2012-10.3
+misra-c2012-10.4
+misra-c2012-10.5
+misra-c2012-10.7
+misra-c2012-12.2
+misra-c2012-14.2
+misra-c2012-17.3
+misra-c2012-21.1
+misra-c2012-21.2
+misra-c2012-21.14
+misra-c2012-21.15
+misra-c2012-21.16
+

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -4,14 +4,10 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PANDA_DIR=$DIR/../../
 
-GREEN='\033[0;32m'
+GREEN="\e[1;32m"
 NC='\033[0m'
 
-GCC_INC="$(arm-none-eabi-gcc -print-file-name=include)"
 : "${CPPCHECK_DIR:=$DIR/cppcheck/}"
-CPPCHECK="$CPPCHECK_DIR/cppcheck --enable=all --force --inline-suppr -I $PANDA_DIR/board/ -I $GCC_INC \
-          --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
-          --suppress=*:*include/* --error-exitcode=2 --addon=misra"
 
 # install cppcheck if missing
 if [ ! -d $CPPCHECK_DIR ]; then
@@ -30,13 +26,37 @@ fi
 cd $PANDA_DIR
 scons -j8
 
+# TODO: sanity check the coverage report output from --checkers-report
+
+cppcheck() {
+  report="$(mktemp)"
+  $CPPCHECK_DIR/cppcheck --enable=all --force --inline-suppr -I $PANDA_DIR/board/ \
+          -I $gcc_inc "$(arm-none-eabi-gcc -print-file-name=include)" \
+          --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
+          --suppress=*:*include/* --error-exitcode=2 --addon=misra --checkers-report=$report  \
+          "$@"
+
+  # sanity check the reported coverage
+  no="$(grep '^No ' $report | wc -l)"
+  yes="$(grep '^Yes' $report | wc -l)"
+  echo "$yes checks enabled, $no disabled"
+  if [[ $yes -lt 250 ]]; then
+    echo "Count of enabled checks seems too low."
+    exit 1
+  fi
+  if [[ $no -ne 99 ]]; then
+    echo "Disabled check count threshold doesn't match, update to $no"
+    exit 1
+  fi
+}
+
 printf "\n${GREEN}** PANDA F4 CODE **${NC}\n"
-$CPPCHECK -DCAN3 -DPANDA -DSTM32F4 -UPEDAL -DUID_BASE board/main.c
+cppcheck -DCAN3 -DPANDA -DSTM32F4 -UPEDAL -DUID_BASE board/main.c
 
 printf "\n${GREEN}** PANDA H7 CODE **${NC}\n"
-$CPPCHECK -DCAN3 -DPANDA -DSTM32H7 -UPEDAL -DUID_BASE board/main.c
+cppcheck -DCAN3 -DPANDA -DSTM32H7 -UPEDAL -DUID_BASE board/main.c
 
 printf "\n${GREEN}** PEDAL CODE **${NC}\n"
-$CPPCHECK -UCAN3 -UPANDA -DSTM32F2 -DPEDAL -UUID_BASE board/pedal/main.c
+cppcheck -UCAN3 -UPANDA -DSTM32F2 -DPEDAL -UUID_BASE board/pedal/main.c
 
 printf "\n${GREEN}Success!${NC} took $SECONDS seconds\n"

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -26,14 +26,16 @@ fi
 cd $PANDA_DIR
 scons -j8
 
-# TODO: sanity check the coverage report output from --checkers-report
-
 cppcheck() {
+  build_dir=/tmp/cppcheck_build
+  mkdir -p $build_dir
+
   report="$(mktemp)"
   $CPPCHECK_DIR/cppcheck --enable=all --force --inline-suppr -I $PANDA_DIR/board/ \
           -I $gcc_inc "$(arm-none-eabi-gcc -print-file-name=include)" \
           --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
           --suppress=*:*include/* --error-exitcode=2 --addon=misra --checkers-report=$report  \
+          --cppcheck-build-dir=$build_dir \
           "$@"
 
   # sanity check the reported coverage


### PR DESCRIPTION
According to the release notes, `Misra C 2012 compliance has been "completed"`.