### PR TITLE
Raise max steer limits for Ram DT

### DIFF
--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -9,7 +9,7 @@ const SteeringLimits CHRYSLER_STEERING_LIMITS = {
 };
 
 const SteeringLimits CHRYSLER_RAM_DT_STEERING_LIMITS = {
-  .max_steer = 261,
+  .max_steer = 350,
   .max_rt_delta = 112,
   .max_rt_interval = 250000,
   .max_rate_up = 6,

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -79,6 +79,7 @@ class TestChryslerRamDTSafety(TestChryslerSafety):
 
   MAX_RATE_UP = 6
   MAX_RATE_DOWN = 6
+  MAX_TORQUE = 350
 
   DAS_BUS = 2
 


### PR DESCRIPTION
We have tested for over a year that the Ram DT can handle 350 on the max steer. Any higher and the EPS will error out. Raising this here and then a PR can be made for the SelfDrive files.