### PR TITLE
safety: fix regen controls mismatch

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -253,9 +253,9 @@ void generic_rx_checks(bool stock_ecu_detected) {
 
   // exit controls on rising edge of brake press or regen paddle
   // match openpilot's behavior, or the signals
-  bool global_brake_pressed = brake_pressed || regen_braking;
-  bool global_brake_pressed_prev = brake_pressed_prev || regen_braking_prev;
-  if (global_brake_pressed && (!global_brake_pressed_prev || vehicle_moving)) {
+  bool current_brake_pressed = brake_pressed || regen_braking;
+  bool current_brake_pressed_prev = brake_pressed_prev || regen_braking_prev;
+  if (current_brake_pressed && (!current_brake_pressed_prev || vehicle_moving)) {
     controls_allowed = 0;
   }
   brake_pressed_prev = brake_pressed;

--- a/board/safety.h
+++ b/board/safety.h
@@ -251,16 +251,14 @@ void generic_rx_checks(bool stock_ecu_detected) {
   }
   gas_pressed_prev = gas_pressed;
 
-  // exit controls on rising edge of brake press
-  if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
+  // exit controls on rising edge of brake press or regen paddle
+  // match openpilot's behavior, or the signals
+  bool current_brake_pressed = brake_pressed || regen_braking;
+  bool current_brake_pressed_prev = brake_pressed_prev || regen_braking_prev;
+  if (current_brake_pressed && (!current_brake_pressed_prev || vehicle_moving)) {
     controls_allowed = 0;
   }
   brake_pressed_prev = brake_pressed;
-
-  // exit controls on rising edge of regen paddle
-  if (regen_braking && (!regen_braking_prev || vehicle_moving)) {
-    controls_allowed = 0;
-  }
   regen_braking_prev = regen_braking;
 
   // check if stock ECU is on bus broken by car harness

--- a/board/safety.h
+++ b/board/safety.h
@@ -253,9 +253,9 @@ void generic_rx_checks(bool stock_ecu_detected) {
 
   // exit controls on rising edge of brake press or regen paddle
   // match openpilot's behavior, or the signals
-  bool current_brake_pressed = brake_pressed || regen_braking;
-  bool current_brake_pressed_prev = brake_pressed_prev || regen_braking_prev;
-  if (current_brake_pressed && (!current_brake_pressed_prev || vehicle_moving)) {
+  bool global_brake_pressed = brake_pressed || regen_braking;
+  bool global_brake_pressed_prev = brake_pressed_prev || regen_braking_prev;
+  if (global_brake_pressed && (!global_brake_pressed_prev || vehicle_moving)) {
     controls_allowed = 0;
   }
   brake_pressed_prev = brake_pressed;


### PR DESCRIPTION
How to reproduce:

1. Come to stop, press brake, engage.
2. With foot on brake, depress regen paddle.

To openpilot, brakePressed does not change. To panda, it independently checks the rising edges of the two signals.