### PR TITLE
add missing type information to /python module, fix incorrect types, minor code simplifications

### DIFF
--- a/python/_typing.py
+++ b/python/_typing.py
@@ -1,0 +1,3 @@
+from typing import Any, Tuple
+
+CAN_MSG = Tuple[int, Any, bytes, int]

--- a/python/ccp.py
+++ b/python/ccp.py
@@ -88,7 +88,7 @@ class CcpClient():
     self._command_counter = (self._command_counter + 1) & 0xFF
     tx_data = (bytes([cmd, self._command_counter]) + dat).ljust(8, b"\x00")
     if self.debug:
-      print(f"CAN-TX: {hex(self.tx_addr)} - 0x{bytes.hex(tx_data)}")
+      print(f"CAN-TX: {hex(self.tx_addr)} - 0x{tx_data.hex()}")
     assert len(tx_data) == 8, "data is not 8 bytes"
     self._panda.can_clear(self.can_bus)
     self._panda.can_clear(0xFFFF)
@@ -104,7 +104,7 @@ class CcpClient():
         if rx_bus == self.can_bus and rx_addr == self.rx_addr:
           rx_data = bytes(rx_data)  # convert bytearray to bytes
           if self.debug:
-            print(f"CAN-RX: {hex(rx_addr)} - 0x{bytes.hex(rx_data)}")
+            print(f"CAN-RX: {hex(rx_addr)} - 0x{rx_data.hex()}")
           assert len(rx_data) == 8, f"message length not 8: {len(rx_data)}"
 
           pid = rx_data[0]

--- a/python/dfu.py
+++ b/python/dfu.py
@@ -32,14 +32,14 @@ class PandaDFU(object):
     raise Exception("failed to open " + dfu_serial if dfu_serial is not None else "DFU device")
 
   @staticmethod
-  def list() -> List[Optional[str]]:
+  def list() -> List[str]:
     context = usb1.USBContext()
-    dfu_serials = []
+    dfu_serials: List[str] = []
     try:
       for device in context.getDeviceList(skip_on_error=True):
         if device.getVendorID() == 0x0483 and device.getProductID() == 0xdf11:
           try:
-            dfu_serials.append(device.open().getASCIIStringDescriptor(3))
+            dfu_serials.append(device.open().getASCIIStringDescriptor(3)) # type: ignore
           except Exception:
             pass
     except Exception:

--- a/python/dfu.py
+++ b/python/dfu.py
@@ -1,7 +1,7 @@
-from typing import List, Optional
 import usb1
 import struct
 import binascii
+from typing import List, Optional
 from .config import BOOTSTUB_ADDRESS, APP_ADDRESS_H7, APP_ADDRESS_FX, BLOCK_SIZE_H7, BLOCK_SIZE_FX, DEFAULT_H7_BOOTSTUB_FN, DEFAULT_BOOTSTUB_FN
 
 

--- a/python/flash_release.py
+++ b/python/flash_release.py
@@ -2,15 +2,20 @@
 
 import sys
 import time
+from typing import Optional, TYPE_CHECKING, Union
 import requests
 import json
 import io
 
-def flash_release(path=None, st_serial=None):
-  from panda import Panda, PandaDFU
+def flash_release(path: Optional[Union[str, io.BytesIO]] = None, st_serial: Optional[str] = None) -> None:
+  if TYPE_CHECKING:
+    from python import Panda, PandaDFU
+  else:
+    from panda import Panda, PandaDFU
+
   from zipfile import ZipFile
 
-  def status(x):
+  def status(x: str) -> None:
     print("\033[1;32;40m" + x + "\033[00m")
 
   if st_serial is not None:

--- a/python/flash_release.py
+++ b/python/flash_release.py
@@ -2,10 +2,10 @@
 
 import sys
 import time
-from typing import Optional, TYPE_CHECKING, Union
 import requests
 import json
 import io
+from typing import Optional, TYPE_CHECKING, Union
 
 def flash_release(path: Optional[Union[str, io.BytesIO]] = None, st_serial: Optional[str] = None) -> None:
   if TYPE_CHECKING:

--- a/python/isotp.py
+++ b/python/isotp.py
@@ -1,9 +1,13 @@
 import binascii
 import time
+from typing import List, Optional, Union
+
+from . import Panda
+from ._typing import CAN_MSG
 
 DEBUG = False
 
-def msg(x):
+def msg(x: bytes) -> bytes:
   if DEBUG:
     print("S:", binascii.hexlify(x))
   if len(x) <= 7:
@@ -12,8 +16,9 @@ def msg(x):
     assert False
   return ret.ljust(8, b"\x00")
 
-kmsgs = []
-def recv(panda, cnt, addr, nbus):
+
+kmsgs: List[CAN_MSG] = []
+def recv(panda: Panda, cnt: int, addr: int, nbus: int) -> List[bytes]:
   global kmsgs
   ret = []
 
@@ -29,7 +34,7 @@ def recv(panda, cnt, addr, nbus):
     kmsgs = nmsgs[-256:]
   return ret
 
-def isotp_recv_subaddr(panda, addr, bus, sendaddr, subaddr):
+def isotp_recv_subaddr(panda: Panda, addr: int, bus: int, sendaddr: int, subaddr: int) -> bytes:
   msg = recv(panda, 1, addr, bus)[0]
 
   # TODO: handle other subaddr also communicating
@@ -62,7 +67,8 @@ def isotp_recv_subaddr(panda, addr, bus, sendaddr, subaddr):
 
 # **** import below this line ****
 
-def isotp_send(panda, x, addr, bus=0, recvaddr=None, subaddr=None, rate=None):
+def isotp_send(panda: Panda, x: bytes, addr: int , bus: int = 0, recvaddr: Optional[int] = None,
+               subaddr: Optional[int] = None, rate: Optional[Union[float, int]] = None) -> None:
   if recvaddr is None:
     recvaddr = addr + 8
 
@@ -104,7 +110,8 @@ def isotp_send(panda, x, addr, bus=0, recvaddr=None, subaddr=None, rate=None):
           panda.can_send(addr, dat, bus)
           time.sleep(rate)
 
-def isotp_recv(panda, addr, bus=0, sendaddr=None, subaddr=None):
+def isotp_recv(panda: Panda, addr: int, bus: int = 0, sendaddr: Optional[int] = None,
+               subaddr: Optional[int] = None) -> bytes:
   if sendaddr is None:
     sendaddr = addr - 8
 

--- a/python/isotp.py
+++ b/python/isotp.py
@@ -1,7 +1,6 @@
 import binascii
 import time
 from typing import List, Optional, Union
-
 from . import Panda
 from ._typing import CAN_MSG
 

--- a/python/serial.py
+++ b/python/serial.py
@@ -1,6 +1,8 @@
+from . import Panda
+
 # mimic a python serial port
 class PandaSerial(object):
-  def __init__(self, panda, port, baud):
+  def __init__(self, panda: Panda, port: int, baud: int) -> None:
     self.panda = panda
     self.port = port
     self.panda.set_uart_parity(self.port, 0)
@@ -8,7 +10,7 @@ class PandaSerial(object):
     self.panda.set_uart_baud(self.port, baud)
     self.buf = b""
 
-  def read(self, l=1):  # noqa: E741
+  def read(self, l: int = 1) -> bytes:  # noqa: E741
     tt = self.panda.serial_read(self.port)
     if len(tt) > 0:
       self.buf += tt
@@ -16,20 +18,20 @@ class PandaSerial(object):
     self.buf = self.buf[l:]
     return ret
 
-  def write(self, dat):
+  def write(self, dat: bytes) -> int:
     return self.panda.serial_write(self.port, dat)
 
-  def close(self):
+  def close(self) -> None:
     pass
 
-  def flush(self):
+  def flush(self) -> None:
     pass
 
   @property
-  def baudrate(self):
+  def baudrate(self) -> int:
     return self._baudrate
 
   @baudrate.setter
-  def baudrate(self, value):
+  def baudrate(self, value: int) -> None:
     self.panda.set_uart_baud(self.port, value)
     self._baudrate = value

--- a/python/uds.py
+++ b/python/uds.py
@@ -356,7 +356,7 @@ class CanClient():
     except IndexError:
       pass  # empty
 
-  def send(self, msgs: List[bytes], delay: float = 0) -> None:
+  def send(self, msgs: List[bytes], delay: float = 0.0) -> None:
     for i, msg in enumerate(msgs):
       if delay and i != 0:
         if self.debug:
@@ -376,7 +376,7 @@ class CanClient():
         self._recv_buffer()
 
 class IsoTpMessage():
-  def __init__(self, can_client: CanClient, timeout: float = 1, debug: bool = False, max_len: int = 8) -> None:
+  def __init__(self, can_client: CanClient, timeout: float = 1.0, debug: bool = False, max_len: int = 8) -> None:
     self._can_client = can_client
     self.timeout = timeout
     self.debug = debug
@@ -528,8 +528,8 @@ def get_rx_addr_for_tx_addr(tx_addr: int, rx_offset: int = 0x8) -> Optional[int]
 
 
 class UdsClient():
-  def __init__(self, panda, tx_addr: int, rx_addr: Optional[int] = None, bus: int = 0, timeout: float = 1,
-               debug: bool = False, tx_timeout: float = 1, response_pending_timeout: float = 10) -> None:
+  def __init__(self, panda, tx_addr: int, rx_addr: Optional[int] = None, bus: int = 0, timeout: float = 1.0,
+               debug: bool = False, tx_timeout: float = 1.0, response_pending_timeout: float = 10.0) -> None:
     self.bus = bus
     self.tx_addr = tx_addr
     self.rx_addr = rx_addr if rx_addr is not None else get_rx_addr_for_tx_addr(tx_addr)

--- a/python/uds.py
+++ b/python/uds.py
@@ -2,9 +2,9 @@
 import time
 import struct
 from collections import deque
-from typing import Any, Callable, Mapping, NamedTuple, Tuple, List, Deque, Generator, Optional, cast
 from enum import IntEnum
 from functools import partial
+from typing import Any, Callable, Mapping, NamedTuple, Tuple, List, Deque, Generator, Optional, cast
 
 class SERVICE_TYPE(IntEnum):
   DIAGNOSTIC_SESSION_CONTROL = 0x10

--- a/python/uds.py
+++ b/python/uds.py
@@ -335,7 +335,7 @@ class CanClient():
             rx_data = bytes(rx_data)  # convert bytearray to bytes
 
             if self.debug:
-              print(f"CAN-RX: {hex(rx_addr)} - 0x{bytes.hex(rx_data)}")
+              print(f"CAN-RX: {hex(rx_addr)} - 0x{rx_data.hex()}")
 
             # Cut off sub addr in first byte
             if self.sub_addr is not None:
@@ -367,7 +367,7 @@ class CanClient():
         msg = bytes([self.sub_addr]) + msg
 
       if self.debug:
-        print(f"CAN-TX: {hex(self.tx_addr)} - 0x{bytes.hex(msg)}")
+        print(f"CAN-TX: {hex(self.tx_addr)} - 0x{msg.hex()}")
       assert len(msg) <= 8
 
       self.tx(self.tx_addr, msg, self.bus)
@@ -397,7 +397,7 @@ class IsoTpMessage():
     self.rx_done = False
 
     if self.debug:
-      print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{bytes.hex(self.tx_dat)}")
+      print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{self.tx_dat.hex()}")
     self._tx_first_frame()
 
   def _tx_first_frame(self) -> None:
@@ -433,7 +433,7 @@ class IsoTpMessage():
           raise MessageTimeoutError("timeout waiting for response")
     finally:
       if self.debug and self._can_client.rx_addr is not None and self.rx_dat:
-        print(f"ISO-TP: RESPONSE - {hex(self._can_client.rx_addr)} 0x{bytes.hex(self.rx_dat)}")
+        print(f"ISO-TP: RESPONSE - {hex(self._can_client.rx_addr)} 0x{self.rx_dat.hex()}")
 
   def _isotp_rx_next(self, rx_data: bytes) -> None:
     # single rx_frame

--- a/python/uds.py
+++ b/python/uds.py
@@ -781,33 +781,43 @@ class UdsClient():
                            dtc_snapshot_record_num: int = 0xFF, dtc_extended_record_num: int = 0xFF):
     data = b''
     # dtc_status_mask_type
-    if dtc_report_type == DTC_REPORT_TYPE.NUMBER_OF_DTC_BY_STATUS_MASK or \
-       dtc_report_type == DTC_REPORT_TYPE.DTC_BY_STATUS_MASK or \
-       dtc_report_type == DTC_REPORT_TYPE.MIRROR_MEMORY_DTC_BY_STATUS_MASK or \
-       dtc_report_type == DTC_REPORT_TYPE.NUMBER_OF_MIRROR_MEMORY_DTC_BY_STATUS_MASK or \
-       dtc_report_type == DTC_REPORT_TYPE.NUMBER_OF_EMISSIONS_RELATED_OBD_DTC_BY_STATUS_MASK or \
-       dtc_report_type == DTC_REPORT_TYPE.EMISSIONS_RELATED_OBD_DTC_BY_STATUS_MASK:
-       data += bytes([dtc_status_mask_type])
+    if dtc_report_type in (
+      DTC_REPORT_TYPE.NUMBER_OF_DTC_BY_STATUS_MASK,
+      DTC_REPORT_TYPE.DTC_BY_STATUS_MASK,
+      DTC_REPORT_TYPE.MIRROR_MEMORY_DTC_BY_STATUS_MASK,
+      DTC_REPORT_TYPE.NUMBER_OF_MIRROR_MEMORY_DTC_BY_STATUS_MASK,
+      DTC_REPORT_TYPE.NUMBER_OF_EMISSIONS_RELATED_OBD_DTC_BY_STATUS_MASK,
+      DTC_REPORT_TYPE.EMISSIONS_RELATED_OBD_DTC_BY_STATUS_MASK
+    ):
+      data += bytes([dtc_status_mask_type])
     # dtc_mask_record
-    if dtc_report_type == DTC_REPORT_TYPE.DTC_SNAPSHOT_IDENTIFICATION or \
-       dtc_report_type == DTC_REPORT_TYPE.DTC_SNAPSHOT_RECORD_BY_DTC_NUMBER or \
-       dtc_report_type == DTC_REPORT_TYPE.DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER or \
-       dtc_report_type == DTC_REPORT_TYPE.MIRROR_MEMORY_DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER or \
-       dtc_report_type == DTC_REPORT_TYPE.SEVERITY_INFORMATION_OF_DTC:
-       data += struct.pack('!I', dtc_mask_record)[1:]  # 3 bytes
+    if dtc_report_type in (
+      DTC_REPORT_TYPE.DTC_SNAPSHOT_IDENTIFICATION,
+      DTC_REPORT_TYPE.DTC_SNAPSHOT_RECORD_BY_DTC_NUMBER,
+      DTC_REPORT_TYPE.DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER,
+      DTC_REPORT_TYPE.MIRROR_MEMORY_DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER,
+      DTC_REPORT_TYPE.SEVERITY_INFORMATION_OF_DTC
+    ):
+      data += struct.pack('!I', dtc_mask_record)[1:]  # 3 bytes
     # dtc_snapshot_record_num
-    if dtc_report_type == DTC_REPORT_TYPE.DTC_SNAPSHOT_IDENTIFICATION or \
-       dtc_report_type == DTC_REPORT_TYPE.DTC_SNAPSHOT_RECORD_BY_DTC_NUMBER or \
-       dtc_report_type == DTC_REPORT_TYPE.DTC_SNAPSHOT_RECORD_BY_RECORD_NUMBER:
-       data += bytes([dtc_snapshot_record_num])
+    if dtc_report_type in (
+      DTC_REPORT_TYPE.DTC_SNAPSHOT_IDENTIFICATION,
+      DTC_REPORT_TYPE.DTC_SNAPSHOT_RECORD_BY_DTC_NUMBER,
+      DTC_REPORT_TYPE.DTC_SNAPSHOT_RECORD_BY_RECORD_NUMBER
+    ):
+      data += bytes([dtc_snapshot_record_num])
     # dtc_extended_record_num
-    if dtc_report_type == DTC_REPORT_TYPE.DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER or \
-       dtc_report_type == DTC_REPORT_TYPE.MIRROR_MEMORY_DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER:
-       data += bytes([dtc_extended_record_num])
+    if dtc_report_type in (
+      DTC_REPORT_TYPE.DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER,
+      DTC_REPORT_TYPE.MIRROR_MEMORY_DTC_EXTENDED_DATA_RECORD_BY_DTC_NUMBER
+    ):
+      data += bytes([dtc_extended_record_num])
     # dtc_severity_mask_type
-    if dtc_report_type == DTC_REPORT_TYPE.NUMBER_OF_DTC_BY_SEVERITY_MASK_RECORD or \
-       dtc_report_type == DTC_REPORT_TYPE.DTC_BY_SEVERITY_MASK_RECORD:
-       data += bytes([dtc_severity_mask_type, dtc_status_mask_type])
+    if dtc_report_type in (
+      DTC_REPORT_TYPE.NUMBER_OF_DTC_BY_SEVERITY_MASK_RECORD,
+      DTC_REPORT_TYPE.DTC_BY_SEVERITY_MASK_RECORD
+    ):
+      data += bytes([dtc_severity_mask_type, dtc_status_mask_type])
 
     resp = self._uds_request(SERVICE_TYPE.READ_DTC_INFORMATION, subfunction=dtc_report_type, data=data)
 

--- a/python/uds.py
+++ b/python/uds.py
@@ -211,13 +211,13 @@ class MessageTimeoutError(Exception):
   pass
 
 class NegativeResponseError(Exception):
-  def __init__(self, message, service_id, error_code):
+  def __init__(self, message: str, service_id: int, error_code: int) -> None:
     super().__init__()
     self.message = message
     self.service_id = service_id
     self.error_code = error_code
 
-  def __str__(self):
+  def __str__(self) -> str:
     return self.message
 
 class InvalidServiceIdError(Exception):
@@ -293,7 +293,7 @@ def get_dtc_status_names(status: int) -> List[str]:
 
 class CanClient():
   def __init__(self, can_send: Callable[[int, bytes, int], None], can_recv: Callable[[], List[Tuple[int, int, bytes, int]]],
-               tx_addr: int, rx_addr: Optional[int], bus: int, sub_addr: Optional[int] = None, debug: bool = False):
+               tx_addr: int, rx_addr: Optional[int], bus: int, sub_addr: Optional[int] = None, debug: bool = False) -> None:
     self.tx = can_send
     self.rx = can_recv
     self.tx_addr = tx_addr
@@ -841,7 +841,7 @@ class UdsClient():
       raise ValueError('invalid response routine identifier: {}'.format(hex(resp_id)))
     return resp[2:]
 
-  def request_download(self, memory_address: int, memory_size: int, memory_address_bytes: int = 4, memory_size_bytes: int = 4, data_format: int = 0x00) -> bytes:
+  def request_download(self, memory_address: int, memory_size: int, memory_address_bytes: int = 4, memory_size_bytes: int = 4, data_format: int = 0x00) -> int:
     data = bytes([data_format])
 
     if memory_address_bytes < 1 or memory_address_bytes > 4:
@@ -860,7 +860,7 @@ class UdsClient():
     resp = self._uds_request(SERVICE_TYPE.REQUEST_DOWNLOAD, subfunction=None, data=data)
     max_num_bytes_len = resp[0] >> 4 if len(resp) > 0 else 0
     if max_num_bytes_len >= 1 and max_num_bytes_len <= 4:
-      max_num_bytes = struct.unpack('!I', (b"\x00" * (4 - max_num_bytes_len)) + resp[1:max_num_bytes_len + 1])[0]
+      max_num_bytes: int = struct.unpack('!I', (b"\x00" * (4 - max_num_bytes_len)) + resp[1:max_num_bytes_len + 1])[0]
     else:
       raise ValueError('invalid max_num_bytes_len: {}'.format(max_num_bytes_len))
 

--- a/python/update.py
+++ b/python/update.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 import os
 import time
+from typing import TYPE_CHECKING
 
-def ensure_st_up_to_date():
-  from panda import Panda, PandaDFU, BASEDIR
+def ensure_st_up_to_date() -> None:
+  if TYPE_CHECKING:
+    from . import Panda, PandaDFU, BASEDIR
+  else:
+    from panda import Panda, PandaDFU, BASEDIR
 
   with open(os.path.join(BASEDIR, "VERSION")) as f:
     repo_version = f.read()
@@ -28,6 +32,8 @@ def ensure_st_up_to_date():
 
     print("waiting for board...")
     time.sleep(1)
+
+  assert panda is not None
 
   if panda.bootstub or not panda.get_version().startswith(repo_version):
     panda.flash()

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -201,7 +201,7 @@ class HondaPcmEnableBase(common.PandaSafetyTest):
 
 
 class HondaBase(common.PandaSafetyTest):
-  MAX_BRAKE: float = 255
+  MAX_BRAKE = 255.0
   PT_BUS: Optional[int] = None  # must be set when inherited
   STEER_BUS: Optional[int] = None  # must be set when inherited
 


### PR DESCRIPTION
hey, just been reading through the code and adding/correcting typing information where possible

one question - which python versions are supported by this project? the [numpy version used in requirements.txt](https://numpy.org/doc/stable/release/1.21.0-notes.html) is >=python3.7 but the [setup.py file has 2 & 3 listed](https://github.com/commaai/panda/blob/master/setup.py#L61-L62).

if only >=3.7 is supported, i can use quite a few newer typing features