### PR TITLE
Note about panda jungle udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
 EOF
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
-The Panda Jungle uses different udev rules, see [the repo](https://github.com/commaai/panda_jungle#udev-rules) for instructions. 
+
+The panda jungle uses different udev rules. See [the repo](https://github.com/commaai/panda_jungle#udev-rules) for instructions. 
+
 ### JavaScript
 
 See [PandaJS](https://github.com/commaai/pandajs)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
 EOF
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
-
+The Panda Jungle uses different udev rules, see [the repo](https://github.com/commaai/panda_jungle#udev-rules) for instructions. 
 ### JavaScript
 
 See [PandaJS](https://github.com/commaai/pandajs)


### PR DESCRIPTION
Another gotcha as users may think that adding panda udev rules for panda also covers the panda jungle. Not adding the rules and running `can_replay.py` results in a hang with no error, which may confuse users.