### PR TITLE
GM: Reduce steer down limit and increase driver allowance

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -1,8 +1,8 @@
 const SteeringLimits GM_STEERING_LIMITS = {
   .max_steer = 300,
   .max_rate_up = 10,
-  .max_rate_down = 25,
-  .driver_torque_allowance = 50,
+  .max_rate_down = 15,
+  .driver_torque_allowance = 65,
   .driver_torque_factor = 4,
   .max_rt_delta = 128,
   .max_rt_interval = 250000,

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -63,11 +63,11 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
   BRAKE_BUS = 0  # tx only
 
   MAX_RATE_UP = 10
-  MAX_RATE_DOWN = 25
+  MAX_RATE_DOWN = 15
   MAX_TORQUE = 300
   MAX_RT_DELTA = 128
   RT_INTERVAL = 250000
-  DRIVER_TORQUE_ALLOWANCE = 50
+  DRIVER_TORQUE_ALLOWANCE = 65
   DRIVER_TORQUE_FACTOR = 4
 
   MAX_GAS = 0


### PR DESCRIPTION
# Changes
- Reduce steer down limit to avoid hitting internal GM thresholds and associated windup
- Increase driver allowance to make the wheel firmer to driver torque (experimentally determined) 