### PR TITLE
Hyundai: CAN-FD Hybrid gas pressed signal

### DIFF
--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -156,7 +156,7 @@ static int hyundai_canfd_rx_hook(CANPacket_t *to_push) {
     // gas press, different for EV, hybrid, and ICE models
     if ((addr == 0x35) && hyundai_ev_gas_signal) {
       gas_pressed = GET_BYTE(to_push, 5) != 0U;
-    } else if ((addr == 0x105) && !hyundai_ev_gas_signal && !hyundai_hybrid_gas_signal) {
+    } else if ((addr == 0x105) && hyundai_hybrid_gas_signal) {
       gas_pressed = (GET_BIT(to_push, 103U) != 0U) || (GET_BYTE(to_push, 13) != 0U) || (GET_BIT(to_push, 112U) != 0U);
     } else {
     }

--- a/tests/safety/test_hyundai_canfd.py
+++ b/tests/safety/test_hyundai_canfd.py
@@ -81,7 +81,7 @@ class TestHyundaiCanfdHDA1(TestHyundaiCanfdBase):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, 0)
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_HYBRID_GAS)
     self.safety.init_tests()
 
   def _user_gas_msg(self, gas):
@@ -93,7 +93,7 @@ class TestHyundaiCanfdHDA1AltButtons(TestHyundaiCanfdHDA1):
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
     self.safety = libpandasafety_py.libpandasafety
-    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_CANFD_ALT_BUTTONS)
+    self.safety.set_safety_hooks(Panda.SAFETY_HYUNDAI_CANFD, Panda.FLAG_HYUNDAI_HYBRID_GAS | Panda.FLAG_HYUNDAI_CANFD_ALT_BUTTONS)
     self.safety.init_tests()
 
   def _button_msg(self, buttons, main_button=0, bus=1):


### PR DESCRIPTION
`0x105` was found on the 2022 Hyundai Tucson Hybrid as the accelerator pedal signal and not any CAN-FD ICE models at the moment. The recent commits prevent the Tucson Hybrid to use this signal.
* https://github.com/commaai/panda/pull/999

**Prerequisite of**
* https://github.com/commaai/openpilot/pull/26086