### PR TITLE
GM Safety: Add support for auto-resume via button spamming

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -237,11 +237,19 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
   }
 
   // BUTTONS: used for resume spamming and cruise cancellation with stock longitudinal
-  if ((addr == 481) && (gm_hw == GM_CAM)) {
+  if (addr == 481) {
     int button = (GET_BYTE(to_send, 5) >> 4) & 0x7U;
+    bool allowed = false;
 
-    bool allowed_cancel = (button == 6) && cruise_engaged_prev;
-    if (!allowed_cancel) {
+    if (gm_hw == GM_CAM) {
+      // Only allow TX of cancel button when cruise is engaged, using Cam Harness
+      allowed |= (button == GM_BTN_CANCEL) && cruise_engaged_prev;
+    }
+
+    // Only allow TX of resume button when cruise is not engaged
+    allowed |= (button == GM_BTN_RESUME) && !cruise_engaged_prev;
+
+    if (!allowed) {
       tx = 0;
     }
   }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -20,12 +20,12 @@ const int GM_MAX_GAS = 3072;
 const int GM_MAX_REGEN = 1404;
 const int GM_MAX_BRAKE = 350;
 
-const CanMsg GM_ASCM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8}, {880, 0, 6},  // pt bus
+const CanMsg GM_ASCM_TX_MSGS[] = {{384, 0, 4}, {1033, 0, 7}, {1034, 0, 7}, {715, 0, 8}, {880, 0, 6}, {481, 0, 7},  // pt bus
                                   {161, 1, 7}, {774, 1, 8}, {776, 1, 7}, {784, 1, 2},   // obs bus
                                   {789, 2, 5},  // ch bus
                                   {0x104c006c, 3, 3}, {0x10400060, 3, 5}};  // gmlan
 
-const CanMsg GM_CAM_TX_MSGS[] = {{384, 0, 4},  // pt bus
+const CanMsg GM_CAM_TX_MSGS[] = {{384, 0, 4}, {481, 0, 7},  // pt bus
                                  {481, 2, 7}};  // camera bus
 
 // TODO: do checksum and counter checks. Add correct timestep, 0.1s for now.


### PR DESCRIPTION
Resume spamming needs to be on PT bus rather than camera bus used for cancel button spamming.

Updated the TX allowed messages to permit the button spamming on the PT bus for all configurations

Updated the TX safety code to allow the resume button if cruise is off. Cancel functionality should be unchanged