### PR TITLE
Toyota: limit using driver torque

### DIFF
--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -5,7 +5,7 @@ const int TOYOTA_MAX_TORQUE = 1500;       // max torque cmd allowed ever
 // packet is sent at 100hz, so this limit is 1500/sec
 const int TOYOTA_MAX_RATE_UP = 15;        // ramp up slow
 const int TOYOTA_MAX_RATE_DOWN = 25;      // ramp down fast
-const int TOYOTA_DRIVER_TORQUE_ALLOWANCE = 10;
+const int TOYOTA_DRIVER_TORQUE_ALLOWANCE = 100;
 const int TOYOTA_DRIVER_TORQUE_FACTOR = 10;
 
 // real time torque limit to prevent controls spamming

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -21,8 +21,7 @@ def interceptor_msg(gas, addr):
   return to_send
 
 
-class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
-                       common.TorqueSteeringSafetyTest):
+class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest):
 
   TX_MSGS = [[0x283, 0], [0x2E6, 0], [0x2E7, 0], [0x33E, 0], [0x344, 0], [0x365, 0], [0x366, 0], [0x4CB, 0],  # DSU bus 0
              [0x128, 1], [0x141, 1], [0x160, 1], [0x161, 1], [0x470, 1],  # DSU bus 1
@@ -38,9 +37,10 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   MAX_RATE_UP = 15
   MAX_RATE_DOWN = 25
   MAX_TORQUE = 1500
+  DRIVER_TORQUE_ALLOWANCE = 100
+  DRIVER_TORQUE_FACTOR = 10
   MAX_RT_DELTA = 450
   RT_INTERVAL = 250000
-  MAX_TORQUE_ERROR = 350
   TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conservative for rounding
   EPS_SCALE = 73
 


### PR DESCRIPTION
Will verify all cars have similar driver torque scales, but shouldn't need an EPS factor