### PR TITLE
Toyota: check STEER_REQUEST bit

### DIFF
--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -214,8 +214,8 @@ static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     // STEER: safety check on bytes 2-3
     if (addr == 0x2E4) {
       int desired_torque = (GET_BYTE(to_send, 1) << 8) | GET_BYTE(to_send, 2);
-      bool steer_req = GET_BIT(to_send, 0U) != 0U;
       desired_torque = to_signed(desired_torque, 16);
+      bool steer_req = GET_BIT(to_send, 0U) != 0U;
       bool violation = 0;
 
       uint32_t ts = microsecond_timer_get();

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -244,7 +244,7 @@ static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
       }
 
       // no torque if controls is not allowed or mismatch with STEER_REQUEST bit
-      if (!(controls_allowed && steer_req) && (desired_torque != 0)) {
+      if ((!controls_allowed || !steer_req) && (desired_torque != 0)) {
         violation = 1;
       }
 

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -214,6 +214,7 @@ static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     // STEER: safety check on bytes 2-3
     if (addr == 0x2E4) {
       int desired_torque = (GET_BYTE(to_send, 1) << 8) | GET_BYTE(to_send, 2);
+      bool steer_req = GET_BIT(to_send, 0U) != 0U;
       desired_torque = to_signed(desired_torque, 16);
       bool violation = 0;
 
@@ -242,8 +243,8 @@ static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
         }
       }
 
-      // no torque if controls is not allowed
-      if (!controls_allowed && (desired_torque != 0)) {
+      // no torque if controls is not allowed or mismatch with STEER_REQUEST bit
+      if (!(controls_allowed && steer_req) && (desired_torque != 0)) {
         violation = 1;
       }
 

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -131,7 +131,7 @@ class TorqueSteeringSafetyTest(PandaSafetyTestBase):
     pass
 
   @abc.abstractmethod
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     pass
 
   def _set_prev_torque(self, t):

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -61,7 +61,7 @@ class TestChryslerSafety(common.PandaSafetyTest, common.TorqueSteeringSafetyTest
     self.__class__.cnt_torque_meas += 1
     return self.packer.make_can_msg_panda("EPS_STATUS", 0, values)
 
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     values = {"LKAS_STEERING_TORQUE": torque}
     return self.packer.make_can_msg_panda("LKAS_COMMAND", 0, values)
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -89,7 +89,7 @@ class TestGmSafety(common.PandaSafetyTest):
     values = {"LKADriverAppldTrq": torque}
     return self.packer.make_can_msg_panda("PSCMStatus", 0, values)
 
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     values = {"LKASteeringCmd": torque}
     return self.packer.make_can_msg_panda("ASCMLKASteeringCmd", 0, values)
 

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -119,7 +119,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
     values = {"CR_Mdps_StrColTq": torque}
     return self.packer.make_can_msg_panda("MDPS12", 0, values)
 
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     values = {"CR_Lkas_StrToqReq": torque}
     return self.packer.make_can_msg_panda("LKAS11", 0, values)
 

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -39,7 +39,7 @@ class TestMazdaSafety(common.PandaSafetyTest):
 #    values = {"STEER_TORQUE_DRIVER": torque}
 #    return self.packer.make_can_msg_panda("STEER_TORQUE", 0, values)
 
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     values = {"LKAS_REQUEST": torque}
     return self.packer.make_can_msg_panda("CAM_LKAS", 0, values)
 

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -58,7 +58,7 @@ class TestSubaruSafety(common.PandaSafetyTest):
     self.__class__.cnt_brake += 1
     return self.packer.make_can_msg_panda("Brake_Status", 0, values)
 
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     values = {"LKAS_Output": torque}
     return self.packer.make_can_msg_panda("ES_LKAS", 0, values)
 

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -50,7 +50,7 @@ class TestSubaruLegacySafety(common.PandaSafetyTest):
     values = {"Brake_Pedal": brake}
     return self.packer.make_can_msg_panda("Brake_Pedal", 0, values)
 
-  def _torque_msg(self, torque):
+  def _torque_msg(self, torque, steer_req=1):
     values = {"LKAS_Command": torque}
     return self.packer.make_can_msg_panda("ES_LKAS", 0, values)
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -141,9 +141,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     """
       On Toyota, you can ramp up torque and then set the steer_req bit and the EPS will ramp up faster than
       the effective panda safety limits. This tests:
-        - Nothing is sent when cutting torque after the first message
+        - Nothing is sent when cutting torque
         - Nothing is blocked when sending torque normally
-        - We can recover after a mismatch
     """
     self.safety.set_controls_allowed(True)
     for _ in range(100):

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -54,8 +54,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     values = {"STEER_TORQUE_EPS": (torque / self.EPS_SCALE) * 100.}
     return self.packer.make_can_msg_panda("STEER_TORQUE_SENSOR", 0, values)
 
-  def _torque_msg(self, torque):
-    values = {"STEER_TORQUE_CMD": torque}
+  def _torque_msg(self, torque, steer_req=1):
+    values = {"STEER_TORQUE_CMD": torque, "STEER_REQUEST": steer_req}
     return self.packer.make_can_msg_panda("STEERING_LKA", 0, values)
 
   def _lta_msg(self, req, req2, angle_cmd):
@@ -136,6 +136,22 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
         angle = random.randint(-50, 50)
         should_tx = not req and not req2 and angle == 0
         self.assertEqual(should_tx, self._tx(self._lta_msg(req, req2, angle)))
+
+  def test_steer_req_bit(self):
+    """
+      On Toyota, you can ramp up torque and then set the steer_req bit and the EPS will ramp up faster than
+      the effective panda safety limits. This tests:
+        - Nothing is blocked when sending torque normally
+        - Nothing is sent when cutting torque after the first message
+    """
+    self.safety.set_controls_allowed(True)
+    self._set_prev_torque(self.MAX_TORQUE)
+    for _ in range(100):
+      self.assertTrue(self._tx(self._torque_msg(self.MAX_TORQUE, steer_req=1)))
+
+    for _ in range(100):
+      self._set_prev_torque(self.MAX_TORQUE)
+      self.assertFalse(self._tx(self._torque_msg(self.MAX_TORQUE, steer_req=0)))
 
   def test_rx_hook(self):
     # checksum checks

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -141,17 +141,18 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     """
       On Toyota, you can ramp up torque and then set the steer_req bit and the EPS will ramp up faster than
       the effective panda safety limits. This tests:
-        - Nothing is blocked when sending torque normally
         - Nothing is sent when cutting torque after the first message
+        - Nothing is blocked when sending torque normally
+        - We can recover after a mismatch
     """
     self.safety.set_controls_allowed(True)
-    self._set_prev_torque(self.MAX_TORQUE)
-    for _ in range(100):
-      self.assertTrue(self._tx(self._torque_msg(self.MAX_TORQUE, steer_req=1)))
-
     for _ in range(100):
       self._set_prev_torque(self.MAX_TORQUE)
       self.assertFalse(self._tx(self._torque_msg(self.MAX_TORQUE, steer_req=0)))
+
+    self._set_prev_torque(self.MAX_TORQUE)
+    for _ in range(100):
+      self.assertTrue(self._tx(self._torque_msg(self.MAX_TORQUE, steer_req=1)))
 
   def test_rx_hook(self):
     # checksum checks

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -139,8 +139,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
 
   def test_steer_req_bit(self):
     """
-      On Toyota, you can ramp up torque and then set the steer_req bit and the EPS will ramp up faster than
-      the effective panda safety limits. This tests:
+      On Toyota, you can ramp up torque and then set the STEER_REQUEST bit and the
+      EPS will ramp up faster than the effective panda safety limits. This tests:
         - Nothing is sent when cutting torque
         - Nothing is blocked when sending torque normally
     """


### PR DESCRIPTION
We could previously ramp up while the bit is 0 and then set to 1 and effectively bypass the openpilot and panda torque rate limits (although not too much as the max torque would be imposed to 350 away from the current due to the torque blending)