### PR TITLE
debug build: remove direct jump to DFU

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -38,15 +38,18 @@ void debug_ring_callback(uart_ring *ring) {
   while (getc(ring, &rcv)) {
     (void)putc(ring, rcv);  // misra-c2012-17.7: cast to void is ok: debug function
 
-    // jump to DFU flash
-    if (rcv == 'z') {
-      enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-      NVIC_SystemReset();
-    }
+    // can do only if in a non car safety mode
+    if (!is_car_safety_mode(current_safety_mode)) {
+      // jump to DFU flash
+      if (rcv == 'z') {
+        enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+        NVIC_SystemReset();
+      }
 
-    // normal reset
-    if (rcv == 'x') {
-      NVIC_SystemReset();
+      // normal reset
+      if (rcv == 'x') {
+        NVIC_SystemReset();
+      }
     }
 
     // enable CDP mode

--- a/board/main.c
+++ b/board/main.c
@@ -40,9 +40,9 @@ void debug_ring_callback(uart_ring *ring) {
 
     // can do only if in a non car safety mode
     if (!is_car_safety_mode(current_safety_mode)) {
-      // jump to DFU flash
+      // jump to bootstub
       if (rcv == 'z') {
-        enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+        enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
         NVIC_SystemReset();
       }
 

--- a/board/main.c
+++ b/board/main.c
@@ -38,14 +38,11 @@ void debug_ring_callback(uart_ring *ring) {
   while (getc(ring, &rcv)) {
     (void)putc(ring, rcv);  // misra-c2012-17.7: cast to void is ok: debug function
 
-    // only allow bootloader entry on debug builds
-    #ifdef ALLOW_DEBUG
-      // jump to DFU flash
-      if (rcv == 'z') {
-        enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-        NVIC_SystemReset();
-      }
-    #endif
+    // jump to DFU flash
+    if (rcv == 'z') {
+      enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+      NVIC_SystemReset();
+    }
 
     // normal reset
     if (rcv == 'x') {

--- a/board/main.c
+++ b/board/main.c
@@ -38,18 +38,15 @@ void debug_ring_callback(uart_ring *ring) {
   while (getc(ring, &rcv)) {
     (void)putc(ring, rcv);  // misra-c2012-17.7: cast to void is ok: debug function
 
-    // can do only if in a non car safety mode
-    if (!is_car_safety_mode(current_safety_mode)) {
-      // jump to bootstub
-      if (rcv == 'z') {
-        enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
-        NVIC_SystemReset();
-      }
+    // jump to bootstub
+    if (rcv == 'z') {
+      enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
+      NVIC_SystemReset();
+    }
 
-      // normal reset
-      if (rcv == 'x') {
-        NVIC_SystemReset();
-      }
+    // normal reset
+    if (rcv == 'x') {
+      NVIC_SystemReset();
     }
 
     // enable CDP mode

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -270,20 +270,22 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
     // **** 0xd1: enter bootloader mode
     case 0xd1:
       // this allows reflashing of the bootstub
-      switch (req->param1) {
-        case 0:
-          puts("-> entering bootloader\n");
-          enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-          NVIC_SystemReset();
-          break;
-        case 1:
-          puts("-> entering softloader\n");
-          enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
-          NVIC_SystemReset();
-          break;
-        default:
-          puts("Bootloader mode invalid\n");
-          break;
+      if (!is_car_safety_mode(current_safety_mode)) {
+        switch (req->param1) {
+          case 0:
+            puts("-> entering bootloader\n");
+            enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+            NVIC_SystemReset();
+            break;
+          case 1:
+            puts("-> entering softloader\n");
+            enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
+            NVIC_SystemReset();
+            break;
+          default:
+            puts("Bootloader mode invalid\n");
+            break;
+        }
       }
       break;
     // **** 0xd2: get health packet
@@ -316,7 +318,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       break;
     // **** 0xd8: reset ST
     case 0xd8:
-      NVIC_SystemReset();
+      if (!is_car_safety_mode(current_safety_mode)) {
+        NVIC_SystemReset();
+      }
       break;
     // **** 0xd9: set ESP power
     case 0xd9:

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -272,11 +272,6 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       // this allows reflashing of the bootstub
       if (!is_car_safety_mode(current_safety_mode)) {
         switch (req->param1) {
-          case 0:
-            puts("-> entering bootloader\n");
-            enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-            NVIC_SystemReset();
-            break;
           case 1:
             puts("-> entering softloader\n");
             enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -279,7 +279,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
         default:
           puts("Bootloader mode invalid\n");
           break;
-        }
+      }
       break;
     // **** 0xd2: get health packet
     case 0xd2:

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -272,12 +272,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       // this allows reflashing of the bootstub
       switch (req->param1) {
         case 0:
-          // only allow bootloader entry on debug builds
-          #ifdef ALLOW_DEBUG
-            puts("-> entering bootloader\n");
-            enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
-            NVIC_SystemReset();
-          #endif
+          puts("-> entering bootloader\n");
+          enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
+          NVIC_SystemReset();
           break;
         case 1:
           puts("-> entering softloader\n");

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -269,19 +269,17 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       break;
     // **** 0xd1: enter bootloader mode
     case 0xd1:
-      // this allows reflashing of the bootstub
-      if (!is_car_safety_mode(current_safety_mode)) {
-        switch (req->param1) {
-          case 1:
-            puts("-> entering softloader\n");
-            enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
-            NVIC_SystemReset();
-            break;
-          default:
-            puts("Bootloader mode invalid\n");
-            break;
+      // jump to bootstub first
+      switch (req->param1) {
+        case 1:
+          puts("-> entering softloader\n");
+          enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
+          NVIC_SystemReset();
+          break;
+        default:
+          puts("Bootloader mode invalid\n");
+          break;
         }
-      }
       break;
     // **** 0xd2: get health packet
     case 0xd2:
@@ -313,9 +311,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       break;
     // **** 0xd8: reset ST
     case 0xd8:
-      if (!is_car_safety_mode(current_safety_mode)) {
-        NVIC_SystemReset();
-      }
+      NVIC_SystemReset();
       break;
     // **** 0xd9: set ESP power
     case 0xd9:


### PR DESCRIPTION
For release build to go into DFU mode we need to jump to bootstub first.
I see no reason for this, just adds complexity.
Also we might want to check if safety is set to car mode before jumping to either bootloader or softloader.