### PR TITLE
safety: fix race condition in engagement heartbeat

### DIFF
--- a/board/main_declarations.h
+++ b/board/main_declarations.h
@@ -20,8 +20,6 @@ bool green_led_enabled = false;
 uint32_t heartbeat_counter = 0;
 bool heartbeat_lost = false;
 bool heartbeat_disabled = false;            // set over USB
-bool heartbeat_engaged = false;             // openpilot enabled, passed in heartbeat USB command
-uint32_t heartbeat_engaged_mismatches = 0;  // count of mismatches between heartbeat_engaged and controls_allowed
 
 // Enter deep sleep mode
 bool deepsleep_requested = false;

--- a/board/safety/safety_hyundai_hda2.h
+++ b/board/safety/safety_hyundai_hda2.h
@@ -30,7 +30,7 @@ uint16_t hyundai_hda2_crc_lut[256];
 
 static uint8_t hyundai_hda2_get_counter(CANPacket_t *to_push) {
   uint8_t ret = 0;
-  if (GET_LEN(to_push) == 8) {
+  if (GET_LEN(to_push) == 8U) {
     ret = GET_BYTE(to_push, 1) >> 4;
   } else {
     ret = GET_BYTE(to_push, 2);

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -123,6 +123,10 @@ struct sample_t torque_meas;       // last 6 motor torques produced by the eps
 struct sample_t torque_driver;     // last 6 driver torques measured
 uint32_t ts_last = 0;
 
+// state for controls_allowed timeout logic
+bool heartbeat_engaged = false;             // openpilot enabled, passed in heartbeat USB command
+uint32_t heartbeat_engaged_mismatches = 0;  // count of mismatches between heartbeat_engaged and controls_allowed
+
 // for safety modes with angle steering control
 uint32_t ts_angle_last = 0;
 int desired_angle_last = 0;


### PR DESCRIPTION
Here's an example from the field. This particularly happens to affect Honda Nidec vehicles because unlike most PCM cruise cars, they don't disable controls_allowed on the falling edge of cruise to allow for braking down to a stop.
![image](https://user-images.githubusercontent.com/8762862/178832656-cc1b5565-b7b2-4dca-afb3-5228dc626f50.png)
