### PR TITLE
rename puts to avoid conflict with stdio.h

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -17,7 +17,7 @@ void black_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
@@ -74,7 +74,7 @@ void black_set_gps_mode(uint8_t mode) {
       set_gpio_output(GPIOC, 5, 0);
       break;
     default:
-      putstr("Invalid GPS mode\n");
+      print("Invalid GPS mode\n");
       break;
   }
 }
@@ -102,7 +102,7 @@ void black_set_can_mode(uint8_t mode){
       }
       break;
     default:
-      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
+      print("Tried to set unsupported CAN mode: "); puth(mode); print("\n");
       break;
   }
 }

--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -17,7 +17,7 @@ void black_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      puts("Invalid CAN transceiver ("); puth(transceiver); puts("): enabling failed\n");
+      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
       break;
   }
 }
@@ -74,7 +74,7 @@ void black_set_gps_mode(uint8_t mode) {
       set_gpio_output(GPIOC, 5, 0);
       break;
     default:
-      puts("Invalid GPS mode\n");
+      putstr("Invalid GPS mode\n");
       break;
   }
 }
@@ -102,7 +102,7 @@ void black_set_can_mode(uint8_t mode){
       }
       break;
     default:
-      puts("Tried to set unsupported CAN mode: "); puth(mode); puts("\n");
+      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
       break;
   }
 }

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -17,7 +17,7 @@ void dos_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
@@ -88,7 +88,7 @@ void dos_set_can_mode(uint8_t mode){
       }
       break;
     default:
-      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
+      print("Tried to set unsupported CAN mode: "); puth(mode); print("\n");
       break;
   }
 }

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -17,7 +17,7 @@ void dos_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      puts("Invalid CAN transceiver ("); puth(transceiver); puts("): enabling failed\n");
+      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
       break;
   }
 }
@@ -88,7 +88,7 @@ void dos_set_can_mode(uint8_t mode){
       }
       break;
     default:
-      puts("Tried to set unsupported CAN mode: "); puth(mode); puts("\n");
+      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
       break;
   }
 }

--- a/board/boards/grey.h
+++ b/board/boards/grey.h
@@ -28,7 +28,7 @@ void grey_set_gps_mode(uint8_t mode) {
       set_gpio_output(GPIOC, 5, 0);
       break;
     default:
-      putstr("Invalid ESP/GPS mode\n");
+      print("Invalid ESP/GPS mode\n");
       break;
   }
 }

--- a/board/boards/grey.h
+++ b/board/boards/grey.h
@@ -28,7 +28,7 @@ void grey_set_gps_mode(uint8_t mode) {
       set_gpio_output(GPIOC, 5, 0);
       break;
     default:
-      puts("Invalid ESP/GPS mode\n");
+      putstr("Invalid ESP/GPS mode\n");
       break;
   }
 }

--- a/board/boards/pedal.h
+++ b/board/boards/pedal.h
@@ -8,7 +8,7 @@ void pedal_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 3, !enabled);
       break;
     default:
-      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
@@ -32,7 +32,7 @@ void pedal_set_led(uint8_t color, bool enabled) {
 
 void pedal_set_gps_mode(uint8_t mode) {
   UNUSED(mode);
-  putstr("Trying to set ESP/GPS mode on pedal. This is not supported.\n");
+  print("Trying to set ESP/GPS mode on pedal. This is not supported.\n");
 }
 
 void pedal_set_can_mode(uint8_t mode){
@@ -40,7 +40,7 @@ void pedal_set_can_mode(uint8_t mode){
     case CAN_MODE_NORMAL:
       break;
     default:
-      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
+      print("Tried to set unsupported CAN mode: "); puth(mode); print("\n");
       break;
   }
 }

--- a/board/boards/pedal.h
+++ b/board/boards/pedal.h
@@ -8,7 +8,7 @@ void pedal_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 3, !enabled);
       break;
     default:
-      puts("Invalid CAN transceiver ("); puth(transceiver); puts("): enabling failed\n");
+      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
       break;
   }
 }
@@ -32,7 +32,7 @@ void pedal_set_led(uint8_t color, bool enabled) {
 
 void pedal_set_gps_mode(uint8_t mode) {
   UNUSED(mode);
-  puts("Trying to set ESP/GPS mode on pedal. This is not supported.\n");
+  putstr("Trying to set ESP/GPS mode on pedal. This is not supported.\n");
 }
 
 void pedal_set_can_mode(uint8_t mode){
@@ -40,7 +40,7 @@ void pedal_set_can_mode(uint8_t mode){
     case CAN_MODE_NORMAL:
       break;
     default:
-      puts("Tried to set unsupported CAN mode: "); puth(mode); puts("\n");
+      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
       break;
   }
 }

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -19,7 +19,7 @@ void uno_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      puts("Invalid CAN transceiver ("); puth(transceiver); puts("): enabling failed\n");
+      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
       break;
   }
 }
@@ -93,7 +93,7 @@ void uno_set_gps_mode(uint8_t mode) {
       uno_set_gps_load_switch(true);
       break;
     default:
-      puts("Invalid ESP/GPS mode\n");
+      putstr("Invalid ESP/GPS mode\n");
       break;
   }
 }
@@ -121,7 +121,7 @@ void uno_set_can_mode(uint8_t mode){
       }
       break;
     default:
-      puts("Tried to set unsupported CAN mode: "); puth(mode); puts("\n");
+      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
       break;
   }
 }

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -19,7 +19,7 @@ void uno_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOB, 10, !enabled);
       break;
     default:
-      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
@@ -93,7 +93,7 @@ void uno_set_gps_mode(uint8_t mode) {
       uno_set_gps_load_switch(true);
       break;
     default:
-      putstr("Invalid ESP/GPS mode\n");
+      print("Invalid ESP/GPS mode\n");
       break;
   }
 }
@@ -121,7 +121,7 @@ void uno_set_can_mode(uint8_t mode){
       }
       break;
     default:
-      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
+      print("Tried to set unsupported CAN mode: "); puth(mode); print("\n");
       break;
   }
 }

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -14,7 +14,7 @@ void white_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOA, 0, !enabled);
       break;
     default:
-      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
+      print("Invalid CAN transceiver ("); puth(transceiver); print("): enabling failed\n");
       break;
   }
 }
@@ -60,7 +60,7 @@ void white_set_usb_power_mode(uint8_t mode){
       set_gpio_output(GPIOA, 13, 0);
       break;
     default:
-      putstr("Invalid usb power mode\n");
+      print("Invalid usb power mode\n");
       break;
   }
 }
@@ -77,7 +77,7 @@ void white_set_gps_mode(uint8_t mode) {
       set_gpio_output(GPIOC, 5, 0);
       break;
     default:
-      putstr("Invalid ESP/GPS mode\n");
+      print("Invalid ESP/GPS mode\n");
       break;
   }
 }
@@ -136,7 +136,7 @@ void white_set_can_mode(uint8_t mode){
       set_gpio_alternate(GPIOB, 6, GPIO_AF9_CAN2);
       break;
     default:
-      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
+      print("Tried to set unsupported CAN mode: "); puth(mode); print("\n");
       break;
   }
 }

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -14,7 +14,7 @@ void white_enable_can_transceiver(uint8_t transceiver, bool enabled) {
       set_gpio_output(GPIOA, 0, !enabled);
       break;
     default:
-      puts("Invalid CAN transceiver ("); puth(transceiver); puts("): enabling failed\n");
+      putstr("Invalid CAN transceiver ("); puth(transceiver); putstr("): enabling failed\n");
       break;
   }
 }
@@ -60,7 +60,7 @@ void white_set_usb_power_mode(uint8_t mode){
       set_gpio_output(GPIOA, 13, 0);
       break;
     default:
-      puts("Invalid usb power mode\n");
+      putstr("Invalid usb power mode\n");
       break;
   }
 }
@@ -77,7 +77,7 @@ void white_set_gps_mode(uint8_t mode) {
       set_gpio_output(GPIOC, 5, 0);
       break;
     default:
-      puts("Invalid ESP/GPS mode\n");
+      putstr("Invalid ESP/GPS mode\n");
       break;
   }
 }
@@ -136,7 +136,7 @@ void white_set_can_mode(uint8_t mode){
       set_gpio_alternate(GPIOB, 6, GPIO_AF9_CAN2);
       break;
     default:
-      puts("Tried to set unsupported CAN mode: "); puth(mode); puts("\n");
+      putstr("Tried to set unsupported CAN mode: "); puth(mode); putstr("\n");
       break;
   }
 }

--- a/board/bootstub_declarations.h
+++ b/board/bootstub_declarations.h
@@ -1,5 +1,5 @@
 // ******************** Prototypes ********************
-void puts(const char *a){ UNUSED(a); }
+void putstr(const char *a){ UNUSED(a); }
 void puth(uint8_t i){ UNUSED(i); }
 void puth2(uint8_t i){ UNUSED(i); }
 void puth4(uint8_t i){ UNUSED(i); }

--- a/board/bootstub_declarations.h
+++ b/board/bootstub_declarations.h
@@ -1,5 +1,5 @@
 // ******************** Prototypes ********************
-void putstr(const char *a){ UNUSED(a); }
+void print(const char *a){ UNUSED(a); }
 void puth(uint8_t i){ UNUSED(i); }
 void puth2(uint8_t i){ UNUSED(i); }
 void puth4(uint8_t i){ UNUSED(i); }

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -27,9 +27,9 @@ void can_set_gmlan(uint8_t bus) {
       switch (prev_bus) {
         case 1:
         case 2:
-          putstr("Disable GMLAN on CAN");
+          print("Disable GMLAN on CAN");
           puth(prev_bus + 1U);
-          putstr("\n");
+          print("\n");
           current_board->set_can_mode(CAN_MODE_NORMAL);
           bus_config[prev_bus].bus_lookup = prev_bus;
           bus_config[prev_bus].can_num_lookup = prev_bus;
@@ -47,9 +47,9 @@ void can_set_gmlan(uint8_t bus) {
     switch (bus) {
       case 1:
       case 2:
-        putstr("Enable GMLAN on CAN");
+        print("Enable GMLAN on CAN");
         puth(bus + 1U);
-        putstr("\n");
+        print("\n");
         current_board->set_can_mode((bus == 1U) ? CAN_MODE_GMLAN_CAN2 : CAN_MODE_GMLAN_CAN3);
         bus_config[bus].bus_lookup = 3;
         bus_config[bus].can_num_lookup = -1;
@@ -60,11 +60,11 @@ void can_set_gmlan(uint8_t bus) {
       case 0xFF:  //-1 unsigned
         break;
       default:
-        putstr("GMLAN can only be set on CAN2 or CAN3\n");
+        print("GMLAN can only be set on CAN2 or CAN3\n");
         break;
     }
   } else {
-    putstr("GMLAN not available on black panda\n");
+    print("GMLAN not available on black panda\n");
   }
 }
 

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -27,9 +27,9 @@ void can_set_gmlan(uint8_t bus) {
       switch (prev_bus) {
         case 1:
         case 2:
-          puts("Disable GMLAN on CAN");
+          putstr("Disable GMLAN on CAN");
           puth(prev_bus + 1U);
-          puts("\n");
+          putstr("\n");
           current_board->set_can_mode(CAN_MODE_NORMAL);
           bus_config[prev_bus].bus_lookup = prev_bus;
           bus_config[prev_bus].can_num_lookup = prev_bus;
@@ -47,9 +47,9 @@ void can_set_gmlan(uint8_t bus) {
     switch (bus) {
       case 1:
       case 2:
-        puts("Enable GMLAN on CAN");
+        putstr("Enable GMLAN on CAN");
         puth(bus + 1U);
-        puts("\n");
+        putstr("\n");
         current_board->set_can_mode((bus == 1U) ? CAN_MODE_GMLAN_CAN2 : CAN_MODE_GMLAN_CAN3);
         bus_config[bus].bus_lookup = 3;
         bus_config[bus].can_num_lookup = -1;
@@ -60,11 +60,11 @@ void can_set_gmlan(uint8_t bus) {
       case 0xFF:  //-1 unsigned
         break;
       default:
-        puts("GMLAN can only be set on CAN2 or CAN3\n");
+        putstr("GMLAN can only be set on CAN2 or CAN3\n");
         break;
     }
   } else {
-    puts("GMLAN not available on black panda\n");
+    putstr("GMLAN not available on black panda\n");
   }
 }
 

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -107,21 +107,21 @@ bool can_push(can_ring *q, CANPacket_t *elem) {
   EXIT_CRITICAL();
   if (!ret) {
     #ifdef DEBUG
-      puts("can_push to ");
+      putstr("can_push to ");
       if (q == &can_rx_q) {
-        puts("can_rx_q");
+        putstr("can_rx_q");
       } else if (q == &can_tx1_q) {
-        puts("can_tx1_q");
+        putstr("can_tx1_q");
       } else if (q == &can_tx2_q) {
-        puts("can_tx2_q");
+        putstr("can_tx2_q");
       } else if (q == &can_tx3_q) {
-        puts("can_tx3_q");
+        putstr("can_tx3_q");
       } else if (q == &can_txgmlan_q) {
-        puts("can_txgmlan_q");
+        putstr("can_txgmlan_q");
       } else {
-        puts("unknown");
+        putstr("unknown");
       }
-      puts(" failed!\n");
+      putstr(" failed!\n");
     #endif
   }
   return ret;

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -107,21 +107,21 @@ bool can_push(can_ring *q, CANPacket_t *elem) {
   EXIT_CRITICAL();
   if (!ret) {
     #ifdef DEBUG
-      putstr("can_push to ");
+      print("can_push to ");
       if (q == &can_rx_q) {
-        putstr("can_rx_q");
+        print("can_rx_q");
       } else if (q == &can_tx1_q) {
-        putstr("can_tx1_q");
+        print("can_tx1_q");
       } else if (q == &can_tx2_q) {
-        putstr("can_tx2_q");
+        print("can_tx2_q");
       } else if (q == &can_tx3_q) {
-        putstr("can_tx3_q");
+        print("can_tx3_q");
       } else if (q == &can_txgmlan_q) {
-        putstr("can_txgmlan_q");
+        print("can_txgmlan_q");
       } else {
-        putstr("unknown");
+        print("unknown");
       }
-      putstr(" failed!\n");
+      print(" failed!\n");
     #endif
   }
   return ret;

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -29,7 +29,7 @@ bool can_set_speed(uint8_t can_number) {
 
 void can_set_gmlan(uint8_t bus) {
   UNUSED(bus);
-  puts("GMLAN not available on red panda\n");
+  putstr("GMLAN not available on red panda\n");
 }
 
 // ***************************** CAN *****************************

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -29,7 +29,7 @@ bool can_set_speed(uint8_t can_number) {
 
 void can_set_gmlan(uint8_t bus) {
   UNUSED(bus);
-  putstr("GMLAN not available on red panda\n");
+  print("GMLAN not available on red panda\n");
 }
 
 // ***************************** CAN *****************************

--- a/board/drivers/gmlan_alt.h
+++ b/board/drivers/gmlan_alt.h
@@ -161,9 +161,9 @@ void gmlan_switch_init(int timeout_enable) {
 void set_gmlan_digital_output(int to_set) {
   inverted_bit_to_send = to_set;
   /*
-  putstr("Writing ");
+  print("Writing ");
   puth(inverted_bit_to_send);
-  putstr("\n");
+  print("\n");
   */
 }
 
@@ -207,12 +207,12 @@ void TIM12_IRQ_Handler(void) {
         if ((gmlan_sending > 0) &&  // not first bit
            ((read == 0) && (pkt_stuffed[gmlan_sending-1] == 1)) &&  // bus wrongly dominant
            (gmlan_sending != (gmlan_sendmax - 11))) {    //not ack bit
-          putstr("GMLAN ERR: bus driven at ");
+          print("GMLAN ERR: bus driven at ");
           puth(gmlan_sending);
-          putstr("\n");
+          print("\n");
           retry = 1;
         } else if ((read == 1) && (gmlan_sending == (gmlan_sendmax - 11))) {    // recessive during ACK
-          putstr("GMLAN ERR: didn't recv ACK\n");
+          print("GMLAN ERR: didn't recv ACK\n");
           retry = 1;
         } else {
           // do not retry
@@ -224,7 +224,7 @@ void TIM12_IRQ_Handler(void) {
           gmlan_sending = 0;
           gmlan_fail_count++;
           if (gmlan_fail_count == MAX_FAIL_COUNT) {
-            putstr("GMLAN ERR: giving up send\n");
+            print("GMLAN ERR: giving up send\n");
             gmlan_send_ok = false;
           }
         } else {

--- a/board/drivers/gmlan_alt.h
+++ b/board/drivers/gmlan_alt.h
@@ -161,9 +161,9 @@ void gmlan_switch_init(int timeout_enable) {
 void set_gmlan_digital_output(int to_set) {
   inverted_bit_to_send = to_set;
   /*
-  puts("Writing ");
+  putstr("Writing ");
   puth(inverted_bit_to_send);
-  puts("\n");
+  putstr("\n");
   */
 }
 
@@ -207,12 +207,12 @@ void TIM12_IRQ_Handler(void) {
         if ((gmlan_sending > 0) &&  // not first bit
            ((read == 0) && (pkt_stuffed[gmlan_sending-1] == 1)) &&  // bus wrongly dominant
            (gmlan_sending != (gmlan_sendmax - 11))) {    //not ack bit
-          puts("GMLAN ERR: bus driven at ");
+          putstr("GMLAN ERR: bus driven at ");
           puth(gmlan_sending);
-          puts("\n");
+          putstr("\n");
           retry = 1;
         } else if ((read == 1) && (gmlan_sending == (gmlan_sendmax - 11))) {    // recessive during ACK
-          puts("GMLAN ERR: didn't recv ACK\n");
+          putstr("GMLAN ERR: didn't recv ACK\n");
           retry = 1;
         } else {
           // do not retry
@@ -224,7 +224,7 @@ void TIM12_IRQ_Handler(void) {
           gmlan_sending = 0;
           gmlan_fail_count++;
           if (gmlan_fail_count == MAX_FAIL_COUNT) {
-            puts("GMLAN ERR: giving up send\n");
+            putstr("GMLAN ERR: giving up send\n");
             gmlan_send_ok = false;
           }
         } else {

--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -21,9 +21,9 @@ struct harness_configuration {
 void set_intercept_relay(bool intercept) {
   if (car_harness_status != HARNESS_STATUS_NC) {
     if (intercept) {
-      putstr("switching harness to intercept (relay on)\n");
+      print("switching harness to intercept (relay on)\n");
     } else {
-      putstr("switching harness to passthrough (relay off)\n");
+      print("switching harness to passthrough (relay off)\n");
     }
 
     if(car_harness_status == HARNESS_STATUS_NORMAL){
@@ -80,7 +80,7 @@ void harness_init(void) {
   // try to detect orientation
   uint8_t ret = harness_detect_orientation();
   if (ret != HARNESS_STATUS_NC) {
-    putstr("detected car harness with orientation "); puth2(ret); putstr("\n");
+    print("detected car harness with orientation "); puth2(ret); print("\n");
     car_harness_status = ret;
 
     // set the SBU lines to be inputs before using the relay. The lines are not 5V tolerant in ADC mode!
@@ -90,6 +90,6 @@ void harness_init(void) {
     // keep busses connected by default
     set_intercept_relay(false);
   } else {
-    putstr("failed to detect car harness!\n");
+    print("failed to detect car harness!\n");
   }
 }

--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -21,9 +21,9 @@ struct harness_configuration {
 void set_intercept_relay(bool intercept) {
   if (car_harness_status != HARNESS_STATUS_NC) {
     if (intercept) {
-      puts("switching harness to intercept (relay on)\n");
+      putstr("switching harness to intercept (relay on)\n");
     } else {
-      puts("switching harness to passthrough (relay off)\n");
+      putstr("switching harness to passthrough (relay off)\n");
     }
 
     if(car_harness_status == HARNESS_STATUS_NORMAL){
@@ -80,7 +80,7 @@ void harness_init(void) {
   // try to detect orientation
   uint8_t ret = harness_detect_orientation();
   if (ret != HARNESS_STATUS_NC) {
-    puts("detected car harness with orientation "); puth2(ret); puts("\n");
+    putstr("detected car harness with orientation "); puth2(ret); putstr("\n");
     car_harness_status = ret;
 
     // set the SBU lines to be inputs before using the relay. The lines are not 5V tolerant in ADC mode!
@@ -90,6 +90,6 @@ void harness_init(void) {
     // keep busses connected by default
     set_intercept_relay(false);
   } else {
-    puts("failed to detect car harness!\n");
+    putstr("failed to detect car harness!\n");
   }
 }

--- a/board/drivers/interrupts.h
+++ b/board/drivers/interrupts.h
@@ -11,7 +11,7 @@ uint32_t microsecond_timer_get(void);
 
 void unused_interrupt_handler(void) {
   // Something is wrong if this handler is called!
-  puts("Unused interrupt handler called!\n");
+  putstr("Unused interrupt handler called!\n");
   fault_occurred(FAULT_UNUSED_INTERRUPT_HANDLED);
 }
 
@@ -47,7 +47,7 @@ void handle_interrupt(IRQn_Type irq_type){
 
   // Check that the interrupts don't fire too often
   if(check_interrupt_rate && (interrupts[irq_type].call_counter > interrupts[irq_type].max_call_rate)){
-    puts("Interrupt 0x"); puth(irq_type); puts(" fired too often (0x"); puth(interrupts[irq_type].call_counter); puts("/s)!\n");
+    putstr("Interrupt 0x"); puth(irq_type); putstr(" fired too often (0x"); puth(interrupts[irq_type].call_counter); putstr("/s)!\n");
     fault_occurred(interrupts[irq_type].call_rate_fault);
   }
 

--- a/board/drivers/interrupts.h
+++ b/board/drivers/interrupts.h
@@ -11,7 +11,7 @@ uint32_t microsecond_timer_get(void);
 
 void unused_interrupt_handler(void) {
   // Something is wrong if this handler is called!
-  putstr("Unused interrupt handler called!\n");
+  print("Unused interrupt handler called!\n");
   fault_occurred(FAULT_UNUSED_INTERRUPT_HANDLED);
 }
 
@@ -47,7 +47,7 @@ void handle_interrupt(IRQn_Type irq_type){
 
   // Check that the interrupts don't fire too often
   if(check_interrupt_rate && (interrupts[irq_type].call_counter > interrupts[irq_type].max_call_rate)){
-    putstr("Interrupt 0x"); puth(irq_type); putstr(" fired too often (0x"); puth(interrupts[irq_type].call_counter); putstr("/s)!\n");
+    print("Interrupt 0x"); puth(irq_type); print(" fired too often (0x"); puth(interrupts[irq_type].call_counter); print("/s)!\n");
     fault_occurred(interrupts[irq_type].call_rate_fault);
   }
 

--- a/board/drivers/registers.h
+++ b/board/drivers/registers.h
@@ -35,7 +35,7 @@ void register_set(volatile uint32_t *addr, uint32_t val, uint32_t mask){
     register_map[hash].check_mask |= mask;
   } else {
     #ifdef DEBUG_FAULTS
-      puts("Hash collision: address 0x"); puth((uint32_t) addr); puts("!\n");
+      putstr("Hash collision: address 0x"); puth((uint32_t) addr); putstr("!\n");
     #endif
   }
   EXIT_CRITICAL()
@@ -60,11 +60,11 @@ void check_registers(void){
       ENTER_CRITICAL()
       if((*(register_map[i].address) & register_map[i].check_mask) != (register_map[i].value & register_map[i].check_mask)){
         #ifdef DEBUG_FAULTS
-          puts("Register at address 0x"); puth((uint32_t) register_map[i].address); puts(" is divergent!");
-          puts("   Map: 0x"); puth(register_map[i].value);
-          puts("   Register: 0x"); puth(*(register_map[i].address));
-          puts("   Mask: 0x"); puth(register_map[i].check_mask);
-          puts("\n");
+          putstr("Register at address 0x"); puth((uint32_t) register_map[i].address); putstr(" is divergent!");
+          putstr("   Map: 0x"); puth(register_map[i].value);
+          putstr("   Register: 0x"); puth(*(register_map[i].address));
+          putstr("   Mask: 0x"); puth(register_map[i].check_mask);
+          putstr("\n");
         #endif
         fault_occurred(FAULT_REGISTER_DIVERGENT);
       }

--- a/board/drivers/registers.h
+++ b/board/drivers/registers.h
@@ -35,7 +35,7 @@ void register_set(volatile uint32_t *addr, uint32_t val, uint32_t mask){
     register_map[hash].check_mask |= mask;
   } else {
     #ifdef DEBUG_FAULTS
-      putstr("Hash collision: address 0x"); puth((uint32_t) addr); putstr("!\n");
+      print("Hash collision: address 0x"); puth((uint32_t) addr); print("!\n");
     #endif
   }
   EXIT_CRITICAL()
@@ -60,11 +60,11 @@ void check_registers(void){
       ENTER_CRITICAL()
       if((*(register_map[i].address) & register_map[i].check_mask) != (register_map[i].value & register_map[i].check_mask)){
         #ifdef DEBUG_FAULTS
-          putstr("Register at address 0x"); puth((uint32_t) register_map[i].address); putstr(" is divergent!");
-          putstr("   Map: 0x"); puth(register_map[i].value);
-          putstr("   Register: 0x"); puth(*(register_map[i].address));
-          putstr("   Mask: 0x"); puth(register_map[i].check_mask);
-          putstr("\n");
+          print("Register at address 0x"); puth((uint32_t) register_map[i].address); print(" is divergent!");
+          print("   Map: 0x"); puth(register_map[i].value);
+          print("   Register: 0x"); puth(*(register_map[i].address));
+          print("   Mask: 0x"); puth(register_map[i].check_mask);
+          print("\n");
         #endif
         fault_occurred(FAULT_REGISTER_DIVERGENT);
       }

--- a/board/drivers/rtc.h
+++ b/board/drivers/rtc.h
@@ -36,7 +36,7 @@ void rtc_init(void){
 
   // Initialize RTC module and clock if not done already.
   if((RCC->BDCR & bdcr_mask) != bdcr_opts){
-    puts("Initializing RTC\n");
+    putstr("Initializing RTC\n");
     // Reset backup domain
     register_set_bits(&(RCC->BDCR), RCC_BDCR_BDRST);
 
@@ -55,7 +55,7 @@ void rtc_init(void){
 }
 
 void rtc_set_time(timestamp_t time){
-  puts("Setting RTC time\n");
+  putstr("Setting RTC time\n");
 
   // Disable write protection
   disable_bdomain_protection();

--- a/board/drivers/rtc.h
+++ b/board/drivers/rtc.h
@@ -36,7 +36,7 @@ void rtc_init(void){
 
   // Initialize RTC module and clock if not done already.
   if((RCC->BDCR & bdcr_mask) != bdcr_opts){
-    putstr("Initializing RTC\n");
+    print("Initializing RTC\n");
     // Reset backup domain
     register_set_bits(&(RCC->BDCR), RCC_BDCR_BDRST);
 
@@ -55,7 +55,7 @@ void rtc_init(void){
 }
 
 void rtc_set_time(timestamp_t time){
-  putstr("Setting RTC time\n");
+  print("Setting RTC time\n");
 
   // Disable write protection
   disable_bdomain_protection();

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -75,7 +75,7 @@ void spi_handle_rx(void) {
       next_rx_state = SPI_STATE_HEADER_ACK;
     } else {
       // response: NACK and reset state machine
-      putstr("- incorrect header sync or checksum "); hexdump(spi_buf_rx, SPI_HEADER_SIZE);
+      print("- incorrect header sync or checksum "); hexdump(spi_buf_rx, SPI_HEADER_SIZE);
       spi_buf_tx[0] = SPI_NACK;
       next_rx_state = SPI_STATE_HEADER_NACK;
     }
@@ -92,14 +92,14 @@ void spi_handle_rx(void) {
           response_len = comms_control_handler(&ctrl, &spi_buf_tx[3]);
           reponse_ack = true;
         } else {
-          putstr("SPI: insufficient data for control handler\n");
+          print("SPI: insufficient data for control handler\n");
         }
       } else if ((spi_endpoint == 1U) || (spi_endpoint == 0x81U)) {
         if (spi_data_len_mosi == 0U) {
           response_len = comms_can_read(&(spi_buf_tx[3]), spi_data_len_miso);
           reponse_ack = true;
         } else {
-          putstr("SPI: did not expect data for can_read\n");
+          print("SPI: did not expect data for can_read\n");
         }
       } else if (spi_endpoint == 2U) {
         comms_endpoint2_write(&spi_buf_rx[SPI_HEADER_SIZE], spi_data_len_mosi);
@@ -109,15 +109,15 @@ void spi_handle_rx(void) {
           comms_can_write(&spi_buf_rx[SPI_HEADER_SIZE], spi_data_len_mosi);
           reponse_ack = true;
         } else {
-          putstr("SPI: did expect data for can_write\n");
+          print("SPI: did expect data for can_write\n");
         }
       } else {
-        putstr("SPI: unexpected endpoint"); puth(spi_endpoint); putstr("\n");
+        print("SPI: unexpected endpoint"); puth(spi_endpoint); print("\n");
       }
     } else {
       // Checksum was incorrect
       reponse_ack = false;
-      putstr("- incorrect data checksum\n");
+      print("- incorrect data checksum\n");
     }
 
     // Setup response header
@@ -137,7 +137,7 @@ void spi_handle_rx(void) {
 
     next_rx_state = SPI_STATE_DATA_TX;
   } else {
-    putstr("SPI: RX unexpected state: "); puth(spi_state); putstr("\n");
+    print("SPI: RX unexpected state: "); puth(spi_state); print("\n");
   }
 
   spi_state = next_rx_state;
@@ -159,6 +159,6 @@ void spi_handle_tx(void) {
   } else {
     spi_state = SPI_STATE_HEADER;
     llspi_mosi_dma(spi_buf_rx, SPI_HEADER_SIZE);
-    putstr("SPI: TX unexpected state: "); puth(spi_state); putstr("\n");
+    print("SPI: TX unexpected state: "); puth(spi_state); print("\n");
   }
 }

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -75,7 +75,7 @@ void spi_handle_rx(void) {
       next_rx_state = SPI_STATE_HEADER_ACK;
     } else {
       // response: NACK and reset state machine
-      puts("- incorrect header sync or checksum "); hexdump(spi_buf_rx, SPI_HEADER_SIZE);
+      putstr("- incorrect header sync or checksum "); hexdump(spi_buf_rx, SPI_HEADER_SIZE);
       spi_buf_tx[0] = SPI_NACK;
       next_rx_state = SPI_STATE_HEADER_NACK;
     }
@@ -92,14 +92,14 @@ void spi_handle_rx(void) {
           response_len = comms_control_handler(&ctrl, &spi_buf_tx[3]);
           reponse_ack = true;
         } else {
-          puts("SPI: insufficient data for control handler\n");
+          putstr("SPI: insufficient data for control handler\n");
         }
       } else if ((spi_endpoint == 1U) || (spi_endpoint == 0x81U)) {
         if (spi_data_len_mosi == 0U) {
           response_len = comms_can_read(&(spi_buf_tx[3]), spi_data_len_miso);
           reponse_ack = true;
         } else {
-          puts("SPI: did not expect data for can_read\n");
+          putstr("SPI: did not expect data for can_read\n");
         }
       } else if (spi_endpoint == 2U) {
         comms_endpoint2_write(&spi_buf_rx[SPI_HEADER_SIZE], spi_data_len_mosi);
@@ -109,15 +109,15 @@ void spi_handle_rx(void) {
           comms_can_write(&spi_buf_rx[SPI_HEADER_SIZE], spi_data_len_mosi);
           reponse_ack = true;
         } else {
-          puts("SPI: did expect data for can_write\n");
+          putstr("SPI: did expect data for can_write\n");
         }
       } else {
-        puts("SPI: unexpected endpoint"); puth(spi_endpoint); puts("\n");
+        putstr("SPI: unexpected endpoint"); puth(spi_endpoint); putstr("\n");
       }
     } else {
       // Checksum was incorrect
       reponse_ack = false;
-      puts("- incorrect data checksum\n");
+      putstr("- incorrect data checksum\n");
     }
 
     // Setup response header
@@ -137,7 +137,7 @@ void spi_handle_rx(void) {
 
     next_rx_state = SPI_STATE_DATA_TX;
   } else {
-    puts("SPI: RX unexpected state: "); puth(spi_state); puts("\n");
+    putstr("SPI: RX unexpected state: "); puth(spi_state); putstr("\n");
   }
 
   spi_state = next_rx_state;
@@ -159,6 +159,6 @@ void spi_handle_tx(void) {
   } else {
     spi_state = SPI_STATE_HEADER;
     llspi_mosi_dma(spi_buf_rx, SPI_HEADER_SIZE);
-    puts("SPI: TX unexpected state: "); puth(spi_state); puts("\n");
+    putstr("SPI: TX unexpected state: "); puth(spi_state); putstr("\n");
   }
 }

--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -165,7 +165,7 @@ void putch(const char a) {
   (void)injectc(&uart_ring_debug, a);
 }
 
-void puts(const char *a) {
+void putstr(const char *a) {
   for (const char *in = a; *in; in++) {
     if (*in == '\n') putch('\r');
     putch(*in);
@@ -183,7 +183,7 @@ void putui(uint32_t i) {
     idx--;
     i_copy /= 10;
   } while (i_copy != 0U);
-  puts(&str[idx + 1U]);
+  putstr(&str[idx + 1U]);
 }
 
 void puthx(uint32_t i, uint8_t len) {
@@ -208,10 +208,10 @@ void puth4(unsigned int i) {
 void hexdump(const void *a, int l) {
   if (a != NULL) {
     for (int i=0; i < l; i++) {
-      if ((i != 0) && ((i & 0xf) == 0)) puts("\n");
+      if ((i != 0) && ((i & 0xf) == 0)) putstr("\n");
       puth2(((const unsigned char*)a)[i]);
-      puts(" ");
+      putstr(" ");
     }
   }
-  puts("\n");
+  putstr("\n");
 }

--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -165,7 +165,7 @@ void putch(const char a) {
   (void)injectc(&uart_ring_debug, a);
 }
 
-void putstr(const char *a) {
+void print(const char *a) {
   for (const char *in = a; *in; in++) {
     if (*in == '\n') putch('\r');
     putch(*in);
@@ -183,7 +183,7 @@ void putui(uint32_t i) {
     idx--;
     i_copy /= 10;
   } while (i_copy != 0U);
-  putstr(&str[idx + 1U]);
+  print(&str[idx + 1U]);
 }
 
 void puthx(uint32_t i, uint8_t len) {
@@ -208,10 +208,10 @@ void puth4(unsigned int i) {
 void hexdump(const void *a, int l) {
   if (a != NULL) {
     for (int i=0; i < l; i++) {
-      if ((i != 0) && ((i & 0xf) == 0)) putstr("\n");
+      if ((i != 0) && ((i & 0xf) == 0)) print("\n");
       puth2(((const unsigned char*)a)[i]);
-      putstr(" ");
+      print(" ");
     }
   }
-  putstr("\n");
+  print("\n");
 }

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -375,7 +375,7 @@ void *USB_ReadPacket(void *dest, uint16_t len) {
 
 void USB_WritePacket(const void *src, uint16_t len, uint32_t ep) {
   #ifdef DEBUG_USB
-  putstr("writing ");
+  print("writing ");
   hexdump(src, len);
   #endif
 
@@ -402,7 +402,7 @@ void USB_WritePacket(const void *src, uint16_t len, uint32_t ep) {
 // so use TX FIFO empty interrupt to send larger amounts of data
 void USB_WritePacket_EP0(uint8_t *src, uint16_t len) {
   #ifdef DEBUG_USB
-  putstr("writing ");
+  print("writing ");
   hexdump(src, len);
   #endif
 
@@ -505,7 +505,7 @@ void usb_setup(void) {
       USBx_DEVICE->DCFG |= ((setup.b.wValue.w & 0x7fU) << 4);
 
       #ifdef DEBUG_USB
-        putstr(" set address\n");
+        print(" set address\n");
       #endif
 
       USB_WritePacket(0, 0, 0);
@@ -515,7 +515,7 @@ void usb_setup(void) {
     case USB_REQ_GET_DESCRIPTOR:
       switch (setup.b.wValue.bw.lsb) {
         case USB_DESC_TYPE_DEVICE:
-          //putstr("    writing device descriptor\n");
+          //print("    writing device descriptor\n");
 
           // set bcdDevice to hardware type
           device_desc[13] = hw_type;
@@ -523,7 +523,7 @@ void usb_setup(void) {
           USB_WritePacket(device_desc, MIN(sizeof(device_desc), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
 
-          //putstr("D");
+          //print("D");
           break;
         case USB_DESC_TYPE_CONFIGURATION:
           USB_WritePacket(configuration_desc, MIN(sizeof(configuration_desc), setup.b.wLength.w), 0);
@@ -660,21 +660,21 @@ void usb_irqhandler(void) {
   // gintsts SUSPEND? 04008428
   #ifdef DEBUG_USB
     puth(gintsts);
-    putstr(" ");
+    print(" ");
     /*puth(USBx->GCCFG);
-    putstr(" ");*/
+    print(" ");*/
     puth(gotgint);
-    putstr(" ep ");
+    print(" ep ");
     puth(daint);
-    putstr(" USB interrupt!\n");
+    print(" USB interrupt!\n");
   #endif
 
   if ((gintsts & USB_OTG_GINTSTS_CIDSCHG) != 0) {
-    putstr("connector ID status change\n");
+    print("connector ID status change\n");
   }
 
   if ((gintsts & USB_OTG_GINTSTS_ESUSP) != 0) {
-    putstr("ESUSP detected\n");
+    print("ESUSP detected\n");
   }
 
   if ((gintsts & USB_OTG_GINTSTS_EOPF) != 0) {
@@ -682,7 +682,7 @@ void usb_irqhandler(void) {
   }
 
   if ((gintsts & USB_OTG_GINTSTS_USBRST) != 0) {
-    putstr("USB reset\n");
+    print("USB reset\n");
     usb_enumerated = false;
     usb_reset();
   }
@@ -692,16 +692,16 @@ void usb_irqhandler(void) {
   }
 
   if ((gintsts & USB_OTG_GINTSTS_ENUMDNE) != 0) {
-    putstr("enumeration done");
+    print("enumeration done");
     // Full speed, ENUMSPD
     //puth(USBx_DEVICE->DSTS);
-    putstr("\n");
+    print("\n");
   }
 
   if ((gintsts & USB_OTG_GINTSTS_OTGINT) != 0) {
-    putstr("OTG int:");
+    print("OTG int:");
     puth(USBx->GOTGINT);
-    putstr("\n");
+    print("\n");
 
     // getting ADTOCHG
     //USBx->GOTGINT = USBx->GOTGINT;
@@ -714,13 +714,13 @@ void usb_irqhandler(void) {
     int status = (rxst & USB_OTG_GRXSTSP_PKTSTS) >> 17;
 
     #ifdef DEBUG_USB
-      putstr(" RX FIFO:");
+      print(" RX FIFO:");
       puth(rxst);
-      putstr(" status: ");
+      print(" status: ");
       puth(status);
-      putstr(" len: ");
+      print(" len: ");
       puth((rxst & USB_OTG_GRXSTSP_BCNT) >> 4);
-      putstr("\n");
+      print("\n");
     #endif
 
     if (status == STS_DATA_UPDT) {
@@ -728,9 +728,9 @@ void usb_irqhandler(void) {
       int len = (rxst & USB_OTG_GRXSTSP_BCNT) >> 4;
       (void)USB_ReadPacket(&usbdata, len);
       #ifdef DEBUG_USB
-        putstr("  data ");
+        print("  data ");
         puth(len);
-        putstr("\n");
+        print("\n");
         hexdump(&usbdata, len);
       #endif
 
@@ -745,9 +745,9 @@ void usb_irqhandler(void) {
     } else if (status == STS_SETUP_UPDT) {
       (void)USB_ReadPacket(&setup, 8);
       #ifdef DEBUG_USB
-        putstr("  setup ");
+        print("  setup ");
         hexdump(&setup, 8);
-        putstr("\n");
+        print("\n");
       #endif
     } else {
       // status is neither STS_DATA_UPDT or STS_SETUP_UPDT, skip
@@ -756,9 +756,9 @@ void usb_irqhandler(void) {
 
   /*if (gintsts & USB_OTG_GINTSTS_HPRTINT) {
     // host
-    putstr("HPRT:");
+    print("HPRT:");
     puth(USBx_HOST_PORT->HPRT);
-    putstr("\n");
+    print("\n");
     if (USBx_HOST_PORT->HPRT & USB_OTG_HPRT_PCDET) {
       USBx_HOST_PORT->HPRT |= USB_OTG_HPRT_PRST;
       USBx_HOST_PORT->HPRT |= USB_OTG_HPRT_PCDET;
@@ -769,16 +769,16 @@ void usb_irqhandler(void) {
   if ((gintsts & USB_OTG_GINTSTS_BOUTNAKEFF) || (gintsts & USB_OTG_GINTSTS_GINAKEFF)) {
     // no global NAK, why is this getting set?
     #ifdef DEBUG_USB
-      putstr("GLOBAL NAK\n");
+      print("GLOBAL NAK\n");
     #endif
     USBx_DEVICE->DCTL |= USB_OTG_DCTL_CGONAK | USB_OTG_DCTL_CGINAK;
   }
 
   if ((gintsts & USB_OTG_GINTSTS_SRQINT) != 0) {
     // we want to do "A-device host negotiation protocol" since we are the A-device
-    /*putstr("start request\n");
+    /*print("start request\n");
     puth(USBx->GOTGCTL);
-    putstr("\n");*/
+    print("\n");*/
     //USBx->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
     //USBx_HOST_PORT->HPRT = USB_OTG_HPRT_PPWR | USB_OTG_HPRT_PENA;
     //USBx->GOTGCTL |= USB_OTG_GOTGCTL_SRQ;
@@ -787,22 +787,22 @@ void usb_irqhandler(void) {
   // out endpoint hit
   if ((gintsts & USB_OTG_GINTSTS_OEPINT) != 0) {
     #ifdef DEBUG_USB
-      putstr("  0:");
+      print("  0:");
       puth(USBx_OUTEP(0)->DOEPINT);
-      putstr(" 2:");
+      print(" 2:");
       puth(USBx_OUTEP(2)->DOEPINT);
-      putstr(" 3:");
+      print(" 3:");
       puth(USBx_OUTEP(3)->DOEPINT);
-      putstr(" ");
+      print(" ");
       puth(USBx_OUTEP(3)->DOEPCTL);
-      putstr(" 4:");
+      print(" 4:");
       puth(USBx_OUTEP(4)->DOEPINT);
-      putstr(" OUT ENDPOINT\n");
+      print(" OUT ENDPOINT\n");
     #endif
 
     if ((USBx_OUTEP(2)->DOEPINT & USB_OTG_DOEPINT_XFRC) != 0) {
       #ifdef DEBUG_USB
-        putstr("  OUT2 PACKET XFRC\n");
+        print("  OUT2 PACKET XFRC\n");
       #endif
       USBx_OUTEP(2)->DOEPTSIZ = (1U << 19) | 0x40U;
       USBx_OUTEP(2)->DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_CNAK;
@@ -810,14 +810,14 @@ void usb_irqhandler(void) {
 
     if ((USBx_OUTEP(3)->DOEPINT & USB_OTG_DOEPINT_XFRC) != 0) {
       #ifdef DEBUG_USB
-        putstr("  OUT3 PACKET XFRC\n");
+        print("  OUT3 PACKET XFRC\n");
       #endif
       // NAK cleared by process_can (if tx buffers have room)
       outep3_processing = false;
       usb_cb_ep3_out_complete();
     } else if ((USBx_OUTEP(3)->DOEPINT & 0x2000) != 0) {
       #ifdef DEBUG_USB
-        putstr("  OUT3 PACKET WTF\n");
+        print("  OUT3 PACKET WTF\n");
       #endif
       // if NAK was set trigger this, unknown interrupt
       // TODO: why was this here? fires when TX buffers when we can't clear NAK
@@ -825,9 +825,9 @@ void usb_irqhandler(void) {
       // USBx_OUTEP(3)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
     } else if ((USBx_OUTEP(3)->DOEPINT) != 0) {
       #ifdef DEBUG_USB
-        putstr("OUTEP3 error ");
+        print("OUTEP3 error ");
         puth(USBx_OUTEP(3)->DOEPINT);
-        putstr("\n");
+        print("\n");
       #endif
     } else {
       // USBx_OUTEP(3)->DOEPINT is 0, ok to skip
@@ -851,11 +851,11 @@ void usb_irqhandler(void) {
   // interrupt endpoint hit (Page 1221)
   if ((gintsts & USB_OTG_GINTSTS_IEPINT) != 0) {
     #ifdef DEBUG_USB
-      putstr("  ");
+      print("  ");
       puth(USBx_INEP(0)->DIEPINT);
-      putstr(" ");
+      print(" ");
       puth(USBx_INEP(1)->DIEPINT);
-      putstr(" IN ENDPOINT\n");
+      print(" IN ENDPOINT\n");
     #endif
 
     // Should likely check the EP of the IN request even if there is
@@ -876,7 +876,7 @@ void usb_irqhandler(void) {
         // *** IN token received when TxFIFO is empty
         if ((USBx_INEP(1)->DIEPINT & USB_OTG_DIEPMSK_ITTXFEMSK) != 0) {
           #ifdef DEBUG_USB
-          putstr("  IN PACKET QUEUE\n");
+          print("  IN PACKET QUEUE\n");
           #endif
           // TODO: always assuming max len, can we get the length?
           USB_WritePacket((void *)resp, comms_can_read(resp, 0x40), 1);
@@ -887,7 +887,7 @@ void usb_irqhandler(void) {
         // *** IN token received when TxFIFO is empty
         if ((USBx_INEP(1)->DIEPINT & USB_OTG_DIEPMSK_ITTXFEMSK) != 0) {
           #ifdef DEBUG_USB
-          putstr("  IN PACKET QUEUE\n");
+          print("  IN PACKET QUEUE\n");
           #endif
           // TODO: always assuming max len, can we get the length?
           int len = comms_can_read(resp, 0x40);
@@ -897,13 +897,13 @@ void usb_irqhandler(void) {
         }
         break;
       default:
-        putstr("current_int0_alt_setting value invalid\n");
+        print("current_int0_alt_setting value invalid\n");
         break;
     }
 
     if ((USBx_INEP(0)->DIEPINT & USB_OTG_DIEPMSK_ITTXFEMSK) != 0) {
       #ifdef DEBUG_USB
-      putstr("  IN PACKET QUEUE\n");
+      print("  IN PACKET QUEUE\n");
       #endif
 
       if ((ep0_txlen != 0U) && ((USBx_INEP(0)->DTXFSTS & USB_OTG_DTXFSTS_INEPTFSAV) >= 0x40U)) {

--- a/board/drivers/usb.h
+++ b/board/drivers/usb.h
@@ -375,7 +375,7 @@ void *USB_ReadPacket(void *dest, uint16_t len) {
 
 void USB_WritePacket(const void *src, uint16_t len, uint32_t ep) {
   #ifdef DEBUG_USB
-  puts("writing ");
+  putstr("writing ");
   hexdump(src, len);
   #endif
 
@@ -402,7 +402,7 @@ void USB_WritePacket(const void *src, uint16_t len, uint32_t ep) {
 // so use TX FIFO empty interrupt to send larger amounts of data
 void USB_WritePacket_EP0(uint8_t *src, uint16_t len) {
   #ifdef DEBUG_USB
-  puts("writing ");
+  putstr("writing ");
   hexdump(src, len);
   #endif
 
@@ -505,7 +505,7 @@ void usb_setup(void) {
       USBx_DEVICE->DCFG |= ((setup.b.wValue.w & 0x7fU) << 4);
 
       #ifdef DEBUG_USB
-        puts(" set address\n");
+        putstr(" set address\n");
       #endif
 
       USB_WritePacket(0, 0, 0);
@@ -515,7 +515,7 @@ void usb_setup(void) {
     case USB_REQ_GET_DESCRIPTOR:
       switch (setup.b.wValue.bw.lsb) {
         case USB_DESC_TYPE_DEVICE:
-          //puts("    writing device descriptor\n");
+          //putstr("    writing device descriptor\n");
 
           // set bcdDevice to hardware type
           device_desc[13] = hw_type;
@@ -523,7 +523,7 @@ void usb_setup(void) {
           USB_WritePacket(device_desc, MIN(sizeof(device_desc), setup.b.wLength.w), 0);
           USBx_OUTEP(0)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
 
-          //puts("D");
+          //putstr("D");
           break;
         case USB_DESC_TYPE_CONFIGURATION:
           USB_WritePacket(configuration_desc, MIN(sizeof(configuration_desc), setup.b.wLength.w), 0);
@@ -660,21 +660,21 @@ void usb_irqhandler(void) {
   // gintsts SUSPEND? 04008428
   #ifdef DEBUG_USB
     puth(gintsts);
-    puts(" ");
+    putstr(" ");
     /*puth(USBx->GCCFG);
-    puts(" ");*/
+    putstr(" ");*/
     puth(gotgint);
-    puts(" ep ");
+    putstr(" ep ");
     puth(daint);
-    puts(" USB interrupt!\n");
+    putstr(" USB interrupt!\n");
   #endif
 
   if ((gintsts & USB_OTG_GINTSTS_CIDSCHG) != 0) {
-    puts("connector ID status change\n");
+    putstr("connector ID status change\n");
   }
 
   if ((gintsts & USB_OTG_GINTSTS_ESUSP) != 0) {
-    puts("ESUSP detected\n");
+    putstr("ESUSP detected\n");
   }
 
   if ((gintsts & USB_OTG_GINTSTS_EOPF) != 0) {
@@ -682,7 +682,7 @@ void usb_irqhandler(void) {
   }
 
   if ((gintsts & USB_OTG_GINTSTS_USBRST) != 0) {
-    puts("USB reset\n");
+    putstr("USB reset\n");
     usb_enumerated = false;
     usb_reset();
   }
@@ -692,16 +692,16 @@ void usb_irqhandler(void) {
   }
 
   if ((gintsts & USB_OTG_GINTSTS_ENUMDNE) != 0) {
-    puts("enumeration done");
+    putstr("enumeration done");
     // Full speed, ENUMSPD
     //puth(USBx_DEVICE->DSTS);
-    puts("\n");
+    putstr("\n");
   }
 
   if ((gintsts & USB_OTG_GINTSTS_OTGINT) != 0) {
-    puts("OTG int:");
+    putstr("OTG int:");
     puth(USBx->GOTGINT);
-    puts("\n");
+    putstr("\n");
 
     // getting ADTOCHG
     //USBx->GOTGINT = USBx->GOTGINT;
@@ -714,13 +714,13 @@ void usb_irqhandler(void) {
     int status = (rxst & USB_OTG_GRXSTSP_PKTSTS) >> 17;
 
     #ifdef DEBUG_USB
-      puts(" RX FIFO:");
+      putstr(" RX FIFO:");
       puth(rxst);
-      puts(" status: ");
+      putstr(" status: ");
       puth(status);
-      puts(" len: ");
+      putstr(" len: ");
       puth((rxst & USB_OTG_GRXSTSP_BCNT) >> 4);
-      puts("\n");
+      putstr("\n");
     #endif
 
     if (status == STS_DATA_UPDT) {
@@ -728,9 +728,9 @@ void usb_irqhandler(void) {
       int len = (rxst & USB_OTG_GRXSTSP_BCNT) >> 4;
       (void)USB_ReadPacket(&usbdata, len);
       #ifdef DEBUG_USB
-        puts("  data ");
+        putstr("  data ");
         puth(len);
-        puts("\n");
+        putstr("\n");
         hexdump(&usbdata, len);
       #endif
 
@@ -745,9 +745,9 @@ void usb_irqhandler(void) {
     } else if (status == STS_SETUP_UPDT) {
       (void)USB_ReadPacket(&setup, 8);
       #ifdef DEBUG_USB
-        puts("  setup ");
+        putstr("  setup ");
         hexdump(&setup, 8);
-        puts("\n");
+        putstr("\n");
       #endif
     } else {
       // status is neither STS_DATA_UPDT or STS_SETUP_UPDT, skip
@@ -756,9 +756,9 @@ void usb_irqhandler(void) {
 
   /*if (gintsts & USB_OTG_GINTSTS_HPRTINT) {
     // host
-    puts("HPRT:");
+    putstr("HPRT:");
     puth(USBx_HOST_PORT->HPRT);
-    puts("\n");
+    putstr("\n");
     if (USBx_HOST_PORT->HPRT & USB_OTG_HPRT_PCDET) {
       USBx_HOST_PORT->HPRT |= USB_OTG_HPRT_PRST;
       USBx_HOST_PORT->HPRT |= USB_OTG_HPRT_PCDET;
@@ -769,16 +769,16 @@ void usb_irqhandler(void) {
   if ((gintsts & USB_OTG_GINTSTS_BOUTNAKEFF) || (gintsts & USB_OTG_GINTSTS_GINAKEFF)) {
     // no global NAK, why is this getting set?
     #ifdef DEBUG_USB
-      puts("GLOBAL NAK\n");
+      putstr("GLOBAL NAK\n");
     #endif
     USBx_DEVICE->DCTL |= USB_OTG_DCTL_CGONAK | USB_OTG_DCTL_CGINAK;
   }
 
   if ((gintsts & USB_OTG_GINTSTS_SRQINT) != 0) {
     // we want to do "A-device host negotiation protocol" since we are the A-device
-    /*puts("start request\n");
+    /*putstr("start request\n");
     puth(USBx->GOTGCTL);
-    puts("\n");*/
+    putstr("\n");*/
     //USBx->GUSBCFG |= USB_OTG_GUSBCFG_FDMOD;
     //USBx_HOST_PORT->HPRT = USB_OTG_HPRT_PPWR | USB_OTG_HPRT_PENA;
     //USBx->GOTGCTL |= USB_OTG_GOTGCTL_SRQ;
@@ -787,22 +787,22 @@ void usb_irqhandler(void) {
   // out endpoint hit
   if ((gintsts & USB_OTG_GINTSTS_OEPINT) != 0) {
     #ifdef DEBUG_USB
-      puts("  0:");
+      putstr("  0:");
       puth(USBx_OUTEP(0)->DOEPINT);
-      puts(" 2:");
+      putstr(" 2:");
       puth(USBx_OUTEP(2)->DOEPINT);
-      puts(" 3:");
+      putstr(" 3:");
       puth(USBx_OUTEP(3)->DOEPINT);
-      puts(" ");
+      putstr(" ");
       puth(USBx_OUTEP(3)->DOEPCTL);
-      puts(" 4:");
+      putstr(" 4:");
       puth(USBx_OUTEP(4)->DOEPINT);
-      puts(" OUT ENDPOINT\n");
+      putstr(" OUT ENDPOINT\n");
     #endif
 
     if ((USBx_OUTEP(2)->DOEPINT & USB_OTG_DOEPINT_XFRC) != 0) {
       #ifdef DEBUG_USB
-        puts("  OUT2 PACKET XFRC\n");
+        putstr("  OUT2 PACKET XFRC\n");
       #endif
       USBx_OUTEP(2)->DOEPTSIZ = (1U << 19) | 0x40U;
       USBx_OUTEP(2)->DOEPCTL |= USB_OTG_DOEPCTL_EPENA | USB_OTG_DOEPCTL_CNAK;
@@ -810,14 +810,14 @@ void usb_irqhandler(void) {
 
     if ((USBx_OUTEP(3)->DOEPINT & USB_OTG_DOEPINT_XFRC) != 0) {
       #ifdef DEBUG_USB
-        puts("  OUT3 PACKET XFRC\n");
+        putstr("  OUT3 PACKET XFRC\n");
       #endif
       // NAK cleared by process_can (if tx buffers have room)
       outep3_processing = false;
       usb_cb_ep3_out_complete();
     } else if ((USBx_OUTEP(3)->DOEPINT & 0x2000) != 0) {
       #ifdef DEBUG_USB
-        puts("  OUT3 PACKET WTF\n");
+        putstr("  OUT3 PACKET WTF\n");
       #endif
       // if NAK was set trigger this, unknown interrupt
       // TODO: why was this here? fires when TX buffers when we can't clear NAK
@@ -825,9 +825,9 @@ void usb_irqhandler(void) {
       // USBx_OUTEP(3)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
     } else if ((USBx_OUTEP(3)->DOEPINT) != 0) {
       #ifdef DEBUG_USB
-        puts("OUTEP3 error ");
+        putstr("OUTEP3 error ");
         puth(USBx_OUTEP(3)->DOEPINT);
-        puts("\n");
+        putstr("\n");
       #endif
     } else {
       // USBx_OUTEP(3)->DOEPINT is 0, ok to skip
@@ -851,11 +851,11 @@ void usb_irqhandler(void) {
   // interrupt endpoint hit (Page 1221)
   if ((gintsts & USB_OTG_GINTSTS_IEPINT) != 0) {
     #ifdef DEBUG_USB
-      puts("  ");
+      putstr("  ");
       puth(USBx_INEP(0)->DIEPINT);
-      puts(" ");
+      putstr(" ");
       puth(USBx_INEP(1)->DIEPINT);
-      puts(" IN ENDPOINT\n");
+      putstr(" IN ENDPOINT\n");
     #endif
 
     // Should likely check the EP of the IN request even if there is
@@ -876,7 +876,7 @@ void usb_irqhandler(void) {
         // *** IN token received when TxFIFO is empty
         if ((USBx_INEP(1)->DIEPINT & USB_OTG_DIEPMSK_ITTXFEMSK) != 0) {
           #ifdef DEBUG_USB
-          puts("  IN PACKET QUEUE\n");
+          putstr("  IN PACKET QUEUE\n");
           #endif
           // TODO: always assuming max len, can we get the length?
           USB_WritePacket((void *)resp, comms_can_read(resp, 0x40), 1);
@@ -887,7 +887,7 @@ void usb_irqhandler(void) {
         // *** IN token received when TxFIFO is empty
         if ((USBx_INEP(1)->DIEPINT & USB_OTG_DIEPMSK_ITTXFEMSK) != 0) {
           #ifdef DEBUG_USB
-          puts("  IN PACKET QUEUE\n");
+          putstr("  IN PACKET QUEUE\n");
           #endif
           // TODO: always assuming max len, can we get the length?
           int len = comms_can_read(resp, 0x40);
@@ -897,13 +897,13 @@ void usb_irqhandler(void) {
         }
         break;
       default:
-        puts("current_int0_alt_setting value invalid\n");
+        putstr("current_int0_alt_setting value invalid\n");
         break;
     }
 
     if ((USBx_INEP(0)->DIEPINT & USB_OTG_DIEPMSK_ITTXFEMSK) != 0) {
       #ifdef DEBUG_USB
-      puts("  IN PACKET QUEUE\n");
+      putstr("  IN PACKET QUEUE\n");
       #endif
 
       if ((ep0_txlen != 0U) && ((USBx_INEP(0)->DTXFSTS & USB_OTG_DTXFSTS_INEPTFSAV) >= 0x40U)) {

--- a/board/faults.h
+++ b/board/faults.h
@@ -38,10 +38,10 @@ uint32_t faults = 0U;
 void fault_occurred(uint32_t fault) {
   faults |= fault;
   if((PERMANENT_FAULTS & fault) != 0U){
-    putstr("Permanent fault occurred: 0x"); puth(fault); putstr("\n");
+    print("Permanent fault occurred: 0x"); puth(fault); print("\n");
     fault_status = FAULT_STATUS_PERMANENT;
   } else {
-    putstr("Temporary fault occurred: 0x"); puth(fault); putstr("\n");
+    print("Temporary fault occurred: 0x"); puth(fault); print("\n");
     fault_status = FAULT_STATUS_TEMPORARY;
   }
 }
@@ -50,6 +50,6 @@ void fault_recovered(uint32_t fault) {
   if((PERMANENT_FAULTS & fault) == 0U){
     faults &= ~fault;
   } else {
-    putstr("Cannot recover from a permanent fault!\n");
+    print("Cannot recover from a permanent fault!\n");
   }
 }

--- a/board/faults.h
+++ b/board/faults.h
@@ -38,10 +38,10 @@ uint32_t faults = 0U;
 void fault_occurred(uint32_t fault) {
   faults |= fault;
   if((PERMANENT_FAULTS & fault) != 0U){
-    puts("Permanent fault occurred: 0x"); puth(fault); puts("\n");
+    putstr("Permanent fault occurred: 0x"); puth(fault); putstr("\n");
     fault_status = FAULT_STATUS_PERMANENT;
   } else {
-    puts("Temporary fault occurred: 0x"); puth(fault); puts("\n");
+    putstr("Temporary fault occurred: 0x"); puth(fault); putstr("\n");
     fault_status = FAULT_STATUS_TEMPORARY;
   }
 }
@@ -50,6 +50,6 @@ void fault_recovered(uint32_t fault) {
   if((PERMANENT_FAULTS & fault) == 0U){
     faults &= ~fault;
   } else {
-    puts("Cannot recover from a permanent fault!\n");
+    putstr("Cannot recover from a permanent fault!\n");
   }
 }

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -59,12 +59,12 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       // this allows reflashing of the bootstub
       switch (req->param1) {
         case 0:
-          puts("-> entering bootloader\n");
+          putstr("-> entering bootloader\n");
           enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
           NVIC_SystemReset();
           break;
         case 1:
-          puts("-> entering softloader\n");
+          putstr("-> entering softloader\n");
           enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
           NVIC_SystemReset();
           break;
@@ -256,7 +256,7 @@ void soft_flasher_start(void) {
     REGISTER_INTERRUPT(CAN1_SCE_IRQn, CAN1_SCE_IRQ_Handler, CAN_INTERRUPT_RATE, FAULT_INTERRUPT_RATE_CAN_1)
   #endif
 
-  puts("\n\n\n************************ FLASHER START ************************\n");
+  putstr("\n\n\n************************ FLASHER START ************************\n");
 
   enter_bootloader_mode = 0;
 

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -59,12 +59,12 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       // this allows reflashing of the bootstub
       switch (req->param1) {
         case 0:
-          putstr("-> entering bootloader\n");
+          print("-> entering bootloader\n");
           enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
           NVIC_SystemReset();
           break;
         case 1:
-          putstr("-> entering softloader\n");
+          print("-> entering softloader\n");
           enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
           NVIC_SystemReset();
           break;
@@ -256,7 +256,7 @@ void soft_flasher_start(void) {
     REGISTER_INTERRUPT(CAN1_SCE_IRQn, CAN1_SCE_IRQ_Handler, CAN_INTERRUPT_RATE, FAULT_INTERRUPT_RATE_CAN_1)
   #endif
 
-  putstr("\n\n\n************************ FLASHER START ************************\n");
+  print("\n\n\n************************ FLASHER START ************************\n");
 
   enter_bootloader_mode = 0;
 

--- a/board/main.c
+++ b/board/main.c
@@ -63,11 +63,11 @@ void set_safety_mode(uint16_t mode, uint16_t param) {
   uint16_t mode_copy = mode;
   int err = set_safety_hooks(mode_copy, param);
   if (err == -1) {
-    putstr("Error: safety set mode failed. Falling back to SILENT\n");
+    print("Error: safety set mode failed. Falling back to SILENT\n");
     mode_copy = SAFETY_SILENT;
     err = set_safety_hooks(mode_copy, 0U);
     if (err == -1) {
-      putstr("Error: Failed setting SILENT mode. Hanging\n");
+      print("Error: Failed setting SILENT mode. Hanging\n");
       while (true) {
         // TERMINAL ERROR: we can't continue if SILENT safety mode isn't succesfully set
       }
@@ -154,18 +154,18 @@ void tick_handler(void) {
     if (loop_counter == 0U) {
       can_live = pending_can_live;
 
-      //puth(usart1_dma); putstr(" "); puth(DMA2_Stream5->M0AR); putstr(" "); puth(DMA2_Stream5->NDTR); putstr("\n");
+      //puth(usart1_dma); print(" "); puth(DMA2_Stream5->M0AR); print(" "); puth(DMA2_Stream5->NDTR); print("\n");
 
       // reset this every 16th pass
       if ((uptime_cnt & 0xFU) == 0U) {
         pending_can_live = 0;
       }
       #ifdef DEBUG
-        putstr("** blink ");
-        putstr("rx:"); puth4(can_rx_q.r_ptr); putstr("-"); puth4(can_rx_q.w_ptr); putstr("  ");
-        putstr("tx1:"); puth4(can_tx1_q.r_ptr); putstr("-"); puth4(can_tx1_q.w_ptr); putstr("  ");
-        putstr("tx2:"); puth4(can_tx2_q.r_ptr); putstr("-"); puth4(can_tx2_q.w_ptr); putstr("  ");
-        putstr("tx3:"); puth4(can_tx3_q.r_ptr); putstr("-"); puth4(can_tx3_q.w_ptr); putstr("\n");
+        print("** blink ");
+        print("rx:"); puth4(can_rx_q.r_ptr); print("-"); puth4(can_rx_q.w_ptr); print("  ");
+        print("tx1:"); puth4(can_tx1_q.r_ptr); print("-"); puth4(can_tx1_q.w_ptr); print("  ");
+        print("tx2:"); puth4(can_tx2_q.r_ptr); print("-"); puth4(can_tx2_q.w_ptr); print("  ");
+        print("tx3:"); puth4(can_tx3_q.r_ptr); print("-"); puth4(can_tx3_q.w_ptr); print("\n");
       #endif
 
       // set green LED to be controls allowed
@@ -214,9 +214,9 @@ void tick_handler(void) {
       if (!heartbeat_disabled) {
         // if the heartbeat has been gone for a while, go to SILENT safety mode and enter power save
         if (heartbeat_counter >= (check_started() ? HEARTBEAT_IGNITION_CNT_ON : HEARTBEAT_IGNITION_CNT_OFF)) {
-          putstr("device hasn't sent a heartbeat for 0x");
+          print("device hasn't sent a heartbeat for 0x");
           puth(heartbeat_counter);
-          putstr(" seconds. Safety is set to SILENT mode.\n");
+          print(" seconds. Safety is set to SILENT mode.\n");
 
           if (controls_allowed_countdown > 0U) {
             siren_countdown = 5U;
@@ -318,16 +318,16 @@ int main(void) {
   adc_init();
 
   // print hello
-  putstr("\n\n\n************************ MAIN START ************************\n");
+  print("\n\n\n************************ MAIN START ************************\n");
 
   // check for non-supported board types
   if(hw_type == HW_TYPE_UNKNOWN){
-    putstr("Unsupported board type\n");
+    print("Unsupported board type\n");
     while (1) { /* hang */ }
   }
 
-  putstr("Config:\n");
-  putstr("  Board type: "); putstr(current_board->board_type); putstr("\n");
+  print("Config:\n");
+  print("  Board type: "); print(current_board->board_type); print("\n");
 
   // init board
   current_board->init();
@@ -367,7 +367,7 @@ int main(void) {
   tick_timer_init();
 
 #ifdef DEBUG
-  putstr("DEBUG ENABLED\n");
+  print("DEBUG ENABLED\n");
 #endif
   // enable USB (right before interrupts or enum can fail!)
   usb_init();
@@ -378,7 +378,7 @@ int main(void) {
   }
 #endif
 
-  putstr("**** INTERRUPTS ON ****\n");
+  print("**** INTERRUPTS ON ****\n");
   enable_interrupts();
 
   // LED should keep on blinking all the time

--- a/board/main.c
+++ b/board/main.c
@@ -63,11 +63,11 @@ void set_safety_mode(uint16_t mode, uint16_t param) {
   uint16_t mode_copy = mode;
   int err = set_safety_hooks(mode_copy, param);
   if (err == -1) {
-    puts("Error: safety set mode failed. Falling back to SILENT\n");
+    putstr("Error: safety set mode failed. Falling back to SILENT\n");
     mode_copy = SAFETY_SILENT;
     err = set_safety_hooks(mode_copy, 0U);
     if (err == -1) {
-      puts("Error: Failed setting SILENT mode. Hanging\n");
+      putstr("Error: Failed setting SILENT mode. Hanging\n");
       while (true) {
         // TERMINAL ERROR: we can't continue if SILENT safety mode isn't succesfully set
       }
@@ -154,18 +154,18 @@ void tick_handler(void) {
     if (loop_counter == 0U) {
       can_live = pending_can_live;
 
-      //puth(usart1_dma); puts(" "); puth(DMA2_Stream5->M0AR); puts(" "); puth(DMA2_Stream5->NDTR); puts("\n");
+      //puth(usart1_dma); putstr(" "); puth(DMA2_Stream5->M0AR); putstr(" "); puth(DMA2_Stream5->NDTR); putstr("\n");
 
       // reset this every 16th pass
       if ((uptime_cnt & 0xFU) == 0U) {
         pending_can_live = 0;
       }
       #ifdef DEBUG
-        puts("** blink ");
-        puts("rx:"); puth4(can_rx_q.r_ptr); puts("-"); puth4(can_rx_q.w_ptr); puts("  ");
-        puts("tx1:"); puth4(can_tx1_q.r_ptr); puts("-"); puth4(can_tx1_q.w_ptr); puts("  ");
-        puts("tx2:"); puth4(can_tx2_q.r_ptr); puts("-"); puth4(can_tx2_q.w_ptr); puts("  ");
-        puts("tx3:"); puth4(can_tx3_q.r_ptr); puts("-"); puth4(can_tx3_q.w_ptr); puts("\n");
+        putstr("** blink ");
+        putstr("rx:"); puth4(can_rx_q.r_ptr); putstr("-"); puth4(can_rx_q.w_ptr); putstr("  ");
+        putstr("tx1:"); puth4(can_tx1_q.r_ptr); putstr("-"); puth4(can_tx1_q.w_ptr); putstr("  ");
+        putstr("tx2:"); puth4(can_tx2_q.r_ptr); putstr("-"); puth4(can_tx2_q.w_ptr); putstr("  ");
+        putstr("tx3:"); puth4(can_tx3_q.r_ptr); putstr("-"); puth4(can_tx3_q.w_ptr); putstr("\n");
       #endif
 
       // set green LED to be controls allowed
@@ -214,9 +214,9 @@ void tick_handler(void) {
       if (!heartbeat_disabled) {
         // if the heartbeat has been gone for a while, go to SILENT safety mode and enter power save
         if (heartbeat_counter >= (check_started() ? HEARTBEAT_IGNITION_CNT_ON : HEARTBEAT_IGNITION_CNT_OFF)) {
-          puts("device hasn't sent a heartbeat for 0x");
+          putstr("device hasn't sent a heartbeat for 0x");
           puth(heartbeat_counter);
-          puts(" seconds. Safety is set to SILENT mode.\n");
+          putstr(" seconds. Safety is set to SILENT mode.\n");
 
           if (controls_allowed_countdown > 0U) {
             siren_countdown = 5U;
@@ -318,16 +318,16 @@ int main(void) {
   adc_init();
 
   // print hello
-  puts("\n\n\n************************ MAIN START ************************\n");
+  putstr("\n\n\n************************ MAIN START ************************\n");
 
   // check for non-supported board types
   if(hw_type == HW_TYPE_UNKNOWN){
-    puts("Unsupported board type\n");
+    putstr("Unsupported board type\n");
     while (1) { /* hang */ }
   }
 
-  puts("Config:\n");
-  puts("  Board type: "); puts(current_board->board_type); puts("\n");
+  putstr("Config:\n");
+  putstr("  Board type: "); putstr(current_board->board_type); putstr("\n");
 
   // init board
   current_board->init();
@@ -367,7 +367,7 @@ int main(void) {
   tick_timer_init();
 
 #ifdef DEBUG
-  puts("DEBUG ENABLED\n");
+  putstr("DEBUG ENABLED\n");
 #endif
   // enable USB (right before interrupts or enum can fail!)
   usb_init();
@@ -378,7 +378,7 @@ int main(void) {
   }
 #endif
 
-  puts("**** INTERRUPTS ON ****\n");
+  putstr("**** INTERRUPTS ON ****\n");
   enable_interrupts();
 
   // LED should keep on blinking all the time

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -178,10 +178,10 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
   timestamp_t t;
 
 #ifdef DEBUG_COMMS
-  putstr("raw control request: "); hexdump(req, sizeof(ControlPacket_t)); putstr("\n");
-  putstr("- request "); puth(req->request); putstr("\n");
-  putstr("- param1 "); puth(req->param1); putstr("\n");
-  putstr("- param2 "); puth(req->param2); putstr("\n");
+  print("raw control request: "); hexdump(req, sizeof(ControlPacket_t)); print("\n");
+  print("- request "); puth(req->request); print("\n");
+  print("- param1 "); puth(req->param1); print("\n");
+  print("- param2 "); puth(req->param2); print("\n");
 #endif
 
   switch (req->request) {
@@ -284,18 +284,18 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
         case 0:
           // only allow bootloader entry on debug builds
           #ifdef ALLOW_DEBUG
-            putstr("-> entering bootloader\n");
+            print("-> entering bootloader\n");
             enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
             NVIC_SystemReset();
           #endif
           break;
         case 1:
-          putstr("-> entering softloader\n");
+          print("-> entering softloader\n");
           enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
           NVIC_SystemReset();
           break;
         default:
-          putstr("Bootloader mode invalid\n");
+          print("Bootloader mode invalid\n");
           break;
       }
       break;
@@ -371,7 +371,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
           } else if (req->param2 == 2U) {
             can_set_gmlan(2);
           } else {
-            putstr("Invalid bus num for GMLAN CAN set\n");
+            print("Invalid bus num for GMLAN CAN set\n");
           }
         } else {
           can_set_gmlan(-1);
@@ -486,13 +486,13 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
     // **** 0xf1: Clear CAN ring buffer.
     case 0xf1:
       if (req->param1 == 0xFFFFU) {
-        putstr("Clearing CAN Rx queue\n");
+        print("Clearing CAN Rx queue\n");
         can_clear(&can_rx_q);
       } else if (req->param1 < PANDA_BUS_CNT) {
-        putstr("Clearing CAN Tx queue\n");
+        print("Clearing CAN Tx queue\n");
         can_clear(can_queues[req->param1]);
       } else {
-        putstr("Clearing CAN CAN ring buffer failed: wrong bus number\n");
+        print("Clearing CAN CAN ring buffer failed: wrong bus number\n");
       }
       break;
     // **** 0xf2: Clear UART ring buffer.
@@ -500,7 +500,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       {
         uart_ring * rb = get_ring_by_number(req->param1);
         if (rb != NULL) {
-          putstr("Clearing UART queue.\n");
+          print("Clearing UART queue.\n");
           clear_uart_buff(rb);
         }
         break;
@@ -564,9 +564,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       }
       break;
     default:
-      putstr("NO HANDLER ");
+      print("NO HANDLER ");
       puth(req->request);
-      putstr("\n");
+      print("\n");
       break;
   }
   return resp_len;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -178,10 +178,10 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
   timestamp_t t;
 
 #ifdef DEBUG_COMMS
-  puts("raw control request: "); hexdump(req, sizeof(ControlPacket_t)); puts("\n");
-  puts("- request "); puth(req->request); puts("\n");
-  puts("- param1 "); puth(req->param1); puts("\n");
-  puts("- param2 "); puth(req->param2); puts("\n");
+  putstr("raw control request: "); hexdump(req, sizeof(ControlPacket_t)); putstr("\n");
+  putstr("- request "); puth(req->request); putstr("\n");
+  putstr("- param1 "); puth(req->param1); putstr("\n");
+  putstr("- param2 "); puth(req->param2); putstr("\n");
 #endif
 
   switch (req->request) {
@@ -284,18 +284,18 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
         case 0:
           // only allow bootloader entry on debug builds
           #ifdef ALLOW_DEBUG
-            puts("-> entering bootloader\n");
+            putstr("-> entering bootloader\n");
             enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
             NVIC_SystemReset();
           #endif
           break;
         case 1:
-          puts("-> entering softloader\n");
+          putstr("-> entering softloader\n");
           enter_bootloader_mode = ENTER_SOFTLOADER_MAGIC;
           NVIC_SystemReset();
           break;
         default:
-          puts("Bootloader mode invalid\n");
+          putstr("Bootloader mode invalid\n");
           break;
       }
       break;
@@ -371,7 +371,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
           } else if (req->param2 == 2U) {
             can_set_gmlan(2);
           } else {
-            puts("Invalid bus num for GMLAN CAN set\n");
+            putstr("Invalid bus num for GMLAN CAN set\n");
           }
         } else {
           can_set_gmlan(-1);
@@ -486,13 +486,13 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
     // **** 0xf1: Clear CAN ring buffer.
     case 0xf1:
       if (req->param1 == 0xFFFFU) {
-        puts("Clearing CAN Rx queue\n");
+        putstr("Clearing CAN Rx queue\n");
         can_clear(&can_rx_q);
       } else if (req->param1 < PANDA_BUS_CNT) {
-        puts("Clearing CAN Tx queue\n");
+        putstr("Clearing CAN Tx queue\n");
         can_clear(can_queues[req->param1]);
       } else {
-        puts("Clearing CAN CAN ring buffer failed: wrong bus number\n");
+        putstr("Clearing CAN CAN ring buffer failed: wrong bus number\n");
       }
       break;
     // **** 0xf2: Clear UART ring buffer.
@@ -500,7 +500,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       {
         uart_ring * rb = get_ring_by_number(req->param1);
         if (rb != NULL) {
-          puts("Clearing UART queue.\n");
+          putstr("Clearing UART queue.\n");
           clear_uart_buff(rb);
         }
         break;
@@ -564,9 +564,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       }
       break;
     default:
-      puts("NO HANDLER ");
+      putstr("NO HANDLER ");
       puth(req->request);
-      puts("\n");
+      putstr("\n");
       break;
   }
   return resp_len;

--- a/board/main_declarations.h
+++ b/board/main_declarations.h
@@ -1,5 +1,5 @@
 // ******************** Prototypes ********************
-void puts(const char *a);
+void putstr(const char *a);
 void puth(unsigned int i);
 void puth2(unsigned int i);
 void puth4(unsigned int i);

--- a/board/main_declarations.h
+++ b/board/main_declarations.h
@@ -1,5 +1,5 @@
 // ******************** Prototypes ********************
-void putstr(const char *a);
+void print(const char *a);
 void puth(unsigned int i);
 void puth2(unsigned int i);
 void puth4(unsigned int i);

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -11,7 +11,7 @@
   #include "drivers/usb.h"
 #else
   // no serial either
-  void putstr(const char *a) {
+  void print(const char *a) {
     UNUSED(a);
   }
   void puth(unsigned int i) {
@@ -78,9 +78,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       }
       break;
     default:
-      putstr("NO HANDLER ");
+      print("NO HANDLER ");
       puth(req->request);
-      putstr("\n");
+      print("\n");
       break;
   }
   return resp_len;
@@ -122,7 +122,7 @@ const uint8_t crc_poly = 0xD5U;  // standard crc8
 void CAN1_RX0_IRQ_Handler(void) {
   while ((CAN->RF0R & CAN_RF0R_FMP0) != 0) {
     #ifdef DEBUG
-      putstr("CAN RX\n");
+      print("CAN RX\n");
     #endif
     int address = CAN->sFIFOMailBox[0].RIR >> 21;
     if (address == CAN_GAS_INPUT) {
@@ -135,7 +135,7 @@ void CAN1_RX0_IRQ_Handler(void) {
           enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
           NVIC_SystemReset();
         } else {
-          putstr("Failed entering Softloader or Bootloader\n");
+          print("Failed entering Softloader or Bootloader\n");
         }
       }
 
@@ -151,9 +151,9 @@ void CAN1_RX0_IRQ_Handler(void) {
       if (crc_checksum(dat, CAN_GAS_SIZE - 1, crc_poly) == dat[5]) {
         if (((current_index + 1U) & COUNTER_CYCLE) == index) {
           #ifdef DEBUG
-            putstr("setting gas ");
+            print("setting gas ");
             puth(value_0);
-            putstr("\n");
+            print("\n");
           #endif
           if (enable) {
             gas_set_0 = value_0;
@@ -196,11 +196,11 @@ int led_value = 0;
 void TIM3_IRQ_Handler(void) {
   #ifdef DEBUG
     puth(TIM3->CNT);
-    putstr(" ");
+    print(" ");
     puth(pdl0);
-    putstr(" ");
+    print(" ");
     puth(pdl1);
-    putstr("\n");
+    print("\n");
   #endif
 
   // check timer for sending the user pedal and clearing the CAN
@@ -222,7 +222,7 @@ void TIM3_IRQ_Handler(void) {
     // old can packet hasn't sent!
     state = FAULT_SEND;
     #ifdef DEBUG
-      putstr("CAN MISS\n");
+      print("CAN MISS\n");
     #endif
   }
 
@@ -292,7 +292,7 @@ int main(void) {
   // init can
   bool llcan_speed_set = llcan_set_speed(CAN1, 5000, false, false);
   if (!llcan_speed_set) {
-    putstr("Failed to set llcan speed");
+    print("Failed to set llcan speed");
   }
 
   bool ret = llcan_init(CAN1);
@@ -304,7 +304,7 @@ int main(void) {
 
   watchdog_init();
 
-  putstr("**** INTERRUPTS ON ****\n");
+  print("**** INTERRUPTS ON ****\n");
   enable_interrupts();
 
   // main pedal loop

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -11,7 +11,7 @@
   #include "drivers/usb.h"
 #else
   // no serial either
-  void puts(const char *a) {
+  void putstr(const char *a) {
     UNUSED(a);
   }
   void puth(unsigned int i) {
@@ -78,9 +78,9 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
       }
       break;
     default:
-      puts("NO HANDLER ");
+      putstr("NO HANDLER ");
       puth(req->request);
-      puts("\n");
+      putstr("\n");
       break;
   }
   return resp_len;
@@ -122,7 +122,7 @@ const uint8_t crc_poly = 0xD5U;  // standard crc8
 void CAN1_RX0_IRQ_Handler(void) {
   while ((CAN->RF0R & CAN_RF0R_FMP0) != 0) {
     #ifdef DEBUG
-      puts("CAN RX\n");
+      putstr("CAN RX\n");
     #endif
     int address = CAN->sFIFOMailBox[0].RIR >> 21;
     if (address == CAN_GAS_INPUT) {
@@ -135,7 +135,7 @@ void CAN1_RX0_IRQ_Handler(void) {
           enter_bootloader_mode = ENTER_BOOTLOADER_MAGIC;
           NVIC_SystemReset();
         } else {
-          puts("Failed entering Softloader or Bootloader\n");
+          putstr("Failed entering Softloader or Bootloader\n");
         }
       }
 
@@ -151,9 +151,9 @@ void CAN1_RX0_IRQ_Handler(void) {
       if (crc_checksum(dat, CAN_GAS_SIZE - 1, crc_poly) == dat[5]) {
         if (((current_index + 1U) & COUNTER_CYCLE) == index) {
           #ifdef DEBUG
-            puts("setting gas ");
+            putstr("setting gas ");
             puth(value_0);
-            puts("\n");
+            putstr("\n");
           #endif
           if (enable) {
             gas_set_0 = value_0;
@@ -196,11 +196,11 @@ int led_value = 0;
 void TIM3_IRQ_Handler(void) {
   #ifdef DEBUG
     puth(TIM3->CNT);
-    puts(" ");
+    putstr(" ");
     puth(pdl0);
-    puts(" ");
+    putstr(" ");
     puth(pdl1);
-    puts("\n");
+    putstr("\n");
   #endif
 
   // check timer for sending the user pedal and clearing the CAN
@@ -222,7 +222,7 @@ void TIM3_IRQ_Handler(void) {
     // old can packet hasn't sent!
     state = FAULT_SEND;
     #ifdef DEBUG
-      puts("CAN MISS\n");
+      putstr("CAN MISS\n");
     #endif
   }
 
@@ -292,7 +292,7 @@ int main(void) {
   // init can
   bool llcan_speed_set = llcan_set_speed(CAN1, 5000, false, false);
   if (!llcan_speed_set) {
-    puts("Failed to set llcan speed");
+    putstr("Failed to set llcan speed");
   }
 
   bool ret = llcan_init(CAN1);
@@ -304,7 +304,7 @@ int main(void) {
 
   watchdog_init();
 
-  puts("**** INTERRUPTS ON ****\n");
+  putstr("**** INTERRUPTS ON ****\n");
   enable_interrupts();
 
   // main pedal loop

--- a/board/pedal/main_declarations.h
+++ b/board/pedal/main_declarations.h
@@ -1,5 +1,5 @@
 // ******************** Prototypes ********************
-void puts(const char *a);
+void putstr(const char *a);
 void puth(unsigned int i);
 void puth2(unsigned int i);
 void puth4(unsigned int i);

--- a/board/pedal/main_declarations.h
+++ b/board/pedal/main_declarations.h
@@ -1,5 +1,5 @@
 // ******************** Prototypes ********************
-void putstr(const char *a);
+void print(const char *a);
 void puth(unsigned int i);
 void puth2(unsigned int i);
 void puth4(unsigned int i);

--- a/board/power_saving.h
+++ b/board/power_saving.h
@@ -12,14 +12,14 @@ void set_power_save_state(int state) {
   if (is_valid_state && (state != power_save_status)) {
     bool enable = false;
     if (state == POWER_SAVE_STATUS_ENABLED) {
-      putstr("enable power savings\n");
+      print("enable power savings\n");
       if (current_board->has_gps) {
         const char UBLOX_SLEEP_MSG[] = "\xb5\x62\x06\x04\x04\x00\x01\x00\x08\x00\x17\x78";
         uart_ring *ur = get_ring_by_number(1);
         for (unsigned int i = 0; i < sizeof(UBLOX_SLEEP_MSG) - 1U; i++) while (!putc(ur, UBLOX_SLEEP_MSG[i]));
       }
     } else {
-      putstr("disable power savings\n");
+      print("disable power savings\n");
       if (current_board->has_gps) {
         const char UBLOX_WAKE_MSG[] = "\xb5\x62\x06\x04\x04\x00\x01\x00\x09\x00\x18\x7a";
         uart_ring *ur = get_ring_by_number(1);

--- a/board/power_saving.h
+++ b/board/power_saving.h
@@ -12,14 +12,14 @@ void set_power_save_state(int state) {
   if (is_valid_state && (state != power_save_status)) {
     bool enable = false;
     if (state == POWER_SAVE_STATUS_ENABLED) {
-      puts("enable power savings\n");
+      putstr("enable power savings\n");
       if (current_board->has_gps) {
         const char UBLOX_SLEEP_MSG[] = "\xb5\x62\x06\x04\x04\x00\x01\x00\x08\x00\x17\x78";
         uart_ring *ur = get_ring_by_number(1);
         for (unsigned int i = 0; i < sizeof(UBLOX_SLEEP_MSG) - 1U; i++) while (!putc(ur, UBLOX_SLEEP_MSG[i]));
       }
     } else {
-      puts("disable power savings\n");
+      putstr("disable power savings\n");
       if (current_board->has_gps) {
         const char UBLOX_WAKE_MSG[] = "\xb5\x62\x06\x04\x04\x00\x01\x00\x09\x00\x18\x7a";
         uart_ring *ur = get_ring_by_number(1);

--- a/board/stm32fx/board.h
+++ b/board/stm32fx/board.h
@@ -48,7 +48,7 @@ void detect_board_type(void) {
       current_board = &board_pedal;
     #else
       hw_type = HW_TYPE_UNKNOWN;
-      puts("Hardware type is UNKNOWN!\n");
+      putstr("Hardware type is UNKNOWN!\n");
     #endif
   #endif
 }

--- a/board/stm32fx/board.h
+++ b/board/stm32fx/board.h
@@ -48,7 +48,7 @@ void detect_board_type(void) {
       current_board = &board_pedal;
     #else
       hw_type = HW_TYPE_UNKNOWN;
-      putstr("Hardware type is UNKNOWN!\n");
+      print("Hardware type is UNKNOWN!\n");
     #endif
   #endif
 }

--- a/board/stm32fx/clock_source.h
+++ b/board/stm32fx/clock_source.h
@@ -92,7 +92,7 @@ void clock_source_init(uint8_t mode){
       clock_source_mode = CLOCK_SOURCE_MODE_PWM;
       break;
     default:
-      puts("Unknown clock source mode: "); puth(mode); puts("\n");
+      putstr("Unknown clock source mode: "); puth(mode); putstr("\n");
       break;
   }
 }

--- a/board/stm32fx/clock_source.h
+++ b/board/stm32fx/clock_source.h
@@ -92,7 +92,7 @@ void clock_source_init(uint8_t mode){
       clock_source_mode = CLOCK_SOURCE_MODE_PWM;
       break;
     default:
-      putstr("Unknown clock source mode: "); puth(mode); putstr("\n");
+      print("Unknown clock source mode: "); puth(mode); print("\n");
       break;
   }
 }

--- a/board/stm32fx/llbxcan.h
+++ b/board/stm32fx/llbxcan.h
@@ -16,7 +16,7 @@
 
 #define CAN_NAME_FROM_CANIF(CAN_DEV) (((CAN_DEV)==CAN1) ? "CAN1" : (((CAN_DEV) == CAN2) ? "CAN2" : "CAN3"))
 
-void puts(const char *a);
+void putstr(const char *a);
 
 // kbps multiplied by 10
 const uint32_t speeds[] = {100U, 200U, 500U, 1000U, 1250U, 2500U, 5000U, 10000U};
@@ -34,7 +34,7 @@ bool llcan_set_speed(CAN_TypeDef *CAN_obj, uint32_t speed, bool loopback, bool s
     timeout_counter++;
 
     if(timeout_counter >= CAN_INIT_TIMEOUT_MS){
-      puts(CAN_NAME_FROM_CANIF(CAN_obj)); puts(" set_speed timed out (1)!\n");
+      putstr(CAN_NAME_FROM_CANIF(CAN_obj)); putstr(" set_speed timed out (1)!\n");
       ret = false;
       break;
     }
@@ -65,7 +65,7 @@ bool llcan_set_speed(CAN_TypeDef *CAN_obj, uint32_t speed, bool loopback, bool s
       timeout_counter++;
 
       if(timeout_counter >= CAN_INIT_TIMEOUT_MS){
-        puts(CAN_NAME_FROM_CANIF(CAN_obj)); puts(" set_speed timed out (2)!\n");
+        putstr(CAN_NAME_FROM_CANIF(CAN_obj)); putstr(" set_speed timed out (2)!\n");
         ret = false;
         break;
       }
@@ -89,7 +89,7 @@ bool llcan_init(CAN_TypeDef *CAN_obj) {
     timeout_counter++;
 
     if(timeout_counter >= CAN_INIT_TIMEOUT_MS){
-      puts(CAN_NAME_FROM_CANIF(CAN_obj)); puts(" initialization timed out!\n");
+      putstr(CAN_NAME_FROM_CANIF(CAN_obj)); putstr(" initialization timed out!\n");
       ret = false;
       break;
     }
@@ -125,7 +125,7 @@ bool llcan_init(CAN_TypeDef *CAN_obj) {
         NVIC_EnableIRQ(CAN3_SCE_IRQn);
     #endif
     } else {
-      puts("Invalid CAN: initialization failed\n");
+      putstr("Invalid CAN: initialization failed\n");
     }
   }
   return ret;

--- a/board/stm32fx/llbxcan.h
+++ b/board/stm32fx/llbxcan.h
@@ -16,7 +16,7 @@
 
 #define CAN_NAME_FROM_CANIF(CAN_DEV) (((CAN_DEV)==CAN1) ? "CAN1" : (((CAN_DEV) == CAN2) ? "CAN2" : "CAN3"))
 
-void putstr(const char *a);
+void print(const char *a);
 
 // kbps multiplied by 10
 const uint32_t speeds[] = {100U, 200U, 500U, 1000U, 1250U, 2500U, 5000U, 10000U};
@@ -34,7 +34,7 @@ bool llcan_set_speed(CAN_TypeDef *CAN_obj, uint32_t speed, bool loopback, bool s
     timeout_counter++;
 
     if(timeout_counter >= CAN_INIT_TIMEOUT_MS){
-      putstr(CAN_NAME_FROM_CANIF(CAN_obj)); putstr(" set_speed timed out (1)!\n");
+      print(CAN_NAME_FROM_CANIF(CAN_obj)); print(" set_speed timed out (1)!\n");
       ret = false;
       break;
     }
@@ -65,7 +65,7 @@ bool llcan_set_speed(CAN_TypeDef *CAN_obj, uint32_t speed, bool loopback, bool s
       timeout_counter++;
 
       if(timeout_counter >= CAN_INIT_TIMEOUT_MS){
-        putstr(CAN_NAME_FROM_CANIF(CAN_obj)); putstr(" set_speed timed out (2)!\n");
+        print(CAN_NAME_FROM_CANIF(CAN_obj)); print(" set_speed timed out (2)!\n");
         ret = false;
         break;
       }
@@ -89,7 +89,7 @@ bool llcan_init(CAN_TypeDef *CAN_obj) {
     timeout_counter++;
 
     if(timeout_counter >= CAN_INIT_TIMEOUT_MS){
-      putstr(CAN_NAME_FROM_CANIF(CAN_obj)); putstr(" initialization timed out!\n");
+      print(CAN_NAME_FROM_CANIF(CAN_obj)); print(" initialization timed out!\n");
       ret = false;
       break;
     }
@@ -125,7 +125,7 @@ bool llcan_init(CAN_TypeDef *CAN_obj) {
         NVIC_EnableIRQ(CAN3_SCE_IRQn);
     #endif
     } else {
-      putstr("Invalid CAN: initialization failed\n");
+      print("Invalid CAN: initialization failed\n");
     }
   }
   return ret;

--- a/board/stm32fx/lldac.h
+++ b/board/stm32fx/lldac.h
@@ -11,6 +11,6 @@ void dac_set(int channel, uint32_t value) {
   } else if (channel == 1) {
     register_set(&(DAC->DHR12R2), value, 0xFFFU);
   } else {
-    putstr("Failed to set DAC: invalid channel value: 0x"); puth(value); putstr("\n");
+    print("Failed to set DAC: invalid channel value: 0x"); puth(value); print("\n");
   }
 }

--- a/board/stm32fx/lldac.h
+++ b/board/stm32fx/lldac.h
@@ -11,6 +11,6 @@ void dac_set(int channel, uint32_t value) {
   } else if (channel == 1) {
     register_set(&(DAC->DHR12R2), value, 0xFFFU);
   } else {
-    puts("Failed to set DAC: invalid channel value: 0x"); puth(value); puts("\n");
+    putstr("Failed to set DAC: invalid channel value: 0x"); puth(value); putstr("\n");
   }
 }

--- a/board/stm32fx/lluart.h
+++ b/board/stm32fx/lluart.h
@@ -93,7 +93,7 @@ void uart_interrupt_handler(uart_ring *q) {
   uint32_t err = (status & USART_SR_ORE) | (status & USART_SR_NE) | (status & USART_SR_FE) | (status & USART_SR_PE);
   if(err != 0U){
     #ifdef DEBUG_UART
-      putstr("Encountered UART error: "); puth(err); putstr("\n");
+      print("Encountered UART error: "); puth(err); print("\n");
     #endif
     UART_READ_DR(q->uart)
   }
@@ -109,7 +109,7 @@ void uart_interrupt_handler(uart_ring *q) {
       dma_pointer_handler(&uart_ring_gps, DMA2_Stream5->NDTR);
     } else {
       #ifdef DEBUG_UART
-        putstr("No IDLE dma_pointer_handler implemented for this UART.");
+        print("No IDLE dma_pointer_handler implemented for this UART.");
       #endif
     }
   }
@@ -128,7 +128,7 @@ void DMA2_Stream5_IRQ_Handler(void) {
   // Handle errors
   if((DMA2->HISR & DMA_HISR_TEIF5) || (DMA2->HISR & DMA_HISR_DMEIF5) || (DMA2->HISR & DMA_HISR_FEIF5)){
     #ifdef DEBUG_UART
-      putstr("Encountered UART DMA error. Clearing and restarting DMA...\n");
+      print("Encountered UART DMA error. Clearing and restarting DMA...\n");
     #endif
 
     // Clear flags
@@ -173,7 +173,7 @@ void dma_rx_init(uart_ring *q) {
     // Enable interrupt
     NVIC_EnableIRQ(DMA2_Stream5_IRQn);
   } else {
-    putstr("Tried to initialize RX DMA for an unsupported UART\n");
+    print("Tried to initialize RX DMA for an unsupported UART\n");
   }
 }
 

--- a/board/stm32fx/lluart.h
+++ b/board/stm32fx/lluart.h
@@ -93,7 +93,7 @@ void uart_interrupt_handler(uart_ring *q) {
   uint32_t err = (status & USART_SR_ORE) | (status & USART_SR_NE) | (status & USART_SR_FE) | (status & USART_SR_PE);
   if(err != 0U){
     #ifdef DEBUG_UART
-      puts("Encountered UART error: "); puth(err); puts("\n");
+      putstr("Encountered UART error: "); puth(err); putstr("\n");
     #endif
     UART_READ_DR(q->uart)
   }
@@ -109,7 +109,7 @@ void uart_interrupt_handler(uart_ring *q) {
       dma_pointer_handler(&uart_ring_gps, DMA2_Stream5->NDTR);
     } else {
       #ifdef DEBUG_UART
-        puts("No IDLE dma_pointer_handler implemented for this UART.");
+        putstr("No IDLE dma_pointer_handler implemented for this UART.");
       #endif
     }
   }
@@ -128,7 +128,7 @@ void DMA2_Stream5_IRQ_Handler(void) {
   // Handle errors
   if((DMA2->HISR & DMA_HISR_TEIF5) || (DMA2->HISR & DMA_HISR_DMEIF5) || (DMA2->HISR & DMA_HISR_FEIF5)){
     #ifdef DEBUG_UART
-      puts("Encountered UART DMA error. Clearing and restarting DMA...\n");
+      putstr("Encountered UART DMA error. Clearing and restarting DMA...\n");
     #endif
 
     // Clear flags
@@ -173,7 +173,7 @@ void dma_rx_init(uart_ring *q) {
     // Enable interrupt
     NVIC_EnableIRQ(DMA2_Stream5_IRQn);
   } else {
-    puts("Tried to initialize RX DMA for an unsupported UART\n");
+    putstr("Tried to initialize RX DMA for an unsupported UART\n");
   }
 }
 

--- a/board/stm32fx/llusb.h
+++ b/board/stm32fx/llusb.h
@@ -33,14 +33,14 @@ void usb_init(void) {
 
   // full speed PHY, do reset and remove power down
   /*puth(USBx->GRSTCTL);
-  puts(" resetting PHY\n");*/
+  putstr(" resetting PHY\n");*/
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0);
-  //puts("AHB idle\n");
+  //putstr("AHB idle\n");
 
   // reset PHY here
   USBx->GRSTCTL |= USB_OTG_GRSTCTL_CSRST;
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST);
-  //puts("reset done\n");
+  //putstr("reset done\n");
 
   // internal PHY, force device mode
   USBx->GUSBCFG = USB_OTG_GUSBCFG_PHYSEL | USB_OTG_GUSBCFG_FDMOD;

--- a/board/stm32fx/llusb.h
+++ b/board/stm32fx/llusb.h
@@ -33,14 +33,14 @@ void usb_init(void) {
 
   // full speed PHY, do reset and remove power down
   /*puth(USBx->GRSTCTL);
-  putstr(" resetting PHY\n");*/
+  print(" resetting PHY\n");*/
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_AHBIDL) == 0);
-  //putstr("AHB idle\n");
+  //print("AHB idle\n");
 
   // reset PHY here
   USBx->GRSTCTL |= USB_OTG_GRSTCTL_CSRST;
   while ((USBx->GRSTCTL & USB_OTG_GRSTCTL_CSRST) == USB_OTG_GRSTCTL_CSRST);
-  //putstr("reset done\n");
+  //print("reset done\n");
 
   // internal PHY, force device mode
   USBx->GUSBCFG = USB_OTG_GUSBCFG_PHYSEL | USB_OTG_GUSBCFG_FDMOD;

--- a/board/stm32h7/board.h
+++ b/board/stm32h7/board.h
@@ -37,6 +37,6 @@ void detect_board_type(void) {
     current_board = &board_tres;
   } else {
     hw_type = HW_TYPE_UNKNOWN;
-    putstr("Hardware type is UNKNOWN!\n");
+    print("Hardware type is UNKNOWN!\n");
   }
 }

--- a/board/stm32h7/board.h
+++ b/board/stm32h7/board.h
@@ -37,6 +37,6 @@ void detect_board_type(void) {
     current_board = &board_tres;
   } else {
     hw_type = HW_TYPE_UNKNOWN;
-    puts("Hardware type is UNKNOWN!\n");
+    putstr("Hardware type is UNKNOWN!\n");
   }
 }

--- a/board/stm32h7/inc/stm32h725xx.h
+++ b/board/stm32h7/inc/stm32h725xx.h
@@ -24478,7 +24478,7 @@ typedef struct
    ((INSTANCE) == TIM23)   || \
    ((INSTANCE) == TIM24))
 
-/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+/****************** TIM Instances : supporting internal trigger inputstr(ITRX) *******/
 #define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)\
   (((INSTANCE) == TIM1)    || \
    ((INSTANCE) == TIM2)    || \

--- a/board/stm32h7/inc/stm32h735xx.h
+++ b/board/stm32h7/inc/stm32h735xx.h
@@ -24478,7 +24478,7 @@ typedef struct
    ((INSTANCE) == TIM23)   || \
    ((INSTANCE) == TIM24))
 
-/****************** TIM Instances : supporting internal trigger inputs(ITRX) *******/
+/****************** TIM Instances : supporting internal trigger inputstr(ITRX) *******/
 #define IS_TIM_CLOCKSOURCE_ITRX_INSTANCE(INSTANCE)\
   (((INSTANCE) == TIM1)    || \
    ((INSTANCE) == TIM2)    || \

--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -37,7 +37,7 @@
 #define CAN_NUM_FROM_CANIF(CAN_DEV) (((CAN_DEV)==FDCAN1) ? 0UL : (((CAN_DEV) == FDCAN2) ? 1UL : 2UL))
 
 
-void puts(const char *a);
+void putstr(const char *a);
 
 // kbps multiplied by 10
 const uint32_t speeds[] = {100U, 200U, 500U, 1000U, 1250U, 2500U, 5000U, 10000U};
@@ -148,10 +148,10 @@ bool llcan_set_speed(FDCAN_GlobalTypeDef *CANx, uint32_t speed, uint32_t data_sp
     }
     ret = fdcan_exit_init(CANx);
     if (!ret) {
-      puts(CAN_NAME_FROM_CANIF(CANx)); puts(" set_speed timed out! (2)\n");
+      putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" set_speed timed out! (2)\n");
     }
   } else {
-    puts(CAN_NAME_FROM_CANIF(CANx)); puts(" set_speed timed out! (1)\n");
+    putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" set_speed timed out! (1)\n");
   }
   return ret;
 }
@@ -219,7 +219,7 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
 
     ret = fdcan_exit_init(CANx);
     if(!ret) {
-      puts(CAN_NAME_FROM_CANIF(CANx)); puts(" llcan_init timed out (2)!\n");
+      putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" llcan_init timed out (2)!\n");
     }
 
     if (CANx == FDCAN1) {
@@ -232,11 +232,11 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
       NVIC_EnableIRQ(FDCAN3_IT0_IRQn);
       NVIC_EnableIRQ(FDCAN3_IT1_IRQn);
     } else {
-      puts("Invalid CAN: initialization failed\n");
+      putstr("Invalid CAN: initialization failed\n");
     }
 
   } else {
-    puts(CAN_NAME_FROM_CANIF(CANx)); puts(" llcan_init timed out (1)!\n");
+    putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" llcan_init timed out (1)!\n");
   }
   return ret;
 }

--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -37,7 +37,7 @@
 #define CAN_NUM_FROM_CANIF(CAN_DEV) (((CAN_DEV)==FDCAN1) ? 0UL : (((CAN_DEV) == FDCAN2) ? 1UL : 2UL))
 
 
-void putstr(const char *a);
+void print(const char *a);
 
 // kbps multiplied by 10
 const uint32_t speeds[] = {100U, 200U, 500U, 1000U, 1250U, 2500U, 5000U, 10000U};
@@ -148,10 +148,10 @@ bool llcan_set_speed(FDCAN_GlobalTypeDef *CANx, uint32_t speed, uint32_t data_sp
     }
     ret = fdcan_exit_init(CANx);
     if (!ret) {
-      putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" set_speed timed out! (2)\n");
+      print(CAN_NAME_FROM_CANIF(CANx)); print(" set_speed timed out! (2)\n");
     }
   } else {
-    putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" set_speed timed out! (1)\n");
+    print(CAN_NAME_FROM_CANIF(CANx)); print(" set_speed timed out! (1)\n");
   }
   return ret;
 }
@@ -219,7 +219,7 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
 
     ret = fdcan_exit_init(CANx);
     if(!ret) {
-      putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" llcan_init timed out (2)!\n");
+      print(CAN_NAME_FROM_CANIF(CANx)); print(" llcan_init timed out (2)!\n");
     }
 
     if (CANx == FDCAN1) {
@@ -232,11 +232,11 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
       NVIC_EnableIRQ(FDCAN3_IT0_IRQn);
       NVIC_EnableIRQ(FDCAN3_IT1_IRQn);
     } else {
-      putstr("Invalid CAN: initialization failed\n");
+      print("Invalid CAN: initialization failed\n");
     }
 
   } else {
-    putstr(CAN_NAME_FROM_CANIF(CANx)); putstr(" llcan_init timed out (1)!\n");
+    print(CAN_NAME_FROM_CANIF(CANx)); print(" llcan_init timed out (1)!\n");
   }
   return ret;
 }

--- a/board/stm32h7/lluart.h
+++ b/board/stm32h7/lluart.h
@@ -72,7 +72,7 @@ void uart_interrupt_handler(uart_ring *q) {
   uint32_t err = (status & USART_ISR_ORE) | (status & USART_ISR_NE) | (status & USART_ISR_FE) | (status & USART_ISR_PE);
   if(err != 0U){
     #ifdef DEBUG_UART
-      puts("Encountered UART error: "); puth(err); puts("\n");
+      putstr("Encountered UART error: "); puth(err); putstr("\n");
     #endif
     UART_READ_RDR(q->uart)
   }
@@ -96,7 +96,7 @@ void uart_interrupt_handler(uart_ring *q) {
     UART_READ_RDR(q->uart)
 
     #ifdef DEBUG_UART
-      puts("No IDLE dma_pointer_handler implemented for this UART.");
+      putstr("No IDLE dma_pointer_handler implemented for this UART.");
     #endif
   }
 

--- a/board/stm32h7/lluart.h
+++ b/board/stm32h7/lluart.h
@@ -72,7 +72,7 @@ void uart_interrupt_handler(uart_ring *q) {
   uint32_t err = (status & USART_ISR_ORE) | (status & USART_ISR_NE) | (status & USART_ISR_FE) | (status & USART_ISR_PE);
   if(err != 0U){
     #ifdef DEBUG_UART
-      putstr("Encountered UART error: "); puth(err); putstr("\n");
+      print("Encountered UART error: "); puth(err); print("\n");
     #endif
     UART_READ_RDR(q->uart)
   }
@@ -96,7 +96,7 @@ void uart_interrupt_handler(uart_ring *q) {
     UART_READ_RDR(q->uart)
 
     #ifdef DEBUG_UART
-      putstr("No IDLE dma_pointer_handler implemented for this UART.");
+      print("No IDLE dma_pointer_handler implemented for this UART.");
     #endif
   }
 


### PR DESCRIPTION
prep for the prep #1172. better to rename since
1. this isn't quite the same as the real `puts` which appends a new line
2. we don't want to return anything, otherwise we'll need a MISRA suppression for each use