### PR TITLE
Reset CAN ign when the specific message is not seen anymore

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -195,24 +195,25 @@ void ignition_can_hook(CANPacket_t *to_push) {
   int addr = GET_ADDR(to_push);
   int len = GET_LEN(to_push);
 
-  ignition_can_cnt = 0U;  // reset counter
-
   if (bus == 0) {
     // GM exception
     if ((addr == 0x160) && (len == 5)) {
       // this message isn't all zeros when ignition is on
       ignition_can = GET_BYTES_04(to_push) != 0U;
+      ignition_can_cnt = 0U;
     }
 
     // Tesla exception
     if ((addr == 0x348) && (len == 8)) {
       // GTW_status
       ignition_can = (GET_BYTE(to_push, 0) & 0x1U) != 0U;
+      ignition_can_cnt = 0U;
     }
 
     // Mazda exception
     if ((addr == 0x9E) && (len == 8)) {
       ignition_can = (GET_BYTE(to_push, 0) >> 5) == 0x6U;
+      ignition_can_cnt = 0U;
     }
 
   }


### PR DESCRIPTION
Right now, it only resets if there's no CAN traffic at all anymore, but if the message disappears the state is kept.
Had this bug trigger in my car after an update, where CAN ignition went high because of an update-related message conflicted with the ignition signal on a different bus, but just disappeared after the update.