### PR TITLE
CAN chunking refactor

### DIFF
--- a/board/can_definitions.h
+++ b/board/can_definitions.h
@@ -1,6 +1,6 @@
 #include "dlc_to_len.h"
 
-#define CAN_PACKET_VERSION 2
+#define CAN_PACKET_VERSION 3
 typedef struct {
   unsigned char reserved : 1;
   unsigned char bus : 3;

--- a/board/comms_definitions.h
+++ b/board/comms_definitions.h
@@ -5,7 +5,13 @@ typedef struct {
   uint16_t length;
 } __attribute__((packed)) ControlPacket_t;
 
+typedef struct {
+  uint8_t counter;
+  uint8_t overflow_len;
+  uint16_t chunk_data_length;
+}  __attribute__((packed)) CanChunkHeader_t;
+
 int comms_control_handler(ControlPacket_t *req, uint8_t *resp);
 void comms_endpoint2_write(uint8_t *data, uint32_t len);
 void comms_can_write(uint8_t *data, uint32_t len);
-int comms_can_read(uint8_t *data, uint32_t max_len);
+int comms_can_read(uint8_t *data, uint16_t max_len);

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -90,7 +90,7 @@ void comms_can_write(uint8_t *data, uint32_t len) {
   UNUSED(len);
 }
 
-int comms_can_read(uint8_t *data, uint32_t max_len) {
+int comms_can_read(uint8_t *data, uint16_t max_len) {
   UNUSED(data);
   UNUSED(max_len);
   return 0;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -59,25 +59,26 @@ asm_buffer can_read_buffer = {.ptr = 0U, .tail_size = 0U, .counter = 0U};
 int comms_can_read(uint8_t *data, uint16_t max_len) {
   uint16_t pos = sizeof(CanChunkHeader_t);
   uint16_t max_data_len = (max_len - sizeof(CanChunkHeader_t));
+  CanChunkHeader_t *chunk_header = (CanChunkHeader_t *)((void *) data);
 
-  ((CanChunkHeader_t *)data)->counter = can_read_buffer.counter;
+  chunk_header->counter = can_read_buffer.counter;
 
   // Send tail of previous message if it is in buffer
   if (can_read_buffer.ptr > 0U) {
     if (can_read_buffer.ptr <= max_data_len) {
       (void)memcpy(&data[pos], can_read_buffer.overflow_data, can_read_buffer.ptr);
       pos += can_read_buffer.ptr;
-      ((CanChunkHeader_t *)data)->overflow_len = can_read_buffer.ptr;
+      chunk_header->overflow_len = can_read_buffer.ptr;
       can_read_buffer.ptr = 0U;
     } else {
       (void)memcpy(&data[pos], can_read_buffer.overflow_data, max_data_len);
       can_read_buffer.ptr = can_read_buffer.ptr - max_data_len;
       (void)memcpy(can_read_buffer.overflow_data, &can_read_buffer.overflow_data[max_data_len], can_read_buffer.ptr);
-      ((CanChunkHeader_t *)data)->overflow_len = max_data_len;
+      chunk_header->overflow_len = max_data_len;
       pos += max_data_len;
     }
   } else {
-    ((CanChunkHeader_t *)data)->overflow_len = 0U;
+    chunk_header->overflow_len = 0U;
   }
 
   CANPacket_t can_packet;
@@ -95,7 +96,7 @@ int comms_can_read(uint8_t *data, uint16_t max_len) {
     }
   }
 
-  ((CanChunkHeader_t *)data)->chunk_data_length = pos - sizeof(CanChunkHeader_t);
+  chunk_header->chunk_data_length = pos - sizeof(CanChunkHeader_t);
 
   can_read_buffer.counter++;
 

--- a/tests/usbprotocol/test_pandalib.py
+++ b/tests/usbprotocol/test_pandalib.py
@@ -15,7 +15,7 @@ class PandaTestPackUnpack(unittest.TestCase):
     packed = pack_can_buffer(to_pack)
     unpacked = []
     for dat in packed:
-      unpacked.extend(unpack_can_buffer(dat))
+      unpacked.extend(unpack_can_buffer(dat)[0])
 
     assert unpacked == to_pack
 

--- a/tests/usbprotocol/test_pandalib.py
+++ b/tests/usbprotocol/test_pandalib.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import random
 import unittest
-from panda import pack_can_buffer, unpack_can_buffer
+from panda import pack_can_buffer, unpack_can_buffer, DLC_TO_LEN
 
 
 class PandaTestPackUnpack(unittest.TestCase):
@@ -9,7 +9,8 @@ class PandaTestPackUnpack(unittest.TestCase):
     to_pack = []
     for _ in range(10000):
       address = random.randint(1, 0x1FFFFFFF)
-      data = bytes([random.getrandbits(8) for _ in range(random.randrange(1, 9))])
+      data = bytes([random.getrandbits(8) for _ in range(DLC_TO_LEN[random.randrange(len(DLC_TO_LEN))])])
+      print(len(data))
       to_pack.append((address, 0, data, 0))
 
     packed = pack_can_buffer(to_pack)

--- a/tests/usbprotocol/test_pandalib.py
+++ b/tests/usbprotocol/test_pandalib.py
@@ -14,8 +14,11 @@ class PandaTestPackUnpack(unittest.TestCase):
 
     packed = pack_can_buffer(to_pack)
     unpacked = []
+    
+    counter = None
     for dat in packed:
-      unpacked.extend(unpack_can_buffer(dat)[0])
+      msgs, counter = unpack_can_buffer(dat, prev_rx_counter=counter)
+      unpacked.extend(msgs)
 
     assert unpacked == to_pack
 


### PR DESCRIPTION
The current chunking code relies on the following assumptions from the USB bulk transfers. This PR removes those assumptions, which aren't true for SPI comms:

- `max_len` is always 0x40 (the bulk transfer chunk size)
- the chunks are always requested in a max-size bulk transfer
- the chunk counter always starts at 0 for a new transfer, with the overflow buffer empty