### PR TITLE
Hyundai: fix button enable controls mismatch

### DIFF
--- a/board/safety/safety_hyundai_common.h
+++ b/board/safety/safety_hyundai_common.h
@@ -63,16 +63,16 @@ void hyundai_common_cruise_buttons_check(const int cruise_button, const int main
   }
 
   if (hyundai_longitudinal) {
+    // enter controls on falling edge of resume or set
+    bool set = (cruise_button != HYUNDAI_BTN_SET) && (cruise_button_prev == HYUNDAI_BTN_SET);
+    bool res = (cruise_button != HYUNDAI_BTN_RESUME) && (cruise_button_prev == HYUNDAI_BTN_RESUME);
+    if (set || res) {
+      controls_allowed = 1;
+    }
+
     // exit controls on cancel press
     if (cruise_button == HYUNDAI_BTN_CANCEL) {
       controls_allowed = 0;
-    }
-
-    // enter controls on falling edge of resume or set
-    bool set = (cruise_button == HYUNDAI_BTN_NONE) && (cruise_button_prev == HYUNDAI_BTN_SET);
-    bool res = (cruise_button == HYUNDAI_BTN_NONE) && (cruise_button_prev == HYUNDAI_BTN_RESUME);
-    if (set || res) {
-      controls_allowed = 1;
     }
 
     cruise_button_prev = cruise_button;

--- a/tests/safety/hyundai_common.py
+++ b/tests/safety/hyundai_common.py
@@ -115,6 +115,7 @@ class HyundaiLongitudinalBase:
           self._rx(self._button_msg(btn_prev))
           self.assertFalse(self.safety.get_controls_allowed())
 
+        # should enter controls allowed on falling edge and not transitioning to cancel
         should_enable = btn_cur != btn_prev and \
                         btn_cur != Buttons.CANCEL and \
                         btn_prev in (Buttons.RESUME, Buttons.SET)

--- a/tests/safety/hyundai_common.py
+++ b/tests/safety/hyundai_common.py
@@ -107,16 +107,20 @@ class HyundaiLongitudinalBase:
     """
       SET and RESUME enter controls allowed on their falling edge.
     """
-    for btn in range(8):
-      self.safety.set_controls_allowed(0)
-      for _ in range(10):
-        self._rx(self._button_msg(btn))
-        self.assertFalse(self.safety.get_controls_allowed())
-
-      # should enter controls allowed on falling edge
-      if btn in (Buttons.RESUME, Buttons.SET):
+    for btn_prev in range(8):
+      for btn_cur in range(8):
         self._rx(self._button_msg(Buttons.NONE))
-        self.assertTrue(self.safety.get_controls_allowed())
+        self.safety.set_controls_allowed(0)
+        for _ in range(10):
+          self._rx(self._button_msg(btn_prev))
+          self.assertFalse(self.safety.get_controls_allowed())
+
+        should_enable = btn_cur != btn_prev and \
+                        btn_cur != Buttons.CANCEL and \
+                        btn_prev in (Buttons.RESUME, Buttons.SET)
+
+        self._rx(self._button_msg(btn_cur))
+        self.assertEqual(should_enable, self.safety.get_controls_allowed())
 
   def test_cancel_button(self):
     self.safety.set_controls_allowed(1)


### PR DESCRIPTION
With Hyundai, you can go from set to resume, or vice-versa, without first going to none/unpressed. openpilot treats this is as a falling edge of set of resume and enables, but panda doesn't since it requires going to none/unpressed.