### PR TITLE
Hyundai: check CF_Lkas_ActToi bit

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -296,6 +296,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
   // LKA STEER: safety check
   if (addr == 832) {
     int desired_torque = ((GET_BYTES_04(to_send) >> 16) & 0x7ffU) - 1024U;
+    bool steer_req = GET_BIT(to_send, 27U) != 0U;
     uint32_t ts = microsecond_timer_get();
     bool violation = 0;
 
@@ -323,8 +324,8 @@ static int hyundai_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
       }
     }
 
-    // no torque if controls is not allowed
-    if (!controls_allowed && (desired_torque != 0)) {
+    // no torque if controls is not allowed or mismatch with STEER_REQUEST bit
+      if ((!controls_allowed || !steer_req) && (desired_torque != 0)) {
       violation = 1;
     }
 

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -324,7 +324,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
       }
     }
 
-    // no torque if controls is not allowed or mismatch with STEER_REQUEST bit
+    // no torque if controls is not allowed or mismatch with CF_Lkas_ActToi bit
       if ((!controls_allowed || !steer_req) && (desired_torque != 0)) {
       violation = 1;
     }

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -211,7 +211,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
 
   def test_steer_req_bit(self):
     """
-      On Hyundai, you can ramp up torque and then set the STEER_REQUEST bit and the
+      On Hyundai, you can ramp up torque and then set the CF_Lkas_ActToi bit and the
       EPS will ramp up faster than the effective panda safety limits. This tests:
         - Nothing is sent when cutting torque
         - Nothing is blocked when sending torque normally

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -120,7 +120,7 @@ class TestHyundaiSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("MDPS12", 0, values)
 
   def _torque_msg(self, torque, steer_req=1):
-    values = {"CR_Lkas_StrToqReq": torque}
+    values = {"CR_Lkas_StrToqReq": torque, "CF_Lkas_ActToi": steer_req}
     return self.packer.make_can_msg_panda("LKAS11", 0, values)
 
   def test_steer_safety_check(self):
@@ -208,6 +208,22 @@ class TestHyundaiSafety(common.PandaSafetyTest):
       self.safety.set_timer(RT_INTERVAL + 1)
       self.assertTrue(self._tx(self._torque_msg(sign * (MAX_RT_DELTA - 1))))
       self.assertTrue(self._tx(self._torque_msg(sign * (MAX_RT_DELTA + 1))))
+
+  def test_steer_req_bit(self):
+    """
+      On Hyundai, you can ramp up torque and then set the STEER_REQUEST bit and the
+      EPS will ramp up faster than the effective panda safety limits. This tests:
+        - Nothing is sent when cutting torque
+        - Nothing is blocked when sending torque normally
+    """
+    self.safety.set_controls_allowed(True)
+    for _ in range(100):
+      self._set_prev_torque(MAX_STEER)
+      self.assertFalse(self._tx(self._torque_msg(MAX_STEER, steer_req=0)))
+
+    self._set_prev_torque(MAX_STEER)
+    for _ in range(100):
+      self.assertTrue(self._tx(self._torque_msg(MAX_STEER, steer_req=1)))
 
   def test_buttons(self):
     """


### PR DESCRIPTION
You can wind up torque with the bit set to 0, then set to 1 to effectively bypass the panda torque rate limits. Seems to be around 2-4 frames of the mismatch before car faults?

Similar to PR: https://github.com/commaai/panda/pull/940/files

Todo:
- [x] Fix tests