### PR TITLE
Hyundai: use GET_BIT and fix safety on incorrect bits

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -230,7 +230,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
     }
 
     if (addr == 916) {
-      brake_pressed = (GET_BYTE(to_push, 6) >> 7) != 0U;
+      brake_pressed = GET_BIT(to_push, 55U) != 0U;
     }
 
     bool stock_ecu_detected = (addr == 832);
@@ -259,8 +259,8 @@ static int hyundai_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
   // FCA11: Block any potential actuation
   if (addr == 909) {
     int CR_VSM_DecCmd = GET_BYTE(to_send, 1);
-    int FCA_CmdAct = (GET_BYTE(to_send, 2) >> 5) & 1U;
-    int CF_VSM_DecCmdAct = (GET_BYTE(to_send, 3) >> 7) & 1U;
+    int FCA_CmdAct = GET_BIT(to_send, 20U);
+    int CF_VSM_DecCmdAct = GET_BIT(to_send, 31U);
 
     if ((CR_VSM_DecCmd != 0) || (FCA_CmdAct != 0) || (CF_VSM_DecCmdAct != 0)) {
       tx = 0;
@@ -273,7 +273,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     int desired_accel_val = ((GET_BYTE(to_send, 5) << 3) | (GET_BYTE(to_send, 4) >> 5)) - 1023U;
 
     int aeb_decel_cmd = GET_BYTE(to_send, 2);
-    int aeb_req = (GET_BYTE(to_send, 6) >> 6) & 1U;
+    int aeb_req = GET_BIT(to_send, 54U);
 
     bool violation = 0;
 

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -329,20 +329,21 @@ class TestHyundaiLongitudinalSafety(TestHyundaiSafety):
     }
     return self.packer.make_can_msg_panda("SCC12", 0, values)
 
-  def _send_fca11_msg(self, idx=0, aeb_req=False, aeb_decel=0):
+  def _send_fca11_msg(self, idx=0, vsm_aeb_req=False, fca_aeb_req=False, aeb_decel=0):
     values = {
       "CR_FCA_Alive": ((-((idx % 0xF) + 2) % 4) << 2) + 1,
       "Supplemental_Counter": idx % 0xF,
       "FCA_Status": 2,
       "CR_VSM_DecCmd": aeb_decel,
-      "CF_VSM_DecCmdAct": int(aeb_req),
-      "FCA_CmdAct": int(aeb_req),
+      "CF_VSM_DecCmdAct": int(vsm_aeb_req),
+      "FCA_CmdAct": int(fca_aeb_req),
     }
     return self.packer.make_can_msg_panda("FCA11", 0, values)
 
   def test_no_aeb_fca11(self):
     self.assertTrue(self._tx(self._send_fca11_msg()))
-    self.assertFalse(self._tx(self._send_fca11_msg(aeb_req=True)))
+    self.assertFalse(self._tx(self._send_fca11_msg(vsm_aeb_req=True)))
+    self.assertFalse(self._tx(self._send_fca11_msg(fca_aeb_req=True)))
     self.assertFalse(self._tx(self._send_fca11_msg(aeb_decel=1.0)))
 
   def test_no_aeb_scc12(self):


### PR DESCRIPTION
This fixes an incorrect signal, always looking at `FCA_CmdAct` instead of `FCA_CmdAct`