### PR TITLE
Honda Bosch: consider correct bus for buttons

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -145,7 +145,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
 
     // state machine to enter and exit controls for button enabling
     // 0x1A6 for the ILX, 0x296 for the Civic Touring
-    if (((addr == 0x1A6) || (addr == 0x296)) && bus == pt_bus) {
+    if (((addr == 0x1A6) || (addr == 0x296)) && (bus == pt_bus)) {
       int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
 
       // exit controls once main or cancel are pressed

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -101,10 +101,13 @@ static int honda_rx_hook(CANPacket_t *to_push) {
   bool valid = addr_safety_check(to_push, &honda_rx_checks,
                                  honda_get_checksum, honda_compute_checksum, honda_get_counter);
 
-  const bool pcm_cruise = ((honda_hw == HONDA_BOSCH) && !honda_bosch_long) || \
-                          ((honda_hw == HONDA_NIDEC) && !gas_interceptor_detected);
-
   if (valid) {
+    const bool pcm_cruise = ((honda_hw == HONDA_BOSCH) && !honda_bosch_long) || \
+                            ((honda_hw == HONDA_NIDEC) && !gas_interceptor_detected);
+
+    int bus_rdr_car = (honda_hw == HONDA_BOSCH) ? 0 : 2;  // radar bus, car side
+    int pt_bus = (honda_hw == HONDA_BOSCH) ? 1 : 0;
+
     int addr = GET_ADDR(to_push);
     int len = GET_LEN(to_push);
     int bus = GET_BUS(to_push);
@@ -142,7 +145,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
 
     // state machine to enter and exit controls for button enabling
     // 0x1A6 for the ILX, 0x296 for the Civic Touring
-    if (((addr == 0x1A6) || (addr == 0x296))) {
+    if (((addr == 0x1A6) || (addr == 0x296)) && bus == pt_bus) {
       int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
 
       // exit controls once main or cancel are pressed
@@ -211,8 +214,6 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     }
 
     bool stock_ecu_detected = false;
-    int bus_rdr_car = (honda_hw == HONDA_BOSCH) ? 0 : 2;  // radar bus, car side
-    int pt_bus = (honda_hw == HONDA_BOSCH) ? 1 : 0;
 
     if (safety_mode_cnt > RELAY_TRNS_TIMEOUT) {
       // If steering controls messages are received on the destination bus, it's an indication


### PR DESCRIPTION
Fixes a bug uncovered by https://github.com/commaai/panda/pull/874. We get quite a few messages from bus 2 where the first byte is 0xff for SCM_BUTTONS, we got unlucky as it parses out to 7 and considering buttons with no past didn't make this an issue (7 is not a recognized button) before. But now it's pretty much always guaranteed the last button is 7, so neither set or resume, causing controls_allowed never to rise.

This is a Bosch Civic: https://user-images.githubusercontent.com/25857203/172751996-27a04991-9232-4591-bdf1-70e13b5c409e.png

What panda sees: https://user-images.githubusercontent.com/25857203/172752445-56369f9e-712b-404a-8d62-3ddf91678646.png

Checked a Honda CR-V (Nidec), didn't have the button message on 0x1A6 on any other bus in normal operation, so only a bosch problem likely.