### PR TITLE
Ford: allow sending buttons msg to camera

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -14,6 +14,7 @@
 
 const CanMsg FORD_TX_MSGS[] = {
   {MSG_Steering_Data_FD1, 0, 8},
+  {MSG_Steering_Data_FD1, 2, 8},
   {MSG_ACCDATA_3, 0, 8},
   {MSG_Lane_Assist_Data1, 0, 8},
   {MSG_LateralMotionControl, 0, 8},

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -112,19 +112,20 @@ class TestFordSafety(common.PandaSafetyTest):
     self.assertFalse(self._tx(self._lkas_command_msg(1)))
 
   def test_acc_buttons(self):
-    for bus in (0, 2):
-      for allowed in (0, 1):
-        self.safety.set_controls_allowed(allowed)
-        for enabled in (True, False):
-          self._rx(self._pcm_status_msg(enabled))
-          self.assertTrue(self._tx(self._acc_button_msg(Buttons.TJA_TOGGLE, bus)))
-
-      for allowed in (0, 1):
-        self.safety.set_controls_allowed(allowed)
-        self.assertEqual(allowed, self._tx(self._acc_button_msg(Buttons.RESUME, bus)))
-
+    for allowed in (0, 1):
+      self.safety.set_controls_allowed(allowed)
       for enabled in (True, False):
         self._rx(self._pcm_status_msg(enabled))
+        self.assertTrue(self._tx(self._acc_button_msg(Buttons.TJA_TOGGLE, 2)))
+
+    for allowed in (0, 1):
+      self.safety.set_controls_allowed(allowed)
+      for bus in (0, 2):
+        self.assertEqual(allowed, self._tx(self._acc_button_msg(Buttons.RESUME, bus)))
+
+    for enabled in (True, False):
+      self._rx(self._pcm_status_msg(enabled))
+      for bus in (0, 2):
         self.assertEqual(enabled, self._tx(self._acc_button_msg(Buttons.CANCEL, bus)))
 
 

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -87,13 +87,13 @@ class TestFordSafety(common.PandaSafetyTest):
     return self.packer.make_can_msg_panda("LateralMotionControl", 0, values)
 
   # Cruise control buttons
-  def _acc_button_msg(self, button: int):
+  def _acc_button_msg(self, button: int, bus: int):
     values = {
       "CcAslButtnCnclPress": 1 if button == Buttons.CANCEL else 0,
       "CcAsllButtnResPress": 1 if button == Buttons.RESUME else 0,
       "TjaButtnOnOffPress": 1 if button == Buttons.TJA_TOGGLE else 0,
     }
-    return self.packer.make_can_msg_panda("Steering_Data_FD1", 0, values)
+    return self.packer.make_can_msg_panda("Steering_Data_FD1", bus, values)
 
   def test_steer_allowed(self):
     self.safety.set_controls_allowed(1)
@@ -112,19 +112,20 @@ class TestFordSafety(common.PandaSafetyTest):
     self.assertFalse(self._tx(self._lkas_command_msg(1)))
 
   def test_acc_buttons(self):
-    for allowed in (0, 1):
-      self.safety.set_controls_allowed(allowed)
+    for bus in (0, 2):
+      for allowed in (0, 1):
+        self.safety.set_controls_allowed(allowed)
+        for enabled in (True, False):
+          self._rx(self._pcm_status_msg(enabled))
+          self.assertTrue(self._tx(self._acc_button_msg(Buttons.TJA_TOGGLE, bus)))
+
+      for allowed in (0, 1):
+        self.safety.set_controls_allowed(allowed)
+        self.assertEqual(allowed, self._tx(self._acc_button_msg(Buttons.RESUME, bus)))
+
       for enabled in (True, False):
         self._rx(self._pcm_status_msg(enabled))
-        self.assertTrue(self._tx(self._acc_button_msg(Buttons.TJA_TOGGLE)))
-
-    for allowed in (0, 1):
-      self.safety.set_controls_allowed(allowed)
-      self.assertEqual(allowed, self._tx(self._acc_button_msg(Buttons.RESUME)))
-
-    for enabled in (True, False):
-      self._rx(self._pcm_status_msg(enabled))
-      self.assertEqual(enabled, self._tx(self._acc_button_msg(Buttons.CANCEL)))
+        self.assertEqual(enabled, self._tx(self._acc_button_msg(Buttons.CANCEL, bus)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The DBC lists both the IPMA and PCM as receiving modules for the `CcAslButtnCnclPress` and `CcAsllButtnResPress` signals used to cancel/resume ACC.

Sending resume to both buses is confirmed to work by three testers, now it's just down to tweaking openpilot to get high reliability.