### PR TITLE
Remove pre-enable state

### DIFF
--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -107,56 +107,54 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
 
   def test_tx_hook_on_pedal_pressed(self):
     for pedal in ['brake', 'gas']:
-      with self.subTest(pedal=pedal):
-        self.safety.set_controls_allowed(1)
-        if pedal == 'brake':
-          # brake_pressed_prev and vehicle_moving
-          self._rx(self._speed_msg(100))
-          self._rx(self._user_brake_msg(1))
-        elif pedal == 'gas':
-          # gas_pressed_prev
-          self._rx(self._user_gas_msg(MAX_GAS))
+      self.safety.set_controls_allowed(1)
+      if pedal == 'brake':
+        # brake_pressed_prev and vehicle_moving
+        self._rx(self._speed_msg(100))
+        self._rx(self._user_brake_msg(1))
+      elif pedal == 'gas':
+        # gas_pressed_prev
+        self._rx(self._user_gas_msg(MAX_GAS))
 
-        self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
-        self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
-        self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
+      self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
+      self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
+      self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
 
-        # reset status
-        self.safety.set_controls_allowed(0)
-        self._tx(self._send_brake_msg(0))
-        self._tx(self._torque_cmd_msg(0))
-        if pedal == 'brake':
-          self._rx(self._speed_msg(0))
-          self._rx(self._user_brake_msg(0))
-        elif pedal == 'gas':
-          self._rx(self._user_gas_msg(0))
+      # reset status
+      self.safety.set_controls_allowed(0)
+      self._tx(self._send_brake_msg(0))
+      self._tx(self._torque_cmd_msg(0))
+      if pedal == 'brake':
+        self._rx(self._speed_msg(0))
+        self._rx(self._user_brake_msg(0))
+      elif pedal == 'gas':
+        self._rx(self._user_gas_msg(0))
 
   def test_tx_hook_on_pedal_pressed_on_alternative_gas_experience(self):
     for pedal in ['brake', 'gas']:
-      with self.subTest(pedal=pedal):
-        self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS)
-        self.safety.set_controls_allowed(1)
-        if pedal == 'brake':
-          # brake_pressed_prev and vehicle_moving
-          self._rx(self._speed_msg(100))
-          self._rx(self._user_brake_msg(1))
-          allow_ctrl = False
-        elif pedal == 'gas':
-          # gas_pressed_prev
-          self._rx(self._user_gas_msg(MAX_GAS))
-          allow_ctrl = True
+      self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS)
+      self.safety.set_controls_allowed(1)
+      if pedal == 'brake':
+        # brake_pressed_prev and vehicle_moving
+        self._rx(self._speed_msg(100))
+        self._rx(self._user_brake_msg(1))
+        allow_ctrl = False
+      elif pedal == 'gas':
+        # gas_pressed_prev
+        self._rx(self._user_gas_msg(MAX_GAS))
+        allow_ctrl = True
 
-        # Test we allow lateral on gas press, but never longitudinal
-        self.assertEqual(allow_ctrl, self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
-        self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
-        self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
+      # Test we allow lateral on gas press, but never longitudinal
+      self.assertEqual(allow_ctrl, self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
+      self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
+      self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
 
-        # reset status
-        if pedal == 'brake':
-          self._rx(self._speed_msg(0))
-          self._rx(self._user_brake_msg(0))
-        elif pedal == 'gas':
-          self._rx(self._user_gas_msg(0))
+      # reset status
+      if pedal == 'brake':
+        self._rx(self._speed_msg(0))
+        self._rx(self._user_brake_msg(0))
+      elif pedal == 'gas':
+        self._rx(self._user_gas_msg(0))
 
 
 class TestGmAscmSafety(TestGmSafetyBase):

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 from panda import Panda
 from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import CANPackerPanda
 
 MAX_BRAKE = 400
 MAX_GAS = 3072

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -107,54 +107,56 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
 
   def test_tx_hook_on_pedal_pressed(self):
     for pedal in ['brake', 'gas']:
-      if pedal == 'brake':
-        # brake_pressed_prev and vehicle_moving
-        self._rx(self._speed_msg(100))
-        self._rx(self._user_brake_msg(1))
-      elif pedal == 'gas':
-        # gas_pressed_prev
-        self._rx(self._user_gas_msg(MAX_GAS))
+      with self.subTest(pedal=pedal):
+        self.safety.set_controls_allowed(1)
+        if pedal == 'brake':
+          # brake_pressed_prev and vehicle_moving
+          self._rx(self._speed_msg(100))
+          self._rx(self._user_brake_msg(1))
+        elif pedal == 'gas':
+          # gas_pressed_prev
+          self._rx(self._user_gas_msg(MAX_GAS))
 
-      self.safety.set_controls_allowed(1)
-      self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
-      self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
-      self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
+        self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
+        self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
+        self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
 
-      # reset status
-      self.safety.set_controls_allowed(0)
-      self._tx(self._send_brake_msg(0))
-      self._tx(self._torque_cmd_msg(0))
-      if pedal == 'brake':
-        self._rx(self._speed_msg(0))
-        self._rx(self._user_brake_msg(0))
-      elif pedal == 'gas':
-        self._rx(self._user_gas_msg(0))
+        # reset status
+        self.safety.set_controls_allowed(0)
+        self._tx(self._send_brake_msg(0))
+        self._tx(self._torque_cmd_msg(0))
+        if pedal == 'brake':
+          self._rx(self._speed_msg(0))
+          self._rx(self._user_brake_msg(0))
+        elif pedal == 'gas':
+          self._rx(self._user_gas_msg(0))
 
   def test_tx_hook_on_pedal_pressed_on_alternative_gas_experience(self):
     for pedal in ['brake', 'gas']:
-      self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS)
-      if pedal == 'brake':
-        # brake_pressed_prev and vehicle_moving
-        self._rx(self._speed_msg(100))
-        self._rx(self._user_brake_msg(1))
-        allow_ctrl = False
-      elif pedal == 'gas':
-        # gas_pressed_prev
-        self._rx(self._user_gas_msg(MAX_GAS))
-        allow_ctrl = True
+      with self.subTest(pedal=pedal):
+        self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS)
+        self.safety.set_controls_allowed(1)
+        if pedal == 'brake':
+          # brake_pressed_prev and vehicle_moving
+          self._rx(self._speed_msg(100))
+          self._rx(self._user_brake_msg(1))
+          allow_ctrl = False
+        elif pedal == 'gas':
+          # gas_pressed_prev
+          self._rx(self._user_gas_msg(MAX_GAS))
+          allow_ctrl = True
 
-      # Test we allow lateral on gas press, but never longitudinal
-      self.safety.set_controls_allowed(1)
-      self.assertEqual(allow_ctrl, self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
-      self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
-      self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
+        # Test we allow lateral on gas press, but never longitudinal
+        self.assertEqual(allow_ctrl, self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
+        self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
+        self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
 
-      # reset status
-      if pedal == 'brake':
-        self._rx(self._speed_msg(0))
-        self._rx(self._user_brake_msg(0))
-      elif pedal == 'gas':
-        self._rx(self._user_gas_msg(0))
+        # reset status
+        if pedal == 'brake':
+          self._rx(self._speed_msg(0))
+          self._rx(self._user_brake_msg(0))
+        elif pedal == 'gas':
+          self._rx(self._user_gas_msg(0))
 
 
 class TestGmAscmSafety(TestGmSafetyBase):

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -105,57 +105,6 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
                       (not enabled and gas_regen == INACTIVE_REGEN)) and not stock_longitudinal)
         self.assertEqual(should_tx, self._tx(self._send_gas_msg(gas_regen)), (enabled, gas_regen))
 
-  def test_tx_hook_on_pedal_pressed(self):
-    for pedal in ['brake', 'gas']:
-      self.safety.set_controls_allowed(1)
-      if pedal == 'brake':
-        # brake_pressed_prev and vehicle_moving
-        self._rx(self._speed_msg(100))
-        self._rx(self._user_brake_msg(1))
-      elif pedal == 'gas':
-        # gas_pressed_prev
-        self._rx(self._user_gas_msg(MAX_GAS))
-
-      self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
-      self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
-      self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
-
-      # reset status
-      self.safety.set_controls_allowed(0)
-      self._tx(self._send_brake_msg(0))
-      self._tx(self._torque_cmd_msg(0))
-      if pedal == 'brake':
-        self._rx(self._speed_msg(0))
-        self._rx(self._user_brake_msg(0))
-      elif pedal == 'gas':
-        self._rx(self._user_gas_msg(0))
-
-  def test_tx_hook_on_pedal_pressed_on_alternative_gas_experience(self):
-    for pedal in ['brake', 'gas']:
-      self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS)
-      self.safety.set_controls_allowed(1)
-      if pedal == 'brake':
-        # brake_pressed_prev and vehicle_moving
-        self._rx(self._speed_msg(100))
-        self._rx(self._user_brake_msg(1))
-        allow_ctrl = False
-      elif pedal == 'gas':
-        # gas_pressed_prev
-        self._rx(self._user_gas_msg(MAX_GAS))
-        allow_ctrl = True
-
-      # Test we allow lateral on gas press, but never longitudinal
-      self.assertEqual(allow_ctrl, self._tx(self._torque_cmd_msg(self.MAX_RATE_UP)))
-      self.assertFalse(self._tx(self._send_brake_msg(MAX_BRAKE)))
-      self.assertFalse(self._tx(self._send_gas_msg(MAX_GAS)))
-
-      # reset status
-      if pedal == 'brake':
-        self._rx(self._speed_msg(0))
-        self._rx(self._user_brake_msg(0))
-      elif pedal == 'gas':
-        self._rx(self._user_gas_msg(0))
-
 
 class TestGmAscmSafety(TestGmSafetyBase):
   TX_MSGS = [[384, 0], [1033, 0], [1034, 0], [715, 0], [880, 0],  # pt bus

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -138,40 +138,6 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
     self._rx(self._button_msg(Btn.SET, main_on=True))
     self.assertTrue(self.safety.get_controls_allowed())
 
-  def test_tx_hook_on_pedal_pressed(self):
-    for mode in [ALTERNATIVE_EXPERIENCE.DEFAULT, ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS]:
-      for pedal in ['brake', 'gas']:
-        self.safety.set_alternative_experience(mode)
-        self.safety.set_controls_allowed(1)
-
-        allow_ctrl = False
-        if pedal == 'brake':
-          # brake_pressed_prev and vehicle_moving
-          self._rx(self._speed_msg(100))
-          self._rx(self._user_brake_msg(1))
-        elif pedal == 'gas':
-          # gas_pressed_prev
-          self._rx(self._user_gas_msg(1))
-          allow_ctrl = mode == ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS
-
-        hw = self.safety.get_honda_hw()
-        if hw == HONDA_NIDEC:
-          self.safety.set_honda_fwd_brake(False)
-          self.assertEqual(allow_ctrl, self._tx(self._send_brake_msg(self.MAX_BRAKE)))
-        self.assertEqual(allow_ctrl, self._tx(self._send_steer_msg(0x1000)))
-
-        # reset status
-        self.safety.set_controls_allowed(0)
-        self.safety.set_alternative_experience(ALTERNATIVE_EXPERIENCE.DEFAULT)
-        if hw == HONDA_NIDEC:
-          self._tx(self._send_brake_msg(0))
-        self._tx(self._send_steer_msg(0))
-        if pedal == 'brake':
-          self._rx(self._speed_msg(0))
-          self._rx(self._user_brake_msg(0))
-        elif pedal == 'gas':
-          self._rx(self._user_gas_msg(0))
-
 
 class HondaPcmEnableBase(common.PandaSafetyTest):
   # pylint: disable=no-member,abstract-method
@@ -362,22 +328,6 @@ class TestHondaNidecSafetyBase(HondaBase):
             send = brake == 0
           self.assertEqual(send, self._tx(self._send_brake_msg(brake)))
     self.safety.set_honda_fwd_brake(False)
-
-  def test_tx_hook_on_interceptor_pressed(self):
-    for mode in [ALTERNATIVE_EXPERIENCE.DEFAULT, ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS]:
-      self.safety.set_controls_allowed(1)
-      self.safety.set_alternative_experience(mode)
-      # gas_interceptor_prev > INTERCEPTOR_THRESHOLD
-      self._rx(self._interceptor_user_gas(self.INTERCEPTOR_THRESHOLD + 1))
-      self._rx(self._interceptor_user_gas(self.INTERCEPTOR_THRESHOLD + 1))
-      allow_ctrl = mode == ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS
-
-      self.safety.set_honda_fwd_brake(False)
-
-      # Test we allow lateral, but never longitudinal
-      self.assertFalse(self._tx(self._interceptor_gas_cmd(self.INTERCEPTOR_THRESHOLD)))
-      self.assertFalse(self._tx(self._send_brake_msg(self.MAX_BRAKE)))
-      self.assertEqual(allow_ctrl, self._tx(self._send_steer_msg(0x1000)))
 
 
 class TestHondaNidecSafety(HondaPcmEnableBase, TestHondaNidecSafetyBase):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -142,6 +142,8 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
     for mode in [ALTERNATIVE_EXPERIENCE.DEFAULT, ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS]:
       for pedal in ['brake', 'gas']:
         self.safety.set_alternative_experience(mode)
+        self.safety.set_controls_allowed(1)
+
         allow_ctrl = False
         if pedal == 'brake':
           # brake_pressed_prev and vehicle_moving
@@ -152,7 +154,6 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
           self._rx(self._user_gas_msg(1))
           allow_ctrl = mode == ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS
 
-        self.safety.set_controls_allowed(1)
         hw = self.safety.get_honda_hw()
         if hw == HONDA_NIDEC:
           self.safety.set_honda_fwd_brake(False)
@@ -364,13 +365,13 @@ class TestHondaNidecSafetyBase(HondaBase):
 
   def test_tx_hook_on_interceptor_pressed(self):
     for mode in [ALTERNATIVE_EXPERIENCE.DEFAULT, ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS]:
+      self.safety.set_controls_allowed(1)
       self.safety.set_alternative_experience(mode)
       # gas_interceptor_prev > INTERCEPTOR_THRESHOLD
       self._rx(self._interceptor_user_gas(self.INTERCEPTOR_THRESHOLD + 1))
       self._rx(self._interceptor_user_gas(self.INTERCEPTOR_THRESHOLD + 1))
       allow_ctrl = mode == ALTERNATIVE_EXPERIENCE.DISABLE_DISENGAGE_ON_GAS
 
-      self.safety.set_controls_allowed(1)
       self.safety.set_honda_fwd_brake(False)
 
       # Test we allow lateral, but never longitudinal

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -6,7 +6,7 @@ from typing import Optional
 from panda import Panda
 from panda.tests.safety import libpandasafety_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS, ALTERNATIVE_EXPERIENCE
+from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS
 
 class Btn:
   NONE = 0


### PR DESCRIPTION
current_controls_allowed used to ensure:
- After enabling with gas pressed and disable on gas:
  - we don't steer until gas is released (now allowed)
  - we don't actuate long until gas is released (replaced with `longitudinal_allowed`)
- That we don't actuate anything with brake pressed and moving, which is an impossible situation (generic_rx_checks does this)