### PR TITLE
safety: clean up passing in longitudinal_allowed

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -484,9 +484,9 @@ float interpolate(struct lookup_t xy, float x) {
 }
 
 // Safety checks for longitudinal actuation
-bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits, const bool longitudinal_allowed) {
+bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits) {
   bool violation = false;
-  if (!longitudinal_allowed) {
+  if (!get_longitudinal_allowed()) {
     violation |= desired_accel != limits.inactive_accel;
   } else {
     violation |= max_limit_check(desired_accel, limits.max_accel, limits.min_accel);
@@ -494,9 +494,9 @@ bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limit
   return violation;
 }
 
-bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits, const bool longitudinal_allowed) {
+bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits) {
   bool violation = false;
-  if (!longitudinal_allowed) {
+  if (!get_longitudinal_allowed()) {
     violation |= desired_gas != limits.inactive_gas;
   } else {
     violation |= max_limit_check(desired_gas, limits.max_gas, limits.min_gas);
@@ -504,9 +504,9 @@ bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits, c
   return violation;
 }
 
-bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits, const bool longitudinal_allowed) {
+bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits) {
   bool violation = false;
-  violation |= !longitudinal_allowed && (desired_brake != 0);
+  violation |= !get_longitudinal_allowed() && (desired_brake != 0);
   violation |= desired_brake > limits.max_brake;
   return violation;
 }

--- a/board/safety/safety_body.h
+++ b/board/safety/safety_body.h
@@ -16,8 +16,7 @@ static int body_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int body_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int body_tx_hook(CANPacket_t *to_send) {
 
   int tx = 0;
   int addr = GET_ADDR(to_send);
@@ -30,8 +29,8 @@ static int body_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
   if (msg_allowed(to_send, BODY_TX_MSGS, sizeof(BODY_TX_MSGS)/sizeof(BODY_TX_MSGS[0])) && controls_allowed) {
     tx = 1;
   }
-  
-  // Allow going into CAN flashing mode even if controls are not allowed 
+
+  // Allow going into CAN flashing mode even if controls are not allowed
   if (!controls_allowed && ((uint32_t)GET_BYTES_04(to_send) == 0xdeadfaceU) && ((uint32_t)GET_BYTES_48(to_send) == 0x0ab00b1eU)) {
     tx = 1;
   }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -226,8 +226,7 @@ static int chrysler_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int chrysler_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int chrysler_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_defaults.h
+++ b/board/safety/safety_defaults.h
@@ -15,9 +15,8 @@ static const addr_checks* nooutput_init(uint16_t param) {
   return &default_rx_checks;
 }
 
-static int nooutput_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int nooutput_tx_hook(CANPacket_t *to_send) {
   UNUSED(to_send);
-  UNUSED(longitudinal_allowed);
   return false;
 }
 
@@ -54,7 +53,7 @@ static const addr_checks* alloutput_init(uint16_t param) {
   return &default_rx_checks;
 }
 
-static int alloutput_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int alloutput_tx_hook(CANPacket_t *to_send) {
   UNUSED(to_send);
   UNUSED(longitudinal_allowed);
   return true;

--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -1,5 +1,4 @@
-static int elm327_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int elm327_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -76,8 +76,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int ford_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int ford_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -147,7 +147,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 // else
 //     block all commands that produce actuation
 
-static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int gm_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -257,7 +257,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
 // else
 //     block all commands that produce actuation
 
-static int honda_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int honda_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -227,7 +227,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int hyundai_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int hyundai_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -226,8 +226,7 @@ static int hyundai_canfd_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int hyundai_canfd_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int hyundai_canfd_tx_hook(CANPacket_t *to_send) {
 
   int tx = 0;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -72,8 +72,7 @@ static int mazda_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int mazda_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int mazda_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -100,8 +100,7 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
 }
 
 
-static int nissan_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int nissan_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -120,8 +120,7 @@ static int subaru_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int subaru_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int subaru_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -61,8 +61,7 @@ static int subaru_legacy_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int subaru_legacy_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
-  UNUSED(longitudinal_allowed);
+static int subaru_legacy_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -115,7 +115,7 @@ static int tesla_rx_hook(CANPacket_t *to_push) {
 }
 
 
-static int tesla_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int tesla_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -132,7 +132,7 @@ static int toyota_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int toyota_tx_hook(CANPacket_t *to_send) {
 
   int tx = 1;
   int addr = GET_ADDR(to_send);

--- a/board/safety/safety_volkswagen_mqb.h
+++ b/board/safety/safety_volkswagen_mqb.h
@@ -202,7 +202,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int volkswagen_mqb_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int volkswagen_mqb_tx_hook(CANPacket_t *to_send) {
   int addr = GET_ADDR(to_send);
   int tx = 1;
 

--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -177,7 +177,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
   return valid;
 }
 
-static int volkswagen_pq_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
+static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
   int addr = GET_ADDR(to_send);
   int tx = 1;
 


### PR DESCRIPTION
Now only should be referenced in a common function