### PR TITLE
Only allow deep sleep if there's been ignition before

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -28,7 +28,9 @@
 // ********************* Serial debugging *********************
 
 bool check_started(void) {
-  return current_board->check_ignition() || ignition_can;
+  bool started = current_board->check_ignition() || ignition_can;
+  ignition_seen |= started;
+  return started;
 }
 
 void debug_ring_callback(uart_ring *ring) {
@@ -419,7 +421,7 @@ int main(void) {
         }
       #endif
     } else {
-      if (deepsleep_allowed && !usb_enumerated && !check_started()) {
+      if (deepsleep_allowed && !usb_enumerated && !check_started() && ignition_seen) {
         usb_soft_disconnect(true);
         current_board->set_fan_power(0U);
         current_board->set_usb_power_mode(USB_POWER_CLIENT);

--- a/board/main.c
+++ b/board/main.c
@@ -421,7 +421,7 @@ int main(void) {
         }
       #endif
     } else {
-      if (deepsleep_allowed && !usb_enumerated && !check_started() && ignition_seen) {
+      if (deepsleep_allowed && !usb_enumerated && !check_started() && ignition_seen && (heartbeat_counter > 20U)) {
         usb_soft_disconnect(true);
         current_board->set_fan_power(0U);
         current_board->set_usb_power_mode(USB_POWER_CLIENT);

--- a/board/main_declarations.h
+++ b/board/main_declarations.h
@@ -22,6 +22,7 @@ bool heartbeat_disabled = false;            // set over USB
 
 // Enter deep sleep mode
 bool deepsleep_allowed = false;
+bool ignition_seen = false;
 
 // siren state
 bool siren_enabled = false;


### PR DESCRIPTION
If the panda is in a multi-panda setup, it's possible that it will never see an ignition signal.
In this case, waking up from deep sleep is impossible, so let's just not enter it in the first place.