### PR TITLE
IsoTpMessage.send: setup_only argument

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -386,7 +386,7 @@ class IsoTpMessage():
   def reset(self):
     # If recv is called before send, we assume all tx has been performed prior
     self.tx_idx = 0
-    self.tx_done = True
+    self.tx_done = False
 
     self.rx_dat = b""
     self.rx_len = 0
@@ -396,10 +396,8 @@ class IsoTpMessage():
   def send(self, dat: bytes) -> None:
     # throw away any stale data
     self._can_client.recv(drain=True)
-
     self.tx_dat = dat
     self.tx_len = len(dat)
-    self.tx_done = False
 
     if self.debug:
       print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{bytes.hex(self.tx_dat)}")

--- a/python/uds.py
+++ b/python/uds.py
@@ -384,7 +384,6 @@ class IsoTpMessage():
     self.reset()
 
   def reset(self):
-    # If recv is called before send, we assume all tx has been performed prior
     self.tx_idx = 0
     self.tx_done = False
 

--- a/python/uds.py
+++ b/python/uds.py
@@ -381,9 +381,13 @@ class IsoTpMessage():
     self.timeout = timeout
     self.debug = debug
     self.max_len = max_len
-    self.reset()
 
-  def reset(self):
+  def send(self, dat: bytes, dry_run: bool = False) -> None:
+    # throw away any stale data
+    self._can_client.recv(drain=True)
+
+    self.tx_dat = dat
+    self.tx_len = len(dat)
     self.tx_idx = 0
     self.tx_done = False
 
@@ -391,12 +395,6 @@ class IsoTpMessage():
     self.rx_len = 0
     self.rx_idx = 0
     self.rx_done = False
-
-  def send(self, dat: bytes, dry_run: bool = False) -> None:
-    # throw away any stale data
-    self._can_client.recv(drain=True)
-    self.tx_dat = dat
-    self.tx_len = len(dat)
 
     if self.debug and not dry_run:
       print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{bytes.hex(self.tx_dat)}")

--- a/python/uds.py
+++ b/python/uds.py
@@ -381,13 +381,10 @@ class IsoTpMessage():
     self.timeout = timeout
     self.debug = debug
     self.max_len = max_len
+    self.reset()
 
-  def send(self, dat: bytes) -> None:
-    # throw away any stale data
-    self._can_client.recv(drain=True)
-
-    self.tx_dat = dat
-    self.tx_len = len(dat)
+  def reset(self):
+    # If recv is called before send, we assume all tx has been performed prior
     self.tx_idx = 0
     self.tx_done = False
 
@@ -395,6 +392,14 @@ class IsoTpMessage():
     self.rx_len = 0
     self.rx_idx = 0
     self.rx_done = False
+
+  def send(self, dat: bytes) -> None:
+    # throw away any stale data
+    self._can_client.recv(drain=True)
+
+    self.tx_dat = dat
+    self.tx_len = len(dat)
+    self.tx_done = False
 
     if self.debug:
       print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{bytes.hex(self.tx_dat)}")

--- a/python/uds.py
+++ b/python/uds.py
@@ -399,20 +399,20 @@ class IsoTpMessage():
     self.tx_dat = dat
     self.tx_len = len(dat)
 
-    if self.debug:
+    if self.debug and not dry_run:
       print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{bytes.hex(self.tx_dat)}")
     self._tx_first_frame(dry_run=dry_run)
 
   def _tx_first_frame(self, dry_run: bool = False) -> None:
     if self.tx_len < self.max_len:
       # single frame (send all bytes)
-      if self.debug:
+      if self.debug and not dry_run:
         print(f"ISO-TP: TX - single frame - {hex(self._can_client.tx_addr)}")
       msg = (bytes([self.tx_len]) + self.tx_dat).ljust(self.max_len, b"\x00")
       self.tx_done = True
     else:
       # first frame (send first 6 bytes)
-      if self.debug:
+      if self.debug and not dry_run:
         print(f"ISO-TP: TX - first frame - {hex(self._can_client.tx_addr)}")
       msg = (struct.pack("!H", 0x1000 | self.tx_len) + self.tx_dat[:self.max_len - 2]).ljust(self.max_len - 2, b"\x00")
     if not dry_run:

--- a/python/uds.py
+++ b/python/uds.py
@@ -382,7 +382,7 @@ class IsoTpMessage():
     self.debug = debug
     self.max_len = max_len
 
-  def send(self, dat: bytes, dry_run: bool = False) -> None:
+  def send(self, dat: bytes, setup_only: bool = False) -> None:
     # throw away any stale data
     self._can_client.recv(drain=True)
 
@@ -396,23 +396,23 @@ class IsoTpMessage():
     self.rx_idx = 0
     self.rx_done = False
 
-    if self.debug and not dry_run:
+    if self.debug and not setup_only:
       print(f"ISO-TP: REQUEST - {hex(self._can_client.tx_addr)} 0x{bytes.hex(self.tx_dat)}")
-    self._tx_first_frame(dry_run=dry_run)
+    self._tx_first_frame(setup_only=setup_only)
 
-  def _tx_first_frame(self, dry_run: bool = False) -> None:
+  def _tx_first_frame(self, setup_only: bool = False) -> None:
     if self.tx_len < self.max_len:
       # single frame (send all bytes)
-      if self.debug and not dry_run:
+      if self.debug and not setup_only:
         print(f"ISO-TP: TX - single frame - {hex(self._can_client.tx_addr)}")
       msg = (bytes([self.tx_len]) + self.tx_dat).ljust(self.max_len, b"\x00")
       self.tx_done = True
     else:
       # first frame (send first 6 bytes)
-      if self.debug and not dry_run:
+      if self.debug and not setup_only:
         print(f"ISO-TP: TX - first frame - {hex(self._can_client.tx_addr)}")
       msg = (struct.pack("!H", 0x1000 | self.tx_len) + self.tx_dat[:self.max_len - 2]).ljust(self.max_len - 2, b"\x00")
-    if not dry_run:
+    if not setup_only:
       self._can_client.send([msg])
 
   def recv(self, timeout=None) -> Tuple[Optional[bytes], bool]:

--- a/python/uds.py
+++ b/python/uds.py
@@ -386,7 +386,7 @@ class IsoTpMessage():
   def reset(self):
     # If recv is called before send, we assume all tx has been performed prior
     self.tx_idx = 0
-    self.tx_done = False
+    self.tx_done = True
 
     self.rx_dat = b""
     self.rx_len = 0


### PR DESCRIPTION
Adds a `setup_only` argument to `IsoTpMessage.send()` so that if the user wants to set up an `IsoTpMessage` to receive data after another `IsoTpMessage` sends a query, that is now possible (sending on a functional addr, and finishing communication on a physical addr for example).