### PR TITLE
Toyota: forward ACC messages if stock longitudinal

### DIFF
--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -287,7 +287,7 @@ static int toyota_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
     // in TSS2, 0x191 is LTA which we need to block to avoid controls collision
     int is_lkas_msg = ((addr == 0x2E4) || (addr == 0x412) || (addr == 0x191));
     // in TSS2 the camera does ACC as well, so filter 0x343
-    int is_acc_msg = (addr == 0x343);
+    int is_acc_msg = !toyota_stock_longitudinal && (addr == 0x343);
     int block_msg = is_lkas_msg || is_acc_msg;
     if (!block_msg) {
       bus_fwd = 0;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -288,7 +288,7 @@ static int toyota_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
     int is_lkas_msg = ((addr == 0x2E4) || (addr == 0x412) || (addr == 0x191));
     // in TSS2 the camera does ACC as well, so filter 0x343
     int is_acc_msg = (addr == 0x343);
-    int block_msg = is_lkas_msg || (is_acc_msg && !toyota_stock_long);
+    int block_msg = is_lkas_msg || (is_acc_msg && !toyota_stock_longitudinal);
     if (!block_msg) {
       bus_fwd = 0;
     }

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -287,8 +287,8 @@ static int toyota_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
     // in TSS2, 0x191 is LTA which we need to block to avoid controls collision
     int is_lkas_msg = ((addr == 0x2E4) || (addr == 0x412) || (addr == 0x191));
     // in TSS2 the camera does ACC as well, so filter 0x343
-    int is_acc_msg = !toyota_stock_longitudinal && (addr == 0x343);
-    int block_msg = is_lkas_msg || is_acc_msg;
+    int is_acc_msg = (addr == 0x343);
+    int block_msg = is_lkas_msg || (is_acc_msg && !toyota_stock_long);
     if (!block_msg) {
       bus_fwd = 0;
     }

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -192,7 +192,7 @@ class TestToyotaStockLongitudinal(TestToyotaSafety):
         self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
 
   def test_fwd_hook(self):
-    # remove 0x343
+    # remove ACC_CONTROL
     self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
     super().test_fwd_hook()
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -192,7 +192,7 @@ class TestToyotaStockLongitudinal(TestToyotaSafety):
         self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
 
   def test_fwd_hook(self):
-    # remove ACC_CONTROL
+    # forward ACC_CONTROL
     self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
     super().test_fwd_hook()
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -191,6 +191,11 @@ class TestToyotaStockLongitudinal(TestToyotaSafety):
         should_tx = np.isclose(accel, 0, atol=0.0001)
         self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
 
+  def test_fwd_hook(self):
+    # remove 0x343
+    self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
+    super().test_fwd_hook()
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
we have toyota_stock_longitudinal in safety_toyota.h

can we not block 0x343 if toyota_stock_longitudinal is set to true?