### PR TITLE
Angle control: match openpilot limits

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -614,8 +614,8 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
     // add 1 to not false trigger the violation. also fudge the speed by 1 m/s so rate limits are
     // always slightly above openpilot's in case we read an updated speed in between angle commands
     // TODO: this speed fudge can be much lower, look at data to determine the lowest reasonable offset
-    int delta_angle_up = (interpolate(limits.angle_rate_up_lookup, vehicle_speed + 1.) * limits.angle_deg_to_can) + 1.;
-    int delta_angle_down = (interpolate(limits.angle_rate_down_lookup, vehicle_speed + 1.) * limits.angle_deg_to_can) + 1.;
+    int delta_angle_up = (interpolate(limits.angle_rate_up_lookup, vehicle_speed - 1.) * limits.angle_deg_to_can) + 1.;
+    int delta_angle_down = (interpolate(limits.angle_rate_down_lookup, vehicle_speed - 1.) * limits.angle_deg_to_can) + 1.;
 
     int highest_desired_angle = desired_angle_last + ((desired_angle_last > 0) ? delta_angle_up : delta_angle_down);
     int lowest_desired_angle = desired_angle_last - ((desired_angle_last >= 0) ? delta_angle_down : delta_angle_up);

--- a/board/safety.h
+++ b/board/safety.h
@@ -611,9 +611,11 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
 
   if (controls_allowed && steer_control_enabled) {
     // convert floating point angle rate limits to integers in the scale of the desired angle on CAN,
-    // add 1 to not false trigger the violation
-    int delta_angle_up = (interpolate(limits.angle_rate_up_lookup, vehicle_speed) * limits.angle_deg_to_can) + 1.;
-    int delta_angle_down = (interpolate(limits.angle_rate_down_lookup, vehicle_speed) * limits.angle_deg_to_can) + 1.;
+    // add 1 to not false trigger the violation. also fudge the speed by 1 m/s so rate limits are
+    // always slightly above openpilot's in case we read an updated speed in between angle commands
+    // TODO: this speed fudge can be much lower, look at data to determine the lowest offset
+    int delta_angle_up = (interpolate(limits.angle_rate_up_lookup, vehicle_speed + 1.) * limits.angle_deg_to_can) + 1.;
+    int delta_angle_down = (interpolate(limits.angle_rate_down_lookup, vehicle_speed + 1.) * limits.angle_deg_to_can) + 1.;
 
     int highest_desired_angle = desired_angle_last + ((desired_angle_last > 0) ? delta_angle_up : delta_angle_down);
     int lowest_desired_angle = desired_angle_last - ((desired_angle_last >= 0) ? delta_angle_down : delta_angle_up);

--- a/board/safety.h
+++ b/board/safety.h
@@ -613,7 +613,7 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
     // convert floating point angle rate limits to integers in the scale of the desired angle on CAN,
     // add 1 to not false trigger the violation. also fudge the speed by 1 m/s so rate limits are
     // always slightly above openpilot's in case we read an updated speed in between angle commands
-    // TODO: this speed fudge can be much lower, look at data to determine the lowest offset
+    // TODO: this speed fudge can be much lower, look at data to determine the lowest reasonable offset
     int delta_angle_up = (interpolate(limits.angle_rate_up_lookup, vehicle_speed + 1.) * limits.angle_deg_to_can) + 1.;
     int delta_angle_down = (interpolate(limits.angle_rate_down_lookup, vehicle_speed + 1.) * limits.angle_deg_to_can) + 1.;
 

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -1,12 +1,12 @@
 const SteeringLimits NISSAN_STEERING_LIMITS = {
   .angle_deg_to_can = 100,
   .angle_rate_up_lookup = {
-    {2., 7., 17.},
+    {0., 5., 15.},
     {5., .8, .15}
   },
   .angle_rate_down_lookup = {
-    {2., 7., 17.},
-    {5., 3.5, .5}
+    {0., 5., 15.},
+    {5., 3.5, .4}
   },
 };
 

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -1,12 +1,12 @@
 const SteeringLimits TESLA_STEERING_LIMITS = {
   .angle_deg_to_can = 10,
   .angle_rate_up_lookup = {
-    {2., 7., 17.},
-    {5., .8, .25}
+    {0., 5., 15.},
+    {5., .8, .15}
   },
   .angle_rate_down_lookup = {
-    {2., 7., 17.},
-    {5., 3.5, .8}
+    {0., 5., 15.},
+    {5., 3.5, .4}
   },
 };
 

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -21,7 +21,7 @@ class TestNissanSafety(common.PandaSafetyTest, common.AngleSteeringSafetyTest):
 
   ANGLE_DELTA_BP = [0., 5., 15.]
   ANGLE_DELTA_V = [5., .8, .15]  # windup limit
-  ANGLE_DELTA_VU = [5., 3.5, 0.4]  # unwind limit
+  ANGLE_DELTA_VU = [5., 3.5, .4]  # unwind limit
 
   def setUp(self):
     self.packer = CANPackerPanda("nissan_x_trail_2017")

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -73,7 +73,7 @@ class TestTeslaSteeringSafety(TestTeslaSafety, common.AngleSteeringSafetyTest):
 
   ANGLE_DELTA_BP = [0., 5., 15.]
   ANGLE_DELTA_V = [5., .8, .15]  # windup limit
-  ANGLE_DELTA_VU = [5., 3.5, 0.4]  # unwind limit
+  ANGLE_DELTA_VU = [5., 3.5, .4]  # unwind limit
 
   def setUp(self):
     self.packer = CANPackerPanda("tesla_can")


### PR DESCRIPTION
Instead of adding an implicit fudge to the raw speed bp lists, add an explicit comment and offset in the angle limiting function. Will make it easy to keep the limits matching OP (some items in the v lists also weren't matching, which is unnecessary with a speed offset. fixed)

We can probably reduce the speed fudging even more, but I left a TODO comment to look at data to determine what a reasonable factor would be for now.

TLDR, what does this PR do?
- Change speed fudging from 2 m/s to 1 m/s (reduce tolerance)
- Fixes one point of the angle limit lookup tables not matching OP
- Makes the lookup tables match the tests' and OP's visually and by value