### PR TITLE
MacOS: use gcc-12 for building tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pip install -r requirements.txt
 
 # macOS
 brew tap ArmMbed/homebrew-formulae
-brew install python dfu-util arm-none-eabi-gcc
+brew install python dfu-util arm-none-eabi-gcc gcc@12
 pip install -r requirements.txt
 ```
 

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -8,5 +8,6 @@ env = Environment(
   CPPPATH=[".", "../board"],
 )
 
+env.PrependENVPath('PATH', '/opt/homebrew/bin')
 env.SharedLibrary("safety/libpandasafety.so", ["safety/test.c"])
 env.SharedLibrary("usbprotocol/libpandaprotocol.so", ["usbprotocol/test.c"])

--- a/tests/libpanda/SConscript
+++ b/tests/libpanda/SConscript
@@ -8,5 +8,6 @@ env = Environment(
   ],
   CPPPATH=[".", "../../board/"],
 )
+env.PrependENVPath('PATH', '/opt/homebrew/bin')
 
 env.SharedLibrary("libpanda.so", ["panda.c",])


### PR DESCRIPTION
Use homebrew gcc@12 from /opt/homebrew/bin to build panda tests, since apple clang does not support -std=gnu11 (https://opensource.apple.com/source/clang/clang-23/clang/tools/clang/docs/UsersManual.html#c)

I will include adding the required symlinks in mac_setup.sh script PR
```
cd /opt/homebrew/bin
ln -s gcc-12 gcc
ln -s g++-12 g++
```