### PR TITLE
Minimum uptime for deep sleep

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -421,7 +421,7 @@ int main(void) {
         }
       #endif
     } else {
-      if (deepsleep_allowed && !usb_enumerated && !check_started() && ignition_seen) {
+      if (deepsleep_allowed && !usb_enumerated && !check_started() && ignition_seen && (heartbeat_counter > 20U)) {
         usb_soft_disconnect(true);
         current_board->set_fan_power(0U);
         current_board->set_usb_power_mode(USB_POWER_CLIENT);


### PR DESCRIPTION
With CAN-based ignition, it's possible that the panda wakes up from deep sleep after the CAN IRQ, but immediately goes back to sleep since `ignition_can` has not been set yet. This PR ensures minimum uptime to not allow that to happen.