### PR TITLE
GM: handle run-away set speed

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -105,16 +105,16 @@ static int gm_rx_hook(CANPacket_t *to_push) {
     if ((addr == 481) && !gm_pcm_cruise) {
       int button = (GET_BYTE(to_push, 5) & 0x70U) >> 4;
 
+      // enter controls on falling edge of set or resume
+      bool set = (button != GM_BTN_SET) && (cruise_button_prev == GM_BTN_SET);
+      bool res = (button != GM_BTN_RESUME) && (cruise_button_prev == GM_BTN_RESUME);
+      if (set || res) {
+        controls_allowed = 1;
+      }
+
       // exit controls on cancel press
       if (button == GM_BTN_CANCEL) {
         controls_allowed = 0;
-      }
-
-      // enter controls on falling edge of set or resume
-      bool set = (button == GM_BTN_UNPRESS) && (cruise_button_prev == GM_BTN_SET);
-      bool res = (button == GM_BTN_UNPRESS) && (cruise_button_prev == GM_BTN_RESUME);
-      if (set || res) {
-        controls_allowed = 1;
       }
 
       cruise_button_prev = button;

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -110,9 +110,9 @@ static int gm_rx_hook(CANPacket_t *to_push) {
         controls_allowed = 0;
       }
 
-      // enter controls on falling edge of set or rising edge of resume (avoids fault)
+      // enter controls on falling edge of set or resume
       bool set = (button == GM_BTN_UNPRESS) && (cruise_button_prev == GM_BTN_SET);
-      bool res = (button == GM_BTN_RESUME) && (cruise_button_prev == GM_BTN_UNPRESS);
+      bool res = (button == GM_BTN_UNPRESS) && (cruise_button_prev == GM_BTN_RESUME);
       if (set || res) {
         controls_allowed = 1;
       }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -107,7 +107,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 
       // enter controls on falling edge of set or resume
       bool set = (button != GM_BTN_SET) && (cruise_button_prev == GM_BTN_SET);
-      bool res = (button != GM_BTN_RESUME) && (cruise_button_prev == GM_BTN_RESUME);
+      bool res = (button == GM_BTN_RESUME) && (cruise_button_prev != GM_BTN_RESUME);
       if (set || res) {
         controls_allowed = 1;
       }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -107,7 +107,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 
       // enter controls on falling edge of set or resume
       bool set = (button != GM_BTN_SET) && (cruise_button_prev == GM_BTN_SET);
-      bool res = (button == GM_BTN_RESUME) && (cruise_button_prev != GM_BTN_RESUME);
+      bool res = (button != GM_BTN_RESUME) && (cruise_button_prev == GM_BTN_RESUME);
       if (set || res) {
         controls_allowed = 1;
       }

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -23,16 +23,21 @@ class GmLongitudinalBase(common.PandaSafetyTest):
     """
       SET and RESUME enter controls allowed on their falling edge.
     """
-    for btn in range(8):
-      self.safety.set_controls_allowed(0)
-      for _ in range(10):
-        self._rx(self._button_msg(btn))
-        self.assertFalse(self.safety.get_controls_allowed())
-
-      # should enter controls allowed on falling edge
-      if btn in (Buttons.RES_ACCEL, Buttons.DECEL_SET):
+    for btn_prev in range(8):
+      for btn_cur in range(8):
         self._rx(self._button_msg(Buttons.UNPRESS))
-        self.assertTrue(self.safety.get_controls_allowed())
+        self.safety.set_controls_allowed(0)
+        for _ in range(10):
+          self._rx(self._button_msg(btn_prev))
+          self.assertFalse(self.safety.get_controls_allowed())
+
+        # should enter controls allowed on falling edge and not transitioning to cancel
+        should_enable = btn_cur != btn_prev and \
+                        btn_cur != Buttons.CANCEL and \
+                        btn_prev in (Buttons.RES_ACCEL, Buttons.DECEL_SET)
+
+        self._rx(self._button_msg(btn_cur))
+        self.assertEqual(should_enable, self.safety.get_controls_allowed())
 
   def test_cancel_button(self):
     self.safety.set_controls_allowed(1)

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -21,16 +21,15 @@ class GmLongitudinalBase(common.PandaSafetyTest):
 
   def test_set_resume_buttons(self):
     """
-      SET and RESUME enter controls allowed on their falling and rising edges, respectively.
+      SET and RESUME enter controls allowed on their falling edge.
     """
     for btn in range(8):
       self.safety.set_controls_allowed(0)
       for _ in range(10):
         self._rx(self._button_msg(btn))
-        should_enable = btn == Buttons.RES_ACCEL
-        self.assertEqual(should_enable, self.safety.get_controls_allowed())
+        self.assertFalse(self.safety.get_controls_allowed())
 
-      # set should enter controls allowed on falling edge, resume should maintain controls allowed
+      # should enter controls allowed on falling edge
       if btn in (Buttons.RES_ACCEL, Buttons.DECEL_SET):
         self._rx(self._button_msg(Buttons.UNPRESS))
         self.assertTrue(self.safety.get_controls_allowed())

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -25,7 +25,7 @@ class GmLongitudinalBase(common.PandaSafetyTest):
     """
     for btn_prev in range(8):
       for btn_cur in range(8):
-        self._rx(self._button_msg(Buttons.NONE))
+        self._rx(self._button_msg(Buttons.UNPRESS))
         self.safety.set_controls_allowed(0)
         for _ in range(10):
           self._rx(self._button_msg(btn_prev))
@@ -34,7 +34,7 @@ class GmLongitudinalBase(common.PandaSafetyTest):
         # should enter controls allowed on falling edge and not transitioning to cancel
         should_enable = btn_cur != btn_prev and \
                         btn_cur != Buttons.CANCEL and \
-                        btn_prev in (Buttons.RESUME, Buttons.SET)
+                        btn_prev in (Buttons.RES_ACCEL, Buttons.DECEL_SET)
 
         self._rx(self._button_msg(btn_cur))
         self.assertEqual(should_enable, self.safety.get_controls_allowed())


### PR DESCRIPTION
if we handle the buttons correctly and add multiple button presses per transition, openpilot will attempt to enable while controls_allowed stays low. This allows any transition to occur like openpilot (RES to SET for example)

for openpilot PR: https://github.com/commaai/openpilot/pull/26480/