### PR TITLE
Nissan: use averaged left and right wheel speeds

### DIFF
--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -65,7 +65,7 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
         uint16_t right_rear = (GET_BYTE(to_push, 0) << 8) | (GET_BYTE(to_push, 1));
         uint16_t left_rear = (GET_BYTE(to_push, 2) << 8) | (GET_BYTE(to_push, 3));
         vehicle_moving = (right_rear | left_rear) != 0U;
-        vehicle_speed = (left_rear + left_rear) / 2.0) * 0.005 / 3.6;
+        vehicle_speed = (left_rear + left_rear) / 2.0 * 0.005 / 3.6;
       }
 
       // X-Trail 0x15c, Leaf 0x239

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -65,7 +65,7 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
         uint16_t right_rear = (GET_BYTE(to_push, 0) << 8) | (GET_BYTE(to_push, 1));
         uint16_t left_rear = (GET_BYTE(to_push, 2) << 8) | (GET_BYTE(to_push, 3));
         vehicle_moving = (right_rear | left_rear) != 0U;
-        vehicle_speed = left_rear * 0.005 / 3.6;
+        vehicle_speed = (left_rear + left_rear) / 2.0) * 0.005 / 3.6;
       }
 
       // X-Trail 0x15c, Leaf 0x239

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -65,7 +65,7 @@ static int nissan_rx_hook(CANPacket_t *to_push) {
         uint16_t right_rear = (GET_BYTE(to_push, 0) << 8) | (GET_BYTE(to_push, 1));
         uint16_t left_rear = (GET_BYTE(to_push, 2) << 8) | (GET_BYTE(to_push, 3));
         vehicle_moving = (right_rear | left_rear) != 0U;
-        vehicle_speed = (left_rear + left_rear) / 2.0 * 0.005 / 3.6;
+        vehicle_speed = (right_rear + left_rear) / 2.0 * 0.005 / 3.6;
       }
 
       // X-Trail 0x15c, Leaf 0x239


### PR DESCRIPTION
The error from the speed openpilot uses can be up to at least 0.6 m/s away using just one side of the car. Allows us to reduce the speed fudge for the angle rate limits: https://github.com/commaai/panda/pull/1254

![Screenshot from 2023-02-22 19-30-04](https://user-images.githubusercontent.com/25857203/220815691-f90d4406-eebe-4f7a-b8eb-d99c31cd7429.png)