### PR TITLE
Dynamic sector erase

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -1,18 +1,19 @@
 import os
 
-
 BASEDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../")
 
 BOOTSTUB_ADDRESS = 0x8000000
 
 BLOCK_SIZE_FX = 0x800
 APP_ADDRESS_FX = 0x8004000
+SECTOR_SIZES_FX = [0x4000 for _ in range(4)] + [0x10000] + [0x20000 for _ in range(11)]
 DEVICE_SERIAL_NUMBER_ADDR_FX = 0x1FFF79C0
 DEFAULT_FW_FN = os.path.join(BASEDIR, "board", "obj", "panda.bin.signed")
 DEFAULT_BOOTSTUB_FN = os.path.join(BASEDIR, "board", "obj", "bootstub.panda.bin")
 
 BLOCK_SIZE_H7 = 0x400
 APP_ADDRESS_H7 = 0x8020000
+SECTOR_SIZES_H7 = [0x20000 for _ in range(7)] # there is an 8th sector, but we use that for the provisioning chunk, so don't program over that!
 DEVICE_SERIAL_NUMBER_ADDR_H7 = 0x080FFFC0
 DEFAULT_H7_FW_FN = os.path.join(BASEDIR, "board", "obj", "panda_h7.bin.signed")
 DEFAULT_H7_BOOTSTUB_FN = os.path.join(BASEDIR, "board", "obj", "bootstub.panda_h7.bin")

--- a/tests/pedal/enter_canloader.py
+++ b/tests/pedal/enter_canloader.py
@@ -2,6 +2,7 @@
 import time
 import argparse
 from panda import Panda
+from panda.python.dfu import MCU_TYPE_F2
 from panda.tests.pedal.canhandle import CanHandle
 
 
@@ -28,6 +29,6 @@ if __name__ == "__main__":
     time.sleep(0.1)
     print("flashing", args.fn)
     code = open(args.fn, "rb").read()
-    Panda.flash_static(CanHandle(p, 0), code)
+    Panda.flash_static(CanHandle(p, 0), code, mcu_type=MCU_TYPE_F2)
 
   print("can flash done")


### PR DESCRIPTION
The latest panda commit in openpilot pushed the binary size (49460 bytes) just over the fixed 3 0x4000 pages (49152 bytes) it [erases before flashing](https://github.com/commaai/panda/blob/8b26ce940f8193012ede411fa55ed30e2c34c536/python/__init__.py#L300), which causes the check in the bootloader to fail.