### PR TITLE
README: remove backtick typo

### DIFF
--- a/drivers/linux/README.md
+++ b/drivers/linux/README.md
@@ -25,5 +25,5 @@ sudo tee /etc/udev/rules.d/11-panda.rules <<EOF
 SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
 EOF
-sudo udevadm control --reload-rules && sudo udevadm trigger`
+sudo udevadm control --reload-rules && sudo udevadm trigger
 ```


### PR DESCRIPTION
This will make it consistent w/ the main `README.md`