### PR TITLE
query_fw_versions: add arg to not multiplex bus 1 to OBD-II port

### DIFF
--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -9,6 +9,7 @@ if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument('--rxoffset', default="")
   parser.add_argument('--nonstandard', action='store_true')
+  parser.add_argument('--no-obd', action='store_true', help='Bus 1 will not be multiplexed to the OBD-II port')
   parser.add_argument('--debug', action='store_true')
   parser.add_argument('--addr')
   parser.add_argument('--bus')
@@ -33,7 +34,8 @@ if __name__ == "__main__":
       uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_SYSTEM_SUPPLIER_SPECIFIC"
 
   panda = Panda()
-  panda.set_safety_mode(Panda.SAFETY_ELM327)
+  safety_param = 1 if args.no_obd else 0
+  panda.set_safety_mode(Panda.SAFETY_ELM327, safety_param)
   print("querying addresses ...")
   with tqdm(addrs) as t:
     for addr in t:

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -4,7 +4,6 @@ from tqdm import tqdm
 from panda import Panda
 from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
 
-
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument('--rxoffset', default="")
@@ -26,11 +25,11 @@ if __name__ == "__main__":
   for std_id in DATA_IDENTIFIER_TYPE:
     uds_data_ids[std_id.value] = std_id.name
   if args.nonstandard:
-    for uds_id in range(0xf100,0xf180):
+    for uds_id in range(0xf100, 0xf180):
       uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC_DATA_IDENTIFIER"
-    for uds_id in range(0xf1a0,0xf1f0):
+    for uds_id in range(0xf1a0, 0xf1f0):
       uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_VEHICLE_MANUFACTURER_SPECIFIC"
-    for uds_id in range(0xf1f0,0xf200):
+    for uds_id in range(0xf1f0, 0xf200):
       uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_SYSTEM_SUPPLIER_SPECIFIC"
 
   panda = Panda()

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -6,12 +6,12 @@ from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseErr
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
-  parser.add_argument('--rxoffset', default="")
-  parser.add_argument('--nonstandard', action='store_true')
-  parser.add_argument('--no-obd', action='store_true', help='Bus 1 will not be multiplexed to the OBD-II port')
-  parser.add_argument('--debug', action='store_true')
-  parser.add_argument('--addr')
-  parser.add_argument('--bus')
+  parser.add_argument("--rxoffset", default="")
+  parser.add_argument("--nonstandard", action="store_true")
+  parser.add_argument("--no-obd", action="store_true", help="Bus 1 will not be multiplexed to the OBD-II port")
+  parser.add_argument("--debug", action="store_true")
+  parser.add_argument("--addr")
+  parser.add_argument("--bus")
   args = parser.parse_args()
 
   if args.addr:


### PR DESCRIPTION
Useful for aux (red) panda setups where we want to query on (in boardd's perspective) bus 5 for example