### PR TITLE
safety tests: refactor for cars with standstill bits

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -3,7 +3,7 @@ import abc
 import unittest
 import importlib
 import numpy as np
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from opendbc.can.packer import CANPacker  # pylint: disable=import-error
 from panda import ALTERNATIVE_EXPERIENCE
@@ -564,8 +564,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
                    *range(0x18DB00F1, 0x18DC00F1, 0x100),   # 29-bit UDS functional addressing
                    *range(0x3300, 0x3400),                  # Honda
                    0x10400060, 0x104c006c]                  # GMLAN (exceptions, range/format unclear)
-  # False if safety mode uses a bit for vehicle_moving
-  STANDSTILL_THRESHOLD: Optional[Union[float, bool]] = None
+  STANDSTILL_THRESHOLD: Optional[float] = None
   GAS_PRESSED_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDR: Optional[int] = None
   RELAY_MALFUNCTION_BUS: Optional[int] = None
@@ -589,7 +588,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
   def _speed_msg(self, speed):
     pass
 
-  @abc.abstractmethod
+  # Safety modes can override if vehicle_moving is driven by a different message
   def _vehicle_moving_msg(self, speed: float):
     return self._speed_msg(speed)
 
@@ -762,25 +761,6 @@ class PandaSafetyTest(PandaSafetyTestBase):
     # past threshold
     self.safety.safety_rx_hook(self._vehicle_moving_msg(self.STANDSTILL_THRESHOLD + 1))
     self.assertTrue(self.safety.get_vehicle_moving())
-
-  # def test_vehicle_moving(self):
-  #   self.assertFalse(self.safety.get_vehicle_moving())
-  #
-  #   # not moving
-  #   self._rx(self._vehicle_moving_msg(False))
-  #   self.assertFalse(self.safety.get_vehicle_moving())
-  #
-  #   if self.STANDSTILL_THRESHOLD is False:
-  #     self._rx(self._vehicle_moving_msg(True))
-  #     self.assertTrue(self.safety.get_vehicle_moving())
-  #   else:
-  #     # speed is at threshold
-  #     self._rx(self._speed_msg(self.STANDSTILL_THRESHOLD))
-  #     self.assertFalse(self.safety.get_vehicle_moving())
-  #
-  #     # past threshold
-  #     self._rx(self._speed_msg(self.STANDSTILL_THRESHOLD + 1))
-  #     self.assertTrue(self.safety.get_vehicle_moving())
 
   def test_tx_hook_on_wrong_safety_mode(self):
     files = os.listdir(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -52,11 +52,10 @@ class TestFordSafety(common.PandaSafetyTest):
     }
     return self.packer.make_can_msg_panda("EngBrakeData", 0, values)
 
-  # Standstill state
   def _speed_msg(self, speed: float):
-    values = {"VehStop_D_Stat": 1 if speed <= self.STANDSTILL_THRESHOLD else 0}
-    return self.packer.make_can_msg_panda("DesiredTorqBrk", 0, values)
+    pass
 
+  # Standstill state
   def _vehicle_moving_msg(self, speed: float):
     values = {"VehStop_D_Stat": 1 if speed <= self.STANDSTILL_THRESHOLD else 0}
     return self.packer.make_can_msg_panda("DesiredTorqBrk", 0, values)

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -57,6 +57,10 @@ class TestFordSafety(common.PandaSafetyTest):
     values = {"VehStop_D_Stat": 1 if speed <= self.STANDSTILL_THRESHOLD else 0}
     return self.packer.make_can_msg_panda("DesiredTorqBrk", 0, values)
 
+  def _vehicle_moving_msg(self, speed: float):
+    values = {"VehStop_D_Stat": 1 if speed <= self.STANDSTILL_THRESHOLD else 0}
+    return self.packer.make_can_msg_panda("DesiredTorqBrk", 0, values)
+
   # Drive throttle input
   def _user_gas_msg(self, gas: float):
     values = {"ApedPos_Pc_ActlArb": gas}

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -102,6 +102,9 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
     values = {"%sWheelSpd" % s: speed for s in ["RL", "RR"]}
     return self.packer.make_can_msg_panda("EBCMWheelSpdRear", 0, values)
 
+  def _vehicle_moving_msg(self, vehicle_moving: bool):
+    return self._speed_msg(int(vehicle_moving))
+
   def _user_brake_msg(self, brake):
     # GM safety has a brake threshold of 8
     values = {"BrakePedalPos": 8 if brake else 0}

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -102,9 +102,6 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
     values = {"%sWheelSpd" % s: speed for s in ["RL", "RR"]}
     return self.packer.make_can_msg_panda("EBCMWheelSpdRear", 0, values)
 
-  def _vehicle_moving_msg(self, vehicle_moving: bool):
-    return self._speed_msg(int(vehicle_moving))
-
   def _user_brake_msg(self, brake):
     # GM safety has a brake threshold of 8
     values = {"BrakePedalPos": 8 if brake else 0}


### PR DESCRIPTION
Allows safety modes like Ford to use the _speed_msg as an actual speed message, for later curvature safety limits/tests