### PR TITLE
H7: free up 29120 bytes of RAM

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -53,13 +53,14 @@ void process_can(uint8_t can_number);
 
 #ifdef STM32H7
 __attribute__((section(".ram_d1"))) can_buffer(rx_q, 0x1000)
-__attribute__((section(".ram_d1"))) can_buffer(txgmlan_q, 0x1A0)
+__attribute__((section(".ram_d1"))) can_buffer(tx2_q, 0x1A0)
+__attribute__((section(".ram_d2"))) can_buffer(txgmlan_q, 0x1A0)
 #else
 can_buffer(rx_q, 0x1000)
+can_buffer(tx2_q, 0x1A0)
 can_buffer(txgmlan_q, 0x1A0)
 #endif
 can_buffer(tx1_q, 0x1A0)
-can_buffer(tx2_q, 0x1A0)
 can_buffer(tx3_q, 0x1A0)
 // FIXME:
 // cppcheck-suppress misra-c2012-9.3

--- a/board/stm32h7/stm32h7x5_flash.ld
+++ b/board/stm32h7/stm32h7x5_flash.ld
@@ -152,7 +152,7 @@ SECTIONS
     _edata = .;        /* define a global symbol at data end */
   } >DTCMRAM AT> FLASH
 
-  
+
   /* Uninitialized data section */
   . = ALIGN(4);
   .bss :
@@ -185,6 +185,12 @@ SECTIONS
     . = ALIGN(4);
     *(.ram_d1*)
   } >RAM_D1
+
+  .ram_d2 (NOLOAD) :
+  {
+    . = ALIGN(4);
+    *(.ram_d2*)
+  } >RAM_D2
 
   .ARM.attributes 0 : { *(.ARM.attributes) }
 }


### PR DESCRIPTION
Move txgmlan buffer to bank D2 and tx2 to D1, give us 29120 bytes of free RAM.
F4 still has enough RAM.
(buffers for H7 a lot bigger because of the size of CAN FD msgs)