### PR TITLE
bugfix: D2 SRAM clocks and CRun CPU state

### DIFF
--- a/board/stm32h7/clock.h
+++ b/board/stm32h7/clock.h
@@ -52,4 +52,8 @@ void clock_init(void) {
   register_set_bits(&(RCC->CR), RCC_CR_CSSHSEON);
   //Enable Vdd33usb supply level detector
   register_set_bits(&(PWR->CR3), PWR_CR3_USB33DEN);
+
+  // Enable CPU access to SRAM1 and SRAM2 (in domain D2)
+  register_set_bits(&(RCC->AHB2ENR), RCC_AHB2ENR_SRAM1EN);
+  register_set_bits(&(RCC->AHB2ENR), RCC_AHB2ENR_SRAM2EN);
 }

--- a/board/stm32h7/stm32h7x5_flash.ld
+++ b/board/stm32h7/stm32h7x5_flash.ld
@@ -64,10 +64,10 @@ _Min_Stack_Size = 0x400; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-DTCMRAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
-RAM_D1 (xrw)      : ORIGIN = 0x24000000, LENGTH = 320K
-RAM_D2 (xrw)      : ORIGIN = 0x30000000, LENGTH = 32K
-RAM_D3 (xrw)      : ORIGIN = 0x38000000, LENGTH = 16K
+DTCMRAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K /* DTCM */
+RAM_D1 (xrw)      : ORIGIN = 0x24000000, LENGTH = 320K /* AXI SRAM */
+RAM_D2 (xrw)      : ORIGIN = 0x30000000, LENGTH = 32K /* SRAM1(16kb) + SRAM2(16kb) */
+RAM_D3 (xrw)      : ORIGIN = 0x38000000, LENGTH = 16K /* SRAM4 */
 ITCMRAM (xrw)      : ORIGIN = 0x00000000, LENGTH = 64K
 FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 1024K
 }


### PR DESCRIPTION
Need to explicitly enable clocks for SRAM1 and SRAM2 (in domain D2) so ram won't be lost in sleep state.