### PR TITLE
safety: common cruise checks

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -519,13 +519,13 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
   return violation;
 }
 
-void pcm_cruise_check(int cruise_engaged) {
+void pcm_cruise_check(bool cruise_engaged) {
   // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
   if (!cruise_engaged) {
-    controls_allowed = 0;
+    controls_allowed = false;
   }
   if (cruise_engaged && !cruise_engaged_prev) {
-    controls_allowed = 1;
+    controls_allowed = true;
   }
   cruise_engaged_prev = cruise_engaged;
 }

--- a/board/safety.h
+++ b/board/safety.h
@@ -518,3 +518,13 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
 
   return violation;
 }
+
+void pcm_cruise_check(int cruise_engaged) {
+  if (!cruise_engaged) {
+    controls_allowed = 0;
+  }
+  if (cruise_engaged && !cruise_engaged_prev) {
+    controls_allowed = 1;
+  }
+  cruise_engaged_prev = cruise_engaged;
+}

--- a/board/safety.h
+++ b/board/safety.h
@@ -520,6 +520,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
 }
 
 void pcm_cruise_check(int cruise_engaged) {
+  // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
   if (!cruise_engaged) {
     controls_allowed = 0;
   }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -200,13 +200,7 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
     const int das_3_bus = (chrysler_platform == CHRYSLER_PACIFICA) ? 0 : 2;
     if ((bus == das_3_bus) && (addr == chrysler_addrs->DAS_3)) {
       int cruise_engaged = GET_BIT(to_push, 21U) == 1U;
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     // TODO: use the same message for both

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -199,7 +199,7 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
     // enter controls on rising edge of ACC, exit controls on ACC off
     const int das_3_bus = (chrysler_platform == CHRYSLER_PACIFICA) ? 0 : 2;
     if ((bus == das_3_bus) && (addr == chrysler_addrs->DAS_3)) {
-      int cruise_engaged = GET_BIT(to_push, 21U) == 1U;
+      bool cruise_engaged = GET_BIT(to_push, 21U) == 1U;
       pcm_cruise_check(cruise_engaged);
     }
 

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -61,15 +61,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
       // Signal: CcStat_D_Actl
       unsigned int cruise_state = GET_BYTE(to_push, 1) & 0x07U;
       bool cruise_engaged = (cruise_state == 4U) || (cruise_state == 5U);
-
-      // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = true;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = false;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     // If steering controls messages are received on the destination bus, it's an indication

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -56,14 +56,7 @@ static int mazda_rx_hook(CANPacket_t *to_push) {
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == MAZDA_CRZ_CTRL) {
       bool cruise_engaged = GET_BYTE(to_push, 0) & 0x8U;
-      if (cruise_engaged) {
-        if (!cruise_engaged_prev) {
-          controls_allowed = 1;
-        }
-      } else {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     if (addr == MAZDA_ENGINE_DATA) {

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -90,14 +90,7 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
     // Handle cruise enabled
     if ((addr == 0x30f) && (((bus == 2) && (!nissan_alt_eps)) || ((bus == 1) && (nissan_alt_eps)))) {
       bool cruise_engaged = (GET_BYTE(to_push, 0) >> 3) & 1U;
-
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     generic_rx_checks((addr == 0x169) && (bus == 0));

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -100,7 +100,7 @@ static int subaru_rx_hook(CANPacket_t *to_push) {
 
     // enter controls on rising edge of ACC, exit controls on ACC off
     if ((addr == 0x240) && (bus == alt_bus)) {
-      int cruise_engaged = ((GET_BYTES_48(to_push) >> 9) & 1U);
+      bool cruise_engaged = GET_BIT(to_push, 41U) != 0U;
       pcm_cruise_check(cruise_engaged);
     }
 

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -101,13 +101,7 @@ static int subaru_rx_hook(CANPacket_t *to_push) {
     // enter controls on rising edge of ACC, exit controls on ACC off
     if ((addr == 0x240) && (bus == alt_bus)) {
       int cruise_engaged = ((GET_BYTES_48(to_push) >> 9) & 1U);
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     // sample wheel speed, averaging opposite corners

--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -40,13 +40,7 @@ static int subaru_legacy_rx_hook(CANPacket_t *to_push) {
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == 0x144) {
       int cruise_engaged = ((GET_BYTES_48(to_push) >> 17) & 1U);
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     // sample wheel speed, averaging opposite corners

--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -39,7 +39,7 @@ static int subaru_legacy_rx_hook(CANPacket_t *to_push) {
 
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == 0x144) {
-      int cruise_engaged = ((GET_BYTES_48(to_push) >> 17) & 1U);
+      bool cruise_engaged = GET_BIT(to_push, 49U) != 0U;
       pcm_cruise_check(cruise_engaged);
     }
 

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -95,14 +95,7 @@ static int tesla_rx_hook(CANPacket_t *to_push) {
                               (cruise_state == 4) ||  // OVERRIDE
                               (cruise_state == 6) ||  // PRE_FAULT
                               (cruise_state == 7);    // PRE_CANCEL
-
-        if(cruise_engaged && !cruise_engaged_prev) {
-          controls_allowed = 1;
-        }
-        if(!cruise_engaged) {
-          controls_allowed = 0;
-        }
-        cruise_engaged_prev = cruise_engaged;
+        pcm_cruise_check(cruise_engaged);
       }
     }
 

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -90,13 +90,7 @@ static int toyota_rx_hook(CANPacket_t *to_push) {
     if (addr == 0x1D2) {
       // 5th bit is CRUISE_ACTIVE
       int cruise_engaged = GET_BYTE(to_push, 0) & 0x20U;
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
 
       // sample gas pedal
       if (!gas_interceptor_detected) {

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -89,7 +89,7 @@ static int toyota_rx_hook(CANPacket_t *to_push) {
     // exit controls on rising edge of gas press
     if (addr == 0x1D2) {
       // 5th bit is CRUISE_ACTIVE
-      int cruise_engaged = GET_BYTE(to_push, 0) & 0x20U;
+      bool cruise_engaged = GET_BIT(to_push, 5U) != 0U;
       pcm_cruise_check(cruise_engaged);
 
       // sample gas pedal

--- a/board/safety/safety_volkswagen_mqb.h
+++ b/board/safety/safety_volkswagen_mqb.h
@@ -123,13 +123,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
     if (addr == MSG_TSK_06) {
       int acc_status = (GET_BYTE(to_push, 3) & 0x7U);
       int cruise_engaged = ((acc_status == 3) || (acc_status == 4) || (acc_status == 5)) ? 1 : 0;
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     // Signal: Motor_20.MO_Fahrpedalrohwert_01

--- a/board/safety/safety_volkswagen_mqb.h
+++ b/board/safety/safety_volkswagen_mqb.h
@@ -122,7 +122,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
     // Signal: TSK_06.TSK_Status
     if (addr == MSG_TSK_06) {
       int acc_status = (GET_BYTE(to_push, 3) & 0x7U);
-      int cruise_engaged = ((acc_status == 3) || (acc_status == 4) || (acc_status == 5)) ? 1 : 0;
+      bool cruise_engaged = (acc_status == 3) || (acc_status == 4) || (acc_status == 5);
       pcm_cruise_check(cruise_engaged);
     }
 

--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -90,7 +90,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
     // Signal: Motor_2.GRA_Status
     if (addr == MSG_MOTOR_2) {
       int acc_status = (GET_BYTE(to_push, 2) & 0xC0U) >> 6;
-      int cruise_engaged = ((acc_status == 1) || (acc_status == 2)) ? 1 : 0;
+      bool cruise_engaged = (acc_status == 1) || (acc_status == 2);
       pcm_cruise_check(cruise_engaged);
     }
 

--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -91,13 +91,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
     if (addr == MSG_MOTOR_2) {
       int acc_status = (GET_BYTE(to_push, 2) & 0xC0U) >> 6;
       int cruise_engaged = ((acc_status == 1) || (acc_status == 2)) ? 1 : 0;
-      if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
-      }
-      if (!cruise_engaged) {
-        controls_allowed = 0;
-      }
-      cruise_engaged_prev = cruise_engaged;
+      pcm_cruise_check(cruise_engaged);
     }
 
     // Signal: Motor_3.Fahrpedal_Rohsignal

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -107,7 +107,7 @@ void generic_rx_checks(bool stock_ecu_detected);
 void relay_malfunction_set(void);
 void relay_malfunction_reset(void);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits);
-void pcm_cruise_check(int cruise_engaged);
+void pcm_cruise_check(bool cruise_engaged);
 
 typedef const addr_checks* (*safety_hook_init)(uint16_t param);
 typedef int (*rx_hook)(CANPacket_t *to_push);

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -107,6 +107,7 @@ void generic_rx_checks(bool stock_ecu_detected);
 void relay_malfunction_set(void);
 void relay_malfunction_reset(void);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits);
+void pcm_cruise_check(int cruise_engaged);
 
 typedef const addr_checks* (*safety_hook_init)(uint16_t param);
 typedef int (*rx_hook)(CANPacket_t *to_push);


### PR DESCRIPTION
On the way to making the safety modes more like openpilot (parsers), per recent conversation. Reducing the setting of controls_allowed in each car-specific mode also seems like a good move.

Hyundai and Honda add special logic to this check, so those aren't moved over yet.