### PR TITLE
Tres: fan cooldown +  no stall recovery

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -191,7 +191,12 @@ const board board_black = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
+<<<<<<< HEAD
   .adc_scale = 8862U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = black_init,
   .enable_can_transceiver = black_enable_can_transceiver,
   .enable_can_transceivers = black_enable_can_transceivers,

--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -191,12 +191,9 @@ const board board_black = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
-<<<<<<< HEAD
   .adc_scale = 8862U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = black_init,
   .enable_can_transceiver = black_enable_can_transceiver,
   .enable_can_transceivers = black_enable_can_transceivers,

--- a/board/boards/board_declarations.h
+++ b/board/boards/board_declarations.h
@@ -25,12 +25,9 @@ struct board {
   const bool has_canfd;
   const bool has_rtc_battery;
   const uint16_t fan_max_rpm;
-<<<<<<< HEAD
   const uint16_t adc_scale;
-=======
   const bool fan_stall_recovery;
   const uint8_t fan_enable_cooldown_time;
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   board_init init;
   board_enable_can_transceiver enable_can_transceiver;
   board_enable_can_transceivers enable_can_transceivers;

--- a/board/boards/board_declarations.h
+++ b/board/boards/board_declarations.h
@@ -25,7 +25,12 @@ struct board {
   const bool has_canfd;
   const bool has_rtc_battery;
   const uint16_t fan_max_rpm;
+<<<<<<< HEAD
   const uint16_t adc_scale;
+=======
+  const bool fan_stall_recovery;
+  const uint8_t fan_enable_cooldown_time;
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   board_init init;
   board_enable_can_transceiver enable_can_transceiver;
   board_enable_can_transceivers enable_can_transceivers;

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -215,7 +215,12 @@ const board board_dos = {
   .has_canfd = false,
   .has_rtc_battery = true,
   .fan_max_rpm = 6500U,
+<<<<<<< HEAD
   .adc_scale = 8862U,
+=======
+  .fan_stall_recovery = true,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = dos_init,
   .enable_can_transceiver = dos_enable_can_transceiver,
   .enable_can_transceivers = dos_enable_can_transceivers,

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -215,12 +215,9 @@ const board board_dos = {
   .has_canfd = false,
   .has_rtc_battery = true,
   .fan_max_rpm = 6500U,
-<<<<<<< HEAD
   .adc_scale = 8862U,
-=======
   .fan_stall_recovery = true,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = dos_init,
   .enable_can_transceiver = dos_enable_can_transceiver,
   .enable_can_transceivers = dos_enable_can_transceivers,

--- a/board/boards/grey.h
+++ b/board/boards/grey.h
@@ -45,7 +45,12 @@ const board board_grey = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
+<<<<<<< HEAD
   .adc_scale = 8862U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = grey_init,
   .enable_can_transceiver = white_enable_can_transceiver,
   .enable_can_transceivers = white_enable_can_transceivers,

--- a/board/boards/grey.h
+++ b/board/boards/grey.h
@@ -45,12 +45,9 @@ const board board_grey = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
-<<<<<<< HEAD
   .adc_scale = 8862U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = grey_init,
   .enable_can_transceiver = white_enable_can_transceiver,
   .enable_can_transceivers = white_enable_can_transceivers,

--- a/board/boards/pedal.h
+++ b/board/boards/pedal.h
@@ -83,7 +83,12 @@ const board board_pedal = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
+<<<<<<< HEAD
   .adc_scale = 8862U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = pedal_init,
   .enable_can_transceiver = pedal_enable_can_transceiver,
   .enable_can_transceivers = pedal_enable_can_transceivers,

--- a/board/boards/pedal.h
+++ b/board/boards/pedal.h
@@ -83,12 +83,9 @@ const board board_pedal = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
-<<<<<<< HEAD
   .adc_scale = 8862U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = pedal_init,
   .enable_can_transceiver = pedal_enable_can_transceiver,
   .enable_can_transceivers = pedal_enable_can_transceivers,

--- a/board/boards/red.h
+++ b/board/boards/red.h
@@ -178,7 +178,12 @@ const board board_red = {
   .has_canfd = true,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
+<<<<<<< HEAD
   .adc_scale = 5539U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = red_init,
   .enable_can_transceiver = red_enable_can_transceiver,
   .enable_can_transceivers = red_enable_can_transceivers,

--- a/board/boards/red.h
+++ b/board/boards/red.h
@@ -178,12 +178,9 @@ const board board_red = {
   .has_canfd = true,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
-<<<<<<< HEAD
   .adc_scale = 5539U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = red_init,
   .enable_can_transceiver = red_enable_can_transceiver,
   .enable_can_transceivers = red_enable_can_transceivers,

--- a/board/boards/red_v2.h
+++ b/board/boards/red_v2.h
@@ -14,7 +14,12 @@ const board board_red_v2 = {
   .has_canfd = true,
   .has_rtc_battery = true,
   .fan_max_rpm = 0U,
+<<<<<<< HEAD
   .adc_scale = 5539U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = red_chiplet_init,
   .enable_can_transceiver = red_chiplet_enable_can_transceiver,
   .enable_can_transceivers = red_chiplet_enable_can_transceivers,

--- a/board/boards/red_v2.h
+++ b/board/boards/red_v2.h
@@ -14,12 +14,9 @@ const board board_red_v2 = {
   .has_canfd = true,
   .has_rtc_battery = true,
   .fan_max_rpm = 0U,
-<<<<<<< HEAD
   .adc_scale = 5539U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = red_chiplet_init,
   .enable_can_transceiver = red_chiplet_enable_can_transceiver,
   .enable_can_transceivers = red_chiplet_enable_can_transceivers,

--- a/board/boards/tres.h
+++ b/board/boards/tres.h
@@ -4,14 +4,8 @@
 
 bool tres_ir_enabled;
 bool tres_fan_enabled;
-uint8_t tres_fan_cooldown = 0U;
 void tres_update_fan_ir_power(void) {
-  if (tres_fan_enabled) {
-    // keep power on a few seconds after disabling to allow the fan to spin down
-    tres_fan_cooldown = 3U;
-  }
-
-  red_chiplet_set_fan_or_usb_load_switch(tres_ir_enabled || tres_fan_enabled || (tres_fan_cooldown > 0U));
+  red_chiplet_set_fan_or_usb_load_switch(tres_ir_enabled || tres_fan_enabled);
 }
 
 void tres_set_ir_power(uint8_t percentage){
@@ -37,11 +31,6 @@ void tres_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen) {
 
   }
   tres_ignition_prev = ignition;
-
-  if (tres_fan_cooldown > 0U) {
-    tres_fan_cooldown--;
-  }
-  tres_update_fan_ir_power();
 }
 
 void tres_set_fan_enabled(bool enabled) {
@@ -104,8 +93,14 @@ const board board_tres = {
   .has_spi = true,
   .has_canfd = true,
   .has_rtc_battery = true,
+<<<<<<< HEAD
   .fan_max_rpm = 6600U,
   .adc_scale = 3021U,
+=======
+  .fan_max_rpm = 6500U,  // TODO: verify this, copied from dos
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 3U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = tres_init,
   .enable_can_transceiver = red_chiplet_enable_can_transceiver,
   .enable_can_transceivers = red_chiplet_enable_can_transceivers,

--- a/board/boards/tres.h
+++ b/board/boards/tres.h
@@ -4,8 +4,14 @@
 
 bool tres_ir_enabled;
 bool tres_fan_enabled;
+uint8_t tres_fan_cooldown = 0U;
 void tres_update_fan_ir_power(void) {
-  red_chiplet_set_fan_or_usb_load_switch(tres_ir_enabled || tres_fan_enabled);
+  if (tres_fan_enabled) {
+    // keep power on a few seconds after disabling to allow the fan to spin down
+    tres_fan_cooldown = 3U;
+  }
+
+  red_chiplet_set_fan_or_usb_load_switch(tres_ir_enabled || tres_fan_enabled || (tres_fan_cooldown > 0U));
 }
 
 void tres_set_ir_power(uint8_t percentage){
@@ -31,6 +37,11 @@ void tres_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen) {
 
   }
   tres_ignition_prev = ignition;
+
+  if (tres_fan_cooldown > 0U) {
+    tres_fan_cooldown--;
+  }
+  tres_update_fan_ir_power();
 }
 
 void tres_set_fan_enabled(bool enabled) {

--- a/board/boards/tres.h
+++ b/board/boards/tres.h
@@ -93,14 +93,10 @@ const board board_tres = {
   .has_spi = true,
   .has_canfd = true,
   .has_rtc_battery = true,
-<<<<<<< HEAD
   .fan_max_rpm = 6600U,
   .adc_scale = 3021U,
-=======
-  .fan_max_rpm = 6500U,  // TODO: verify this, copied from dos
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 3U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = tres_init,
   .enable_can_transceiver = red_chiplet_enable_can_transceiver,
   .enable_can_transceivers = red_chiplet_enable_can_transceivers,

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -251,12 +251,9 @@ const board board_uno = {
   .has_canfd = false,
   .has_rtc_battery = true,
   .fan_max_rpm = 5100U,
-<<<<<<< HEAD
   .adc_scale = 8862U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = uno_init,
   .enable_can_transceiver = uno_enable_can_transceiver,
   .enable_can_transceivers = uno_enable_can_transceivers,

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -251,7 +251,12 @@ const board board_uno = {
   .has_canfd = false,
   .has_rtc_battery = true,
   .fan_max_rpm = 5100U,
+<<<<<<< HEAD
   .adc_scale = 8862U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = uno_init,
   .enable_can_transceiver = uno_enable_can_transceiver,
   .enable_can_transceivers = uno_enable_can_transceivers,

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -247,7 +247,12 @@ const board board_white = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
+<<<<<<< HEAD
   .adc_scale = 8862U,
+=======
+  .fan_stall_recovery = false,
+  .fan_enable_cooldown_time = 0U,
+>>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = white_init,
   .enable_can_transceiver = white_enable_can_transceiver,
   .enable_can_transceivers = white_enable_can_transceivers,

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -247,12 +247,9 @@ const board board_white = {
   .has_canfd = false,
   .has_rtc_battery = false,
   .fan_max_rpm = 0U,
-<<<<<<< HEAD
   .adc_scale = 8862U,
-=======
   .fan_stall_recovery = false,
   .fan_enable_cooldown_time = 0U,
->>>>>>> 89777a58 (refactor to be inside the fan driver)
   .init = white_init,
   .enable_can_transceiver = white_enable_can_transceiver,
   .enable_can_transceivers = white_enable_can_transceivers,

--- a/board/stm32fx/llfan.h
+++ b/board/stm32fx/llfan.h
@@ -2,12 +2,14 @@
 void EXTI2_IRQ_Handler(void) {
   volatile unsigned int pr = EXTI->PR & (1U << 2);
   if ((pr & (1U << 2)) != 0U) {
-      fan_state.tach_counter++;
+    fan_state.tach_counter++;
   }
   EXTI->PR = (1U << 2);
 }
 
 void llfan_init(void) {
+  fan_reset_cooldown();
+
   // 5000RPM * 4 tach edges / 60 seconds
   REGISTER_INTERRUPT(EXTI2_IRQn, EXTI2_IRQ_Handler, 700U, FAULT_INTERRUPT_RATE_TACH)
 

--- a/board/stm32h7/llfan.h
+++ b/board/stm32h7/llfan.h
@@ -8,6 +8,8 @@ void EXTI2_IRQ_Handler(void) {
 }
 
 void llfan_init(void) {
+  fan_reset_cooldown();
+
   // 5000RPM * 4 tach edges / 60 seconds
   REGISTER_INTERRUPT(EXTI2_IRQn, EXTI2_IRQ_Handler, 700U, FAULT_INTERRUPT_RATE_TACH)
 


### PR DESCRIPTION
Wait a few seconds before turning the fan power off. If we turn it off with the rotor still spinning, the back EMF creates enough power to slightly power the fan controller and generate spurious tach edges.