### PR TITLE
H7: bump up fan tach IRQ max call rate

### DIFF
--- a/board/stm32h7/llfan.h
+++ b/board/stm32h7/llfan.h
@@ -9,7 +9,7 @@ void EXTI2_IRQ_Handler(void) {
 
 void llfan_init(void) {
   // 5000RPM * 4 tach edges / 60 seconds
-  REGISTER_INTERRUPT(EXTI2_IRQn, EXTI2_IRQ_Handler, 700U, FAULT_INTERRUPT_RATE_TACH)
+  REGISTER_INTERRUPT(EXTI2_IRQn, EXTI2_IRQ_Handler, 800U, FAULT_INTERRUPT_RATE_TACH)
 
   // Init PWM speed control
   pwm_init(TIM3, 3);


### PR DESCRIPTION
Getting these randomly, which are slightly outside the max call rate.
```
Interrupt 0x00000008 fired too often (0x000002bd/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002be/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002bf/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002c0/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002c1/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002c2/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002c3/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002c4/s)!
Temporary fault occurred: 0x00000020
Interrupt 0x00000008 fired too often (0x000002c5/s)!
```

@robbederks how did you calculate this originally for the F4? 5000 * 4 / 60 = 333. Did you just double it for some headroom?