### PR TITLE
fix debug uart buffer size

### DIFF
--- a/board/drivers/uart.h
+++ b/board/drivers/uart.h
@@ -51,7 +51,7 @@ UART_BUFFER(lin1, FIFO_SIZE_INT, FIFO_SIZE_INT, UART5, NULL, false)
 UART_BUFFER(lin2, FIFO_SIZE_INT, FIFO_SIZE_INT, USART3, NULL, false)
 
 // debug = USART2
-UART_BUFFER(debug, FIFO_SIZE_DMA, FIFO_SIZE_INT, USART2, debug_ring_callback, false)
+UART_BUFFER(debug, FIFO_SIZE_INT, FIFO_SIZE_INT, USART2, debug_ring_callback, false)
 
 // SOM debug = UART7
 #ifdef STM32H7


### PR DESCRIPTION
Buffer size was changed in https://github.com/commaai/panda/pull/1151. Since `rx_dma` is false I assume the buffer size should also be `FIFO_SIZE_INT`.

For some reason using a larger buffer causes the firmware to stop working on f4 devices when compiling on MacOS (`arm-none-eabi-gcc (Arm GNU Toolchain 12.2.Rel1 (Build arm-12.24)) 12.2.1 20221205`) or with the latest compiler from the arch repos ( `arm-none-eabi-gcc (Arch Repository) 12.2.0`). Since this is unexpected I assume you'd like to figure out why. 

`.bss` size is the same between both compilers, so it's not suddenly creating larger global variables.
