### PR TITLE
Tres: enable IR power irregardless of fan state

### DIFF
--- a/board/boards/tres.h
+++ b/board/boards/tres.h
@@ -2,7 +2,8 @@
 // Tres + Harness //
 // /////////////////
 
-bool tres_ir_enabled, tres_fan_enabled;
+bool tres_ir_enabled;
+bool tres_fan_enabled;
 void tres_update_fan_ir_power(void) {
   red_chiplet_set_fan_or_usb_load_switch(tres_ir_enabled || tres_fan_enabled);
 }


### PR DESCRIPTION
The IR and the fan share the same load switch. Make sure it's on, regardless of which component we want to run.