### PR TITLE
Hyundai: enforce ACC main state with controls allowed

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -67,7 +67,7 @@ AddrCheckStruct hyundai_legacy_addr_checks[] = {
            {881, 0, 8, .expected_timestep = 10000U}, { 0 }}},
   {.msg = {{902, 0, 8, .expected_timestep = 10000U}, { 0 }, { 0 }}},
   {.msg = {{916, 0, 8, .expected_timestep = 10000U}, { 0 }, { 0 }}},
-  {.msg = {{1067, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
+  {.msg = {{1056, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
   {.msg = {{1057, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
 };
 #define HYUNDAI_LEGACY_ADDR_CHECK_LEN (sizeof(hyundai_legacy_addr_checks) / sizeof(hyundai_legacy_addr_checks[0]))

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -45,8 +45,8 @@ AddrCheckStruct hyundai_addr_checks[] = {
            {881, 0, 8, .expected_timestep = 10000U}, { 0 }}},
   {.msg = {{902, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U}, { 0 }, { 0 }}},
   {.msg = {{916, 0, 8, .check_checksum = true, .max_counter = 7U, .expected_timestep = 10000U}, { 0 }, { 0 }}},
-  {.msg = {{1056, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
-           {1056, 2, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }}},
+  {.msg = {{1056, 0, 8, .max_counter = 15U, .expected_timestep = 20000U},
+           {1056, 2, 8, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }}},
   {.msg = {{1057, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U},
            {1057, 2, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }}},
 };
@@ -67,7 +67,7 @@ AddrCheckStruct hyundai_legacy_addr_checks[] = {
            {881, 0, 8, .expected_timestep = 10000U}, { 0 }}},
   {.msg = {{902, 0, 8, .expected_timestep = 10000U}, { 0 }, { 0 }}},
   {.msg = {{916, 0, 8, .expected_timestep = 10000U}, { 0 }, { 0 }}},
-  {.msg = {{1056, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
+  {.msg = {{1056, 0, 8, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
   {.msg = {{1057, 0, 8, .check_checksum = true, .max_counter = 15U, .expected_timestep = 20000U}, { 0 }, { 0 }}},
 };
 #define HYUNDAI_LEGACY_ADDR_CHECK_LEN (sizeof(hyundai_legacy_addr_checks) / sizeof(hyundai_legacy_addr_checks[0]))


### PR DESCRIPTION
Enforce ACC main state with stock/openpilot longitudinal control in openpilot and panda safety. Enforce `controls_allowed = 0` when the signal is `0`.

Stock ACC: `SCC11|MainMode_ACC`

openpilot ACC: `EMS16|CRUISE_LAMP_M`
- Available on all currently supported openpilot longitudinal HKG cars
- Sync with ACC MAIN button press
- Will be copied and sent with `SCC11|MainMode_ACC` to the car when ACC MAIN is pressed

**Prerequisite of:**
- https://github.com/commaai/openpilot/pull/25624

