### PR TITLE
query_fw_versions: continue on error

### DIFF
--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -69,6 +69,9 @@ if __name__ == "__main__":
             resp[uds_data_id] = data
         except (NegativeResponseError, MessageTimeoutError):
           pass
+        except Exception as e:
+          print(e)
+          continue
 
       if resp.keys():
         results[addr] = resp


### PR DESCRIPTION
This would often abort a two minute query without printing any response. I believe fw_versions.py prints these errors as well