### PR TITLE
safety: common interceptor checks

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -512,7 +512,7 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
 }
 
 bool longitudinal_interceptor_checks(CANPacket_t *to_send, bool longitudinal_allowed) {
-  return !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0);
+  return !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0U);
 }
 
 // Safety checks for torque-based steering commands

--- a/board/safety.h
+++ b/board/safety.h
@@ -512,7 +512,7 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
 }
 
 bool longitudinal_interceptor_checks(CANPacket_t *to_send, bool longitudinal_allowed) {
-  return !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0U);
+  return !longitudinal_allowed && (GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1));
 }
 
 // Safety checks for torque-based steering commands

--- a/board/safety.h
+++ b/board/safety.h
@@ -512,9 +512,7 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
 }
 
 bool longitudinal_interceptor_checks(CANPacket_t *to_send, bool longitudinal_allowed) {
-  bool violation = false;
-  violation = !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0);
-  return violation;
+  bool !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0);
 }
 
 // Safety checks for torque-based steering commands

--- a/board/safety.h
+++ b/board/safety.h
@@ -511,6 +511,12 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
   return violation;
 }
 
+bool longitudinal_interceptor_checks(CANPacket_t *to_send, bool longitudinal_allowed) {
+  bool violation = false;
+  violation = !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0);
+  return violation;
+}
+
 // Safety checks for torque-based steering commands
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits) {
   bool violation = false;

--- a/board/safety.h
+++ b/board/safety.h
@@ -512,7 +512,7 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
 }
 
 bool longitudinal_interceptor_checks(CANPacket_t *to_send, bool longitudinal_allowed) {
-  bool !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0);
+  return !longitudinal_allowed && ((GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) != 0);
 }
 
 // Safety checks for torque-based steering commands

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -333,10 +333,8 @@ static int honda_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
 
   // GAS: safety check (interceptor)
   if (addr == 0x200) {
-    if (!longitudinal_allowed) {
-      if (GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) {
-        tx = 0;
-      }
+    if (longitudinal_interceptor_checks(to_send, longitudinal_allowed)) {
+      tx = 0;
     }
   }
 

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -147,10 +147,8 @@ static int toyota_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
 
     // GAS PEDAL: safety check
     if (addr == 0x200) {
-      if (!longitudinal_allowed) {
-        if (GET_BYTE(to_send, 0) || GET_BYTE(to_send, 1)) {
-          tx = 0;
-        }
+      if (longitudinal_interceptor_checks(to_send, longitudinal_allowed)) {
+        tx = 0;
       }
     }
 

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -130,6 +130,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits, const bool longitudinal_allowed);
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits, const bool longitudinal_allowed);
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits, const bool longitudinal_allowed);
+bool longitudinal_interceptor_checks(CANPacket_t *to_send, const bool longitudinal_allowed);
 void pcm_cruise_check(bool cruise_engaged);
 
 typedef const addr_checks* (*safety_hook_init)(uint16_t param);


### PR DESCRIPTION
on the road to removing `longitudinal_allowed` the safety modes