### PR TITLE
fix CANPackerPanda counter state init

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -30,7 +30,9 @@ def make_msg(bus, addr, length=8):
 
 
 class CANPackerPanda(CANPacker):
-  _counters: Dict[str, int] = defaultdict(lambda: -1)
+  def __init__(self, dbc_name):
+    super().__init__(dbc_name)
+    self._counters: Dict[str, int] = defaultdict(lambda: -1)
 
   def make_can_msg_panda(self, name_or_addr, bus, values, counter=False, fix_checksum=None):
     if counter:


### PR DESCRIPTION
With #905 we were given a much nicer way to handle message counters in the safety test CAN packer, which should enable a nice future red diff for the Volkswagen tests among others. Since that PR, the car safety CI test has been passing, but it's also been spamming "COUNTER not defined" to console.

This traced back to a Toyota wheel speed message without a counter, but the Toyota test would run fine in isolation. The problem traced further back to the new CANPackerPanda leaking counter state between packer instances. This PR should fix it.

```
Testing HW_TYPE: 0
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
COUNTER not defined
.......................................................sss......................................................s..........................................................................................................s......................................................................................................................................................................................................................................................................................................sssssssssssssssssssss.....................ssssssssssssssssss...............................................................................................................................s....................................................
----------------------------------------------------------------------
Ran 748 tests in 6.930s

OK (skipped=45)
```