### PR TITLE
Remove external debug UART support

### DIFF
--- a/board/bootstub.c
+++ b/board/bootstub.c
@@ -39,7 +39,6 @@ int main(void) {
 
   disable_interrupts();
   clock_init();
-  detect_external_debug_serial();
   detect_board_type();
 
   if (enter_bootloader_mode == ENTER_SOFTLOADER_MAGIC) {

--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -150,14 +150,8 @@ void clear_uart_buff(uart_ring *q) {
 
 // ************************ High-level debug functions **********************
 void putch(const char a) {
-  if (has_external_debug_serial) {
-    // assuming debugging is important if there's external serial connected
-    while (!putc(&uart_ring_debug, a));
-
-  } else {
-    // misra-c2012-17.7: serial debug function, ok to ignore output
-    (void)injectc(&uart_ring_debug, a);
-  }
+  // misra-c2012-17.7: serial debug function, ok to ignore output
+  (void)injectc(&uart_ring_debug, a);
 }
 
 void puts(const char *a) {

--- a/board/early_init.h
+++ b/board/early_init.h
@@ -48,7 +48,6 @@ void early_initialization(void) {
   // early GPIOs float everything
   early_gpio_float();
 
-  detect_external_debug_serial();
   detect_board_type();
 
   if (enter_bootloader_mode == ENTER_BOOTLOADER_MAGIC) {

--- a/board/main.c
+++ b/board/main.c
@@ -312,7 +312,6 @@ int main(void) {
   // init early devices
   clock_init();
   peripherals_init();
-  detect_external_debug_serial();
   detect_board_type();
   adc_init();
 
@@ -327,20 +326,12 @@ int main(void) {
 
   puts("Config:\n");
   puts("  Board type: "); puts(current_board->board_type); puts("\n");
-  puts(has_external_debug_serial ? "  Real serial\n" : "  USB serial\n");
 
   // init board
   current_board->init();
 
   // panda has an FPU, let's use it!
   enable_fpu();
-
-  // enable main uart if it's connected
-  if (has_external_debug_serial) {
-    // WEIRDNESS: without this gate around the UART, it would "crash", but only if the ESP is enabled
-    // assuming it's because the lines were left floating and spurious noise was on them
-    uart_init(&uart_ring_debug, 115200);
-  }
 
   if (current_board->has_gps) {
     uart_init(&uart_ring_gps, 9600);

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -275,7 +275,6 @@ int main(void) {
   // init devices
   clock_init();
   peripherals_init();
-  detect_external_debug_serial();
   detect_board_type();
 
   // init board

--- a/board/stm32fx/board.h
+++ b/board/stm32fx/board.h
@@ -52,10 +52,3 @@ void detect_board_type(void) {
     #endif
   #endif
 }
-
-bool has_external_debug_serial = 0;
-
-void detect_external_debug_serial(void) {
-  // detect if external serial debugging is present
-  has_external_debug_serial = detect_with_pull(GPIOA, 3, PULL_DOWN);
-}

--- a/board/stm32h7/board.h
+++ b/board/stm32h7/board.h
@@ -40,9 +40,3 @@ void detect_board_type(void) {
     puts("Hardware type is UNKNOWN!\n");
   }
 }
-
-bool has_external_debug_serial = 0;
-void detect_external_debug_serial(void) {
-  // detect if external serial debugging is present
-  has_external_debug_serial = detect_with_pull(GPIOA, 3, PULL_DOWN) || detect_with_pull(GPIOE, 7, PULL_DOWN);
-}


### PR DESCRIPTION
Afaik this isn't in use anymore, and if the check fails the panda hangs without a decent way to debug.