### PR TITLE
Hyundai: Car Port for Kia EV6 (HDA1) 2022

### DIFF
--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -25,7 +25,7 @@ const CanMsg HYUNDAI_CANFD_HDA1_TX_MSGS[] = {
 };
 
 AddrCheckStruct hyundai_canfd_addr_checks[] = {
-  {.msg = {{0x35, 1, 32, .check_checksum = true, .max_counter = 0xffU, .expected_timestep = 10000U},
+  {.msg = {{0x35, 0, 32, .check_checksum = true, .max_counter = 0xffU, .expected_timestep = 10000U},
            {0x105, 0, 32, .check_checksum = true, .max_counter = 0xffU, .expected_timestep = 10000U}, { 0 }}},
   {.msg = {{0x65, 1, 32, .check_checksum = true, .max_counter = 0xffU, .expected_timestep = 10000U},
            {0x65, 0, 32, .check_checksum = true, .max_counter = 0xffU, .expected_timestep = 10000U}, { 0 }}},

--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -149,9 +149,9 @@ static int hyundai_canfd_rx_hook(CANPacket_t *to_push) {
     }
 
     // gas press
-    if ((addr == 0x35) && hyundai_canfd_hda2) {
+    if ((addr == 0x35) && !hyundai_canfd_alt_buttons) {
       gas_pressed = GET_BYTE(to_push, 5) != 0U;
-    } else if ((addr == 0x105) && !hyundai_canfd_hda2) {
+    } else if ((addr == 0x105) && hyundai_canfd_alt_buttons) {
       gas_pressed = (GET_BIT(to_push, 103U) != 0U) || (GET_BYTE(to_push, 13) != 0U) || (GET_BIT(to_push, 112U) != 0U);
     } else {
     }


### PR DESCRIPTION
**Prerequisite for:**
[#25629 #Kia: Car Port for EV6 (HDA1) 2022](https://github.com/commaai/openpilot/pull/25629)

**Need Help**
1. I could not figure out how to add multiple 0x35 signal checks like you do for 0x1cf without getting errors
2. Resume from stop is not working for my HDA1 EV6; does 0x1cf need to be added to forward hook since it is on bus0 instead of bus1?
