### PR TITLE
Mazda: fix steering safety and add tests

### DIFF
--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -95,7 +95,7 @@ static int mazda_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
 
     // steer cmd checks
     if (addr == MAZDA_LKAS) {
-      int desired_torque = (((GET_BYTE(to_send, 0) & 0x0FU) << 8) | GET_BYTE(to_send, 1)) - 2048;
+      int desired_torque = (((GET_BYTE(to_send, 0) & 0x0FU) << 8) | GET_BYTE(to_send, 1)) - 2048U;
       bool violation = 0;
       uint32_t ts = microsecond_timer_get();
 

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -12,12 +12,11 @@
 #define MAZDA_AUX  1
 #define MAZDA_CAM  2
 
-#define MAZDA_MAX_STEER 2048U
+#define MAZDA_MAX_STEER 800U
 
-// max delta torque allowed for real time checks
-#define MAZDA_MAX_RT_DELTA 940
-// 250ms between real time checks
-#define MAZDA_RT_INTERVAL 250000
+// the real time limit is 960/sec, a 20% buffer
+#define MAZDA_MAX_RT_DELTA 300  // max delta torque allowed for real time checks
+#define MAZDA_RT_INTERVAL 250000  // 250ms between real time checks
 #define MAZDA_MAX_RATE_UP 10
 #define MAZDA_MAX_RATE_DOWN 25
 #define MAZDA_DRIVER_TORQUE_ALLOWANCE 15
@@ -96,7 +95,7 @@ static int mazda_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
 
     // steer cmd checks
     if (addr == MAZDA_LKAS) {
-      int desired_torque = (((GET_BYTE(to_send, 0) & 0x0FU) << 8) | GET_BYTE(to_send, 1)) - MAZDA_MAX_STEER;
+      int desired_torque = (((GET_BYTE(to_send, 0) & 0x0FU) << 8) | GET_BYTE(to_send, 1)) - 2048;
       bool violation = 0;
       uint32_t ts = microsecond_timer_get();
 

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -5,18 +5,8 @@ from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda
 
-MAX_RATE_UP = 10
-MAX_RATE_DOWN = 25
-MAX_STEER = 2047
 
-MAX_RT_DELTA = 940
-RT_INTERVAL = 250000
-
-DRIVER_TORQUE_ALLOWANCE = 15
-DRIVER_TORQUE_FACTOR = 1
-
-
-class TestMazdaSafety(common.PandaSafetyTest):
+class TestMazdaSafety(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
 
   TX_MSGS = [[0x243, 0], [0x09d, 0], [0x440, 0]]
   STANDSTILL_THRESHOLD = .1
@@ -24,6 +14,16 @@ class TestMazdaSafety(common.PandaSafetyTest):
   RELAY_MALFUNCTION_BUS = 0
   FWD_BLACKLISTED_ADDRS = {2: [0x243, 0x440]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
+
+  MAX_RATE_UP = 10
+  MAX_RATE_DOWN = 25
+  MAX_TORQUE = 800
+
+  MAX_RT_DELTA = 300
+  RT_INTERVAL = 250000
+
+  DRIVER_TORQUE_ALLOWANCE = 15
+  DRIVER_TORQUE_FACTOR = 1
 
   def setUp(self):
     self.packer = CANPackerPanda("mazda_2017")
@@ -39,7 +39,7 @@ class TestMazdaSafety(common.PandaSafetyTest):
 #    values = {"STEER_TORQUE_DRIVER": torque}
 #    return self.packer.make_can_msg_panda("STEER_TORQUE", 0, values)
 
-  def _torque_msg(self, torque, steer_req=1):
+  def _torque_cmd_msg(self, torque, steer_req=1):
     values = {"LKAS_REQUEST": torque}
     return self.packer.make_can_msg_panda("CAM_LKAS", 0, values)
 


### PR DESCRIPTION
In openpilot, the max steer is only 800 units, but in panda we were allowing up to 2048 with a super high realtime allowance (allowed 800 torque in 0.2 seconds and 2048 torque in 0.55 seconds, while the rate up limit only allowed reaching 800 torque in 0.8 seconds).

Mazda safety changes:
- Runs all driver torque tests
- Change max torque constant to openpilot's
- Lower realtime delta limits to be 20% higher than max rate up