### PR TITLE
refactor torque measurement reset on violation

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -266,6 +266,12 @@ void relay_malfunction_reset(void) {
   fault_recovered(FAULT_RELAY_MALFUNCTION);
 }
 
+void torque_measurements_reset(uint32_t ts) {
+  desired_torque_last = 0;
+  rt_torque_last = 0;
+  ts_last = ts;
+}
+
 typedef struct {
   uint16_t id;
   const safety_hooks *hooks;
@@ -511,9 +517,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
 
   // reset to 0 if either controls is not allowed or there's a violation
   if (violation || !controls_allowed) {
-    desired_torque_last = 0;
-    rt_torque_last = 0;
-    ts_last = ts;
+    torque_measurements_reset(ts);
   }
 
   return violation;

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -203,9 +203,7 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
 
     // reset to 0 if either controls is not allowed or there's a violation
     if (violation || !current_controls_allowed) {
-      desired_torque_last = 0;
-      rt_torque_last = 0;
-      ts_last = ts;
+      torque_measurements_reset(ts);
     }
 
     if (violation) {

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -106,6 +106,7 @@ bool addr_safety_check(CANPacket_t *to_push,
 void generic_rx_checks(bool stock_ecu_detected);
 void relay_malfunction_set(void);
 void relay_malfunction_reset(void);
+void torque_measurements_reset(uint32_t);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits);
 void pcm_cruise_check(bool cruise_engaged);
 

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -106,7 +106,7 @@ bool addr_safety_check(CANPacket_t *to_push,
 void generic_rx_checks(bool stock_ecu_detected);
 void relay_malfunction_set(void);
 void relay_malfunction_reset(void);
-void torque_measurements_reset(uint32_t);
+void torque_measurements_reset(uint32_t ts);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits);
 void pcm_cruise_check(bool cruise_engaged);
 


### PR DESCRIPTION
* removes some duplication
* allows for cleaner custom steer request mismatch handling (useful when updating toyota-steer-faults2)