### PR TITLE
IsoTpMessage: param for single frame flow control

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -480,7 +480,7 @@ class IsoTpMessage():
         self.rx_done = True
       elif self.single_frame_mode:
         # notify ECU to send next frame
-        msg = b"\x30\x01\x00".ljust(self.max_len, b"\x00")
+        msg = b"\x30\x01\x0a".ljust(self.max_len, b"\x00")
         self._can_client.send([msg])
       if self.debug:
         print(f"ISO-TP: RX - consecutive frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")

--- a/python/uds.py
+++ b/python/uds.py
@@ -464,7 +464,7 @@ class IsoTpMessage():
       msg = bytes([
         0x30,  # flow control
         0x01 if self.single_frame_mode else 0x00,  # block size
-        0x0a,  # 10 ms STmin
+        0x0a,  # 10 ms separation time
       ]).ljust(self.max_len, b"\x00")
       self._can_client.send([msg])
       return

--- a/python/uds.py
+++ b/python/uds.py
@@ -458,8 +458,8 @@ class IsoTpMessage():
         print(f"ISO-TP: RX - first frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")
       if self.debug:
         print(f"ISO-TP: TX - flow control continue - {hex(self._can_client.tx_addr)}")
-      # send flow control message (send all bytes) with a separation time of 10 ms
-      msg = b"\x30\x00\x0a".ljust(self.max_len, b"\x00")
+      # send flow control message (send one frame at a time)
+      msg = b"\x30\x01\x00".ljust(self.max_len, b"\x00")
       self._can_client.send([msg])
       return
 
@@ -472,6 +472,10 @@ class IsoTpMessage():
       self.rx_dat += rx_data[1:1 + rx_size]
       if self.rx_len == len(self.rx_dat):
         self.rx_done = True
+      else:
+        # notify ECU to send next frame
+        msg = b"\x30\x01\x00".ljust(self.max_len, b"\x00")
+        self._can_client.send([msg])
       if self.debug:
         print(f"ISO-TP: RX - consecutive frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")
       return

--- a/python/uds.py
+++ b/python/uds.py
@@ -461,10 +461,12 @@ class IsoTpMessage():
       if self.debug:
         print(f"ISO-TP: TX - flow control continue - {hex(self._can_client.tx_addr)}")
       # send flow control message
-      msg = [0x30, 0x00, 0x00]
-      if self.single_frame_mode:
-        msg[1] = 0x01
-      self._can_client.send([bytes(msg).ljust(self.max_len, b"\x00")])
+      msg = bytes([
+        0x30,  # flow control
+        0x01 if self.single_frame_mode else 0x00,  # block size
+        0x0a,  # 10 ms STmin
+      ]).ljust(self.max_len, b"\x00")
+      self._can_client.send([msg])
       return
 
     # consecutive rx frame

--- a/python/uds.py
+++ b/python/uds.py
@@ -460,8 +460,10 @@ class IsoTpMessage():
       if self.debug:
         print(f"ISO-TP: TX - flow control continue - {hex(self._can_client.tx_addr)}")
       # send flow control message
-      msg = b"\x30\x01\x00" if self.single_frame_mode else b"\x30\x00\x00"
-      self._can_client.send([msg.ljust(self.max_len, b"\x00")])
+      msg = [0x30, 0x00, 0x00]
+      if self.single_frame_mode:
+        msg[1] = 0x01
+      self._can_client.send([bytes(msg).ljust(self.max_len, b"\x00")])
       return
 
     # consecutive rx frame


### PR DESCRIPTION
Before the fix in https://github.com/commaai/panda/pull/1078, we'd time out on certain ecus that take longer than 100 ms to finish a full FW query response. Then, when a brand has multiple requests with no ecu whitelists and we'd receive frames from the previous request, throwing invalid consecutive frame errors.

Extending the timeouts on each received frame fixed most of those issues, however the 10 ms delay we have in the flow control message is a minimum, and it's quite possible that an ECU takes 100+ ms to send a frame and we'd time out on it.

This PR removes the frame interval we added to fix certain Hyundai ECUs and replaces it by sending the block size parameter. `IsoTpMessage` now needs to send a flow control message after each consecutive frame it gets from the ECU. This way, if we time out on an ECU, it won't send any more frames on its own.