### PR TITLE
VW PQ: Corrected message name for ACC_GRA_Anzeige

### DIFF
--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -28,14 +28,14 @@ const LongitudinalLimits VOLKSWAGEN_PQ_LONG_LIMITS = {
 #define MSG_MOTOR_3             0x380   // RX from ECU, for driver throttle input
 #define MSG_GRA_NEU             0x38A   // TX by OP, ACC control buttons for cancel/resume
 #define MSG_MOTOR_5             0x480   // RX from ECU, for ACC main switch state
-#define MSG_ACC_GRA_ANZIEGE     0x56A   // TX by OP, ACC HUD
+#define MSG_ACC_GRA_ANZEIGE     0x56A   // TX by OP, ACC HUD
 #define MSG_LDW_1               0x5BE   // TX by OP, Lane line recognition and text alerts
 
 // Transmit of GRA_Neu is allowed on bus 0 and 2 to keep compatibility with gateway and camera integration
 const CanMsg VOLKSWAGEN_PQ_STOCK_TX_MSGS[] = {{MSG_HCA_1, 0, 5}, {MSG_LDW_1, 0, 8},
                                               {MSG_GRA_NEU, 0, 4}, {MSG_GRA_NEU, 2, 4}};
 const CanMsg VOLKSWAGEN_PQ_LONG_TX_MSGS[] =  {{MSG_HCA_1, 0, 5}, {MSG_LDW_1, 0, 8},
-                                              {MSG_ACC_SYSTEM, 0, 8}, {MSG_ACC_GRA_ANZIEGE, 0, 8}};
+                                              {MSG_ACC_SYSTEM, 0, 8}, {MSG_ACC_GRA_ANZEIGE, 0, 8}};
 
 AddrCheckStruct volkswagen_pq_addr_checks[] = {
   {.msg = {{MSG_LENKHILFE_3, 0, 6, .check_checksum = true, .max_counter = 15U, .expected_timestep = 10000U}, { 0 }, { 0 }}},
@@ -240,7 +240,7 @@ static int volkswagen_pq_fwd_hook(int bus_num, CANPacket_t *to_fwd) {
       if ((addr == MSG_HCA_1) || (addr == MSG_LDW_1)) {
         // openpilot takes over LKAS steering control and related HUD messages from the camera
         bus_fwd = -1;
-      } else if (volkswagen_longitudinal && ((addr == MSG_ACC_SYSTEM) || (addr == MSG_ACC_GRA_ANZIEGE))) {
+      } else if (volkswagen_longitudinal && ((addr == MSG_ACC_SYSTEM) || (addr == MSG_ACC_GRA_ANZEIGE))) {
         // openpilot takes over acceleration/braking control and related HUD messages from the stock ACC radar
       } else {
         // Forward all remaining traffic from Extended CAN devices to J533 gateway

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -14,7 +14,7 @@ MSG_ACC_SYSTEM = 0x368        # TX by OP, longitudinal acceleration controls
 MSG_MOTOR_3 = 0x380           # RX from ECU, for driver throttle input
 MSG_GRA_NEU = 0x38A           # TX by OP, ACC control buttons for cancel/resume
 MSG_MOTOR_5 = 0x480           # RX from ECU, for ACC main switch state
-MSG_ACC_GRA_ANZIEGE = 0x56A   # TX by OP, ACC HUD
+MSG_ACC_GRA_ANZEIGE = 0x56A   # TX by OP, ACC HUD
 MSG_LDW_1 = 0x5BE             # TX by OP, Lane line recognition and text alerts
 
 MAX_ACCEL = 2.0
@@ -143,8 +143,8 @@ class TestVolkswagenPqStockSafety(TestVolkswagenPqSafety):
 
 
 class TestVolkswagenPqLongSafety(TestVolkswagenPqSafety):
-  TX_MSGS = [[MSG_HCA_1, 0], [MSG_LDW_1, 0], [MSG_ACC_SYSTEM, 0], [MSG_ACC_GRA_ANZIEGE, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_1, MSG_LDW_1, MSG_ACC_SYSTEM, MSG_ACC_GRA_ANZIEGE]}
+  TX_MSGS = [[MSG_HCA_1, 0], [MSG_LDW_1, 0], [MSG_ACC_SYSTEM, 0], [MSG_ACC_GRA_ANZEIGE, 0]]
+  FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_1, MSG_LDW_1, MSG_ACC_SYSTEM, MSG_ACC_GRA_ANZEIGE]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
   INACTIVE_ACCEL = 3.01
 


### PR DESCRIPTION
Corrected message name Anziege -> Anzeige. Null effect change.

In Panda, we only refer to the CAN arb ID with C/Panda constants (not opendbc/packer) so there are no dependencies.