### PR TITLE
safety replay: set alternative experience

### DIFF
--- a/tests/safety_replay/replay_drive.py
+++ b/tests/safety_replay/replay_drive.py
@@ -93,12 +93,12 @@ if __name__ == "__main__":
         if args.param is None:
           args.param = msg.carParams.safetyConfigs[0].safetyParam
         if args.alternative_experience is None:
-          args.param = msg.carParams.safetyConfigs[0].alternativeExperience
+          args.alternative_experience = msg.carParams.alternativeExperience
         break
     else:
       raise Exception("carParams not found in log. Set safety mode and param manually.")
 
     lr.reset()
 
-  print(f"replaying {args.route_or_segment_name[0]} with safety mode {args.mode} and param {args.param}")
+  print(f"replaying {args.route_or_segment_name[0]} with safety mode {args.mode}, param {args.param}, and alternative experience {args.alternative_experience}")
   replay_drive(lr, args.mode, args.param, args.alternative_experience, segment=(s.segment_num >= 0))

--- a/tests/safety_replay/replay_drive.py
+++ b/tests/safety_replay/replay_drive.py
@@ -5,12 +5,14 @@ import os
 from panda.tests.safety import libpandasafety_py
 from panda.tests.safety_replay.helpers import package_can_msg, init_segment
 
+
 # replay a drive to check for safety violations
-def replay_drive(lr, safety_mode, param, segment=False):
+def replay_drive(lr, safety_mode, param, alternative_experience, segment=False):
   safety = libpandasafety_py.libpandasafety
 
   err = safety.set_safety_hooks(safety_mode, param)
   assert err == 0, "invalid safety mode: %d" % safety_mode
+  safety.set_alternative_experience(alternative_experience)
 
   if segment:
     init_segment(safety, lr, safety_mode)
@@ -64,6 +66,7 @@ def replay_drive(lr, safety_mode, param, segment=False):
 
   return tx_controls_blocked == 0 and rx_invalid == 0
 
+
 if __name__ == "__main__":
   from tools.lib.route import Route, SegmentName
   from tools.lib.logreader import MultiLogIterator  # pylint: disable=import-error
@@ -73,6 +76,7 @@ if __name__ == "__main__":
   parser.add_argument("route_or_segment_name", nargs='+')
   parser.add_argument("--mode", type=int, help="Override the safety mode from the log")
   parser.add_argument("--param", type=int, help="Override the safety param from the log")
+  parser.add_argument("--alternative-experience", type=int, help="Override the alternative experience from the log")
   args = parser.parse_args()
 
   s = SegmentName(args.route_or_segment_name[0], allow_route_name=True)
@@ -88,6 +92,8 @@ if __name__ == "__main__":
           args.mode = msg.carParams.safetyConfigs[0].safetyModel.raw
         if args.param is None:
           args.param = msg.carParams.safetyConfigs[0].safetyParam
+        if args.alternative_experience is None:
+          args.param = msg.carParams.safetyConfigs[0].alternativeExperience
         break
     else:
       raise Exception("carParams not found in log. Set safety mode and param manually.")
@@ -95,4 +101,4 @@ if __name__ == "__main__":
     lr.reset()
 
   print(f"replaying {args.route_or_segment_name[0]} with safety mode {args.mode} and param {args.param}")
-  replay_drive(lr, args.mode, args.param, segment=(s.segment_num >= 0))
+  replay_drive(lr, args.mode, args.param, args.alternative_experience, segment=(s.segment_num >= 0))

--- a/tests/safety_replay/replay_drive.py
+++ b/tests/safety_replay/replay_drive.py
@@ -5,7 +5,6 @@ import os
 from panda.tests.safety import libpandasafety_py
 from panda.tests.safety_replay.helpers import package_can_msg, init_segment
 
-
 # replay a drive to check for safety violations
 def replay_drive(lr, safety_mode, param, alternative_experience, segment=False):
   safety = libpandasafety_py.libpandasafety
@@ -66,7 +65,6 @@ def replay_drive(lr, safety_mode, param, alternative_experience, segment=False):
 
   return tx_controls_blocked == 0 and rx_invalid == 0
 
-
 if __name__ == "__main__":
   from tools.lib.route import Route, SegmentName
   from tools.lib.logreader import MultiLogIterator  # pylint: disable=import-error
@@ -100,5 +98,5 @@ if __name__ == "__main__":
 
     lr.reset()
 
-  print(f"replaying {args.route_or_segment_name[0]} with safety mode {args.mode}, param {args.param}, and alternative experience {args.alternative_experience}")
+  print(f"replaying {args.route_or_segment_name[0]} with safety mode {args.mode}, param {args.param}, alternative experience {args.alternative_experience}")
   replay_drive(lr, args.mode, args.param, args.alternative_experience, segment=(s.segment_num >= 0))

--- a/tests/safety_replay/test_safety_replay.py
+++ b/tests/safety_replay/test_safety_replay.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from collections import namedtuple
 import os
 import requests
 
@@ -8,39 +9,40 @@ from tools.lib.logreader import LogReader  # pylint: disable=import-error
 
 BASE_URL = "https://commadataci.blob.core.windows.net/openpilotci/"
 
+ReplayRoute = namedtuple("ReplayRoute", ("route", "safety_mode", "param", "alternative_experience"), defaults=(0, 0))
+
 logs = [
-  # (route, safety mode, param)
-  ("2425568437959f9d|2019-12-22--16-24-37.bz2", Panda.SAFETY_HONDA_NIDEC, 0),          # HONDA.CIVIC (fcw presents: 0x1FA blocked as expected)
-  ("38bfd238edecbcd7|2019-06-07--10-15-25.bz2", Panda.SAFETY_TOYOTA, 66),              # TOYOTA.PRIUS
-  ("f89c604cf653e2bf|2018-09-29--13-46-50.bz2", Panda.SAFETY_GM, 0),                   # GM.VOLT
-  ("6fb4948a7ebe670e|2019-11-12--00-35-53.bz2", Panda.SAFETY_CHRYSLER, 0),             # CHRYSLER.PACIFICA_2018_HYBRID
-  ("791340bc01ed993d|2019-04-08--10-26-00.bz2", Panda.SAFETY_SUBARU, 0),               # SUBARU.IMPREZA
-  ("76b83eb0245de90e|2020-03-05--19-16-05.bz2", Panda.SAFETY_VOLKSWAGEN_MQB, 0),       # VOLKSWAGEN.GOLF (MK7)
-  ("d12cd943127f267b|2020-03-27--15-57-18.bz2", Panda.SAFETY_VOLKSWAGEN_PQ, 0),        # 2009 VW Passat R36 (B6), supporting OP port not yet upstreamed
-  ("fbbfa6af821552b9|2020-03-03--08-09-43.bz2", Panda.SAFETY_NISSAN, 0),               # NISSAN.XTRAIL
-  ("5b7c365c50084530_2020-04-15--16-13-24--3--rlog.bz2", Panda.SAFETY_HYUNDAI, 0),     # HYUNDAI.SONATA
-  ("610ebb9faaad6b43|2020-06-13--15-28-36.bz2", Panda.SAFETY_HYUNDAI_LEGACY, 0),       # HYUNDAI.IONIQ_EV_LTD
-  ("5ab784f361e19b78_2020-06-08--16-30-41.bz2", Panda.SAFETY_SUBARU_LEGACY, 0),        # SUBARU.OUTBACK
-  ("bb50caf5f0945ab1|2021-06-19--17-20-18.bz2", Panda.SAFETY_TESLA, 0),                # TESLA.AP2_MODELS
-  ("bd6a637565e91581_2021-10-29--22-18-31--1--rlog.bz2", Panda.SAFETY_MAZDA, 0),       # MAZDA.CX9_2021
+  ReplayRoute("2425568437959f9d|2019-12-22--16-24-37.bz2", Panda.SAFETY_HONDA_NIDEC),       # HONDA.CIVIC (fcw presents: 0x1FA blocked as expected)
+  ReplayRoute("38bfd238edecbcd7|2019-06-07--10-15-25.bz2", Panda.SAFETY_TOYOTA, 66),        # TOYOTA.PRIUS
+  ReplayRoute("f89c604cf653e2bf|2018-09-29--13-46-50.bz2", Panda.SAFETY_GM),                # GM.VOLT
+  ReplayRoute("6fb4948a7ebe670e|2019-11-12--00-35-53.bz2", Panda.SAFETY_CHRYSLER),          # CHRYSLER.PACIFICA_2018_HYBRID
+  ReplayRoute("791340bc01ed993d|2019-04-08--10-26-00.bz2", Panda.SAFETY_SUBARU),            # SUBARU.IMPREZA
+  ReplayRoute("76b83eb0245de90e|2020-03-05--19-16-05.bz2", Panda.SAFETY_VOLKSWAGEN_MQB),    # VOLKSWAGEN.GOLF (MK7)
+  ReplayRoute("d12cd943127f267b|2020-03-27--15-57-18.bz2", Panda.SAFETY_VOLKSWAGEN_PQ),     # 2009 VW Passat R36 (B6), supporting OP port not yet upstreamed
+  ReplayRoute("fbbfa6af821552b9|2020-03-03--08-09-43.bz2", Panda.SAFETY_NISSAN),            # NISSAN.XTRAIL
+  ReplayRoute("5b7c365c50084530_2020-04-15--16-13-24--3--rlog.bz2", Panda.SAFETY_HYUNDAI),  # HYUNDAI.SONATA
+  ReplayRoute("610ebb9faaad6b43|2020-06-13--15-28-36.bz2", Panda.SAFETY_HYUNDAI_LEGACY),    # HYUNDAI.IONIQ_EV_LTD
+  ReplayRoute("5ab784f361e19b78_2020-06-08--16-30-41.bz2", Panda.SAFETY_SUBARU_LEGACY),     # SUBARU.OUTBACK
+  ReplayRoute("bb50caf5f0945ab1|2021-06-19--17-20-18.bz2", Panda.SAFETY_TESLA),             # TESLA.AP2_MODELS
+  ReplayRoute("bd6a637565e91581_2021-10-29--22-18-31--1--rlog.bz2", Panda.SAFETY_MAZDA),    # MAZDA.CX9_2021
 ]
 
 
 if __name__ == "__main__":
 
   # get all the routes
-  for route, _, _ in logs:
-    if not os.path.isfile(route):
-      with open(route, "wb") as f:
-        f.write(requests.get(BASE_URL + route).content)
+  for r in logs:
+    if not os.path.isfile(r.route):
+      with open(r.route, "wb") as f:
+        f.write(requests.get(BASE_URL + r.route).content)
 
   failed = []
-  for route, mode, param in logs:
-    lr = LogReader(route)
+  for r in logs:
+    lr = LogReader(r.route)
 
-    print("\nreplaying %s with safety mode %d and param %s" % (route, mode, param))
-    if not replay_drive(lr, mode, int(param)):
-      failed.append(route)
+    print("\nreplaying %s with safety mode %d, param %s, alternative experience %s" % (r.route, r.safety_mode, r.param, r.alternative_experience))
+    if not replay_drive(lr, r.safety_mode, int(r.param), r.alternative_experience):
+      failed.append(r.route)
 
     for f in failed:  # type: ignore
       print(f"\n**** failed on {f} ****")

--- a/tests/safety_replay/test_safety_replay.py
+++ b/tests/safety_replay/test_safety_replay.py
@@ -31,18 +31,18 @@ logs = [
 if __name__ == "__main__":
 
   # get all the routes
-  for r in logs:
-    if not os.path.isfile(r.route):
-      with open(r.route, "wb") as f:
-        f.write(requests.get(BASE_URL + r.route).content)
+  for route, _, _, _ in logs:
+    if not os.path.isfile(route):
+      with open(route, "wb") as f:
+        f.write(requests.get(BASE_URL + route).content)
 
   failed = []
-  for r in logs:
-    lr = LogReader(r.route)
+  for route, mode, param, alt_exp in logs:
+    lr = LogReader(route)
 
-    print("\nreplaying %s with safety mode %d, param %s, alternative experience %s" % (r.route, r.safety_mode, r.param, r.alternative_experience))
-    if not replay_drive(lr, r.safety_mode, int(r.param), r.alternative_experience):
-      failed.append(r.route)
+    print("\nreplaying %s with safety mode %d, param %s, alternative experience %s" % (route, mode, param, alt_exp))
+    if not replay_drive(lr, mode, param, alt_exp):
+      failed.append(route)
 
     for f in failed:  # type: ignore
       print(f"\n**** failed on {f} ****")


### PR DESCRIPTION
A new Civic 2022 route had no disengage on gas enabled so it was blocking a bunch of messages. This adds support for alternative experiences to safety replay