### PR TITLE
Dockerfile: pin opendbc commit

### DIFF
--- a/Dockerfile.panda
+++ b/Dockerfile.panda
@@ -45,6 +45,8 @@ ENV LC_ALL en_US.UTF-8
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
 ENV PATH="/root/.pyenv/bin:/root/.pyenv/shims:${PATH}"
+ENV OPENPILOT_REF="1b0167ce24afb037b36464c40f9c5e0d657e77d9"
+ENV OPENDBC_REF="b8b3adfd9d64413642201954808810ea853782d7"
 
 COPY requirements.txt /tmp/
 RUN pyenv install 3.8.10 && \
@@ -63,9 +65,12 @@ RUN cd /tmp && \
     git clone https://github.com/commaai/openpilot.git tmppilot || true && \
     cd /tmp/tmppilot && \
     git fetch && \
-    git checkout 1b0167ce24afb037b36464c40f9c5e0d657e77d9 && \
+    git checkout $OPENPILOT_REF && \
     git submodule update --init cereal opendbc rednose_repo && \
-    git -C opendbc checkout b8b3adfd9d64413642201954808810ea853782d7 && \
+    git -C opendbc fetch && \
+    git -C opendbc checkout $OPENDBC_REF && \
+    git -C opendbc reset --hard HEAD && \
+    git -C opendbc clean -xfd && \
     mkdir /tmp/openpilot && \
     cp -pR SConstruct site_scons/ tools/ selfdrive/ system/ common/ cereal/ opendbc/ rednose/ third_party/ /tmp/openpilot && \
     rm -rf /tmp/tmppilot

--- a/Dockerfile.panda
+++ b/Dockerfile.panda
@@ -65,6 +65,7 @@ RUN cd /tmp && \
     git fetch && \
     git checkout 1b0167ce24afb037b36464c40f9c5e0d657e77d9 && \
     git submodule update --init cereal opendbc rednose_repo && \
+    git -C opendbc checkout e7cd3ebc893047bf6eb947c60d8e3196b506e8d3 && \
     mkdir /tmp/openpilot && \
     cp -pR SConstruct site_scons/ tools/ selfdrive/ system/ common/ cereal/ opendbc/ rednose/ third_party/ /tmp/openpilot && \
     rm -rf /tmp/tmppilot

--- a/Dockerfile.panda
+++ b/Dockerfile.panda
@@ -65,7 +65,7 @@ RUN cd /tmp && \
     git fetch && \
     git checkout 1b0167ce24afb037b36464c40f9c5e0d657e77d9 && \
     git submodule update --init cereal opendbc rednose_repo && \
-    git -C opendbc checkout e7cd3ebc893047bf6eb947c60d8e3196b506e8d3 && \
+    git -C opendbc checkout b8b3adfd9d64413642201954808810ea853782d7 && \
     mkdir /tmp/openpilot && \
     cp -pR SConstruct site_scons/ tools/ selfdrive/ system/ common/ cereal/ opendbc/ rednose/ third_party/ /tmp/openpilot && \
     rm -rf /tmp/tmppilot


### PR DESCRIPTION
For cases where you need to merge a new signal to opendbc, however you can't bump opendbc on openpilot master until the panda PR is ready and tests pass. Previously you needed to make a second commit in panda to bump openpilot once it was merged (with failing panda tests).