### PR TITLE
Toyota steer fault workaround safety

### DIFF
--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -262,7 +262,7 @@ static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
       // no torque if controls is not allowed or apply bit not set
       if (desired_torque != 0) {
         bool no_steer_req_allowed = toyota_rate_limit_counter > TOYOTA_MAX_STEER_RATE_SAMPLES;
-        if (!controls_allowed || (!steer_req || no_steer_req_allowed)) {
+        if (!controls_allowed || (!steer_req && !no_steer_req_allowed)) {
           violation = 1;
         }
         if (no_steer_req_allowed) {


### PR DESCRIPTION
I did all my testing on vl, not vl_all (message based), and I believe that the fault is also time based (faults in the same time sending at 50hz vs 100hz), so I'm not sure how the car will respond to doing the torque cutting on messages vs. time/frames

Will make another PR that just allows one message with mismatched steer_req bit as that will allow the correct torque cutting from openpilot, and also be easier for the Hyundai fault workaround as well

In short, do we want to allow the behavior of a mismatched torque request bit from openpilot at any time, or do we want to do an identical check on openpilot's side?