### PR TITLE
Add the 0x600 range for UDS messages

### DIFF
--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -13,7 +13,7 @@ static int elm327_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
   //Check valid 29 bit send addresses for ISO 15765-4
   //Check valid 11 bit send addresses for ISO 15765-4
   if ((addr != 0x18DB33F1) && ((addr & 0x1FFF00FF) != 0x18DA00F1) &&
-      ((addr & 0x1FFFFF00) != 0x700)) {
+      ((addr & 0x1FFFFF00) != 0x600) && ((addr & 0x1FFFFF00) != 0x700)) {
     tx = 0;
   }
   return tx;


### PR DESCRIPTION
Tesla has most ECUs in the 0x600-0x700 range, so we need to add this range to allow queries