### PR TITLE
safety replay: update Honda steer value getter

### DIFF
--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -29,7 +29,8 @@ def is_steering_msg(mode, addr):
 def get_steer_value(mode, to_send):
   torque, angle = 0, 0
   if mode in (Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_BOSCH):
-    torque = to_send.RDLR & 0xFFFF0000
+    torque = (to_send.data[0] << 8) | to_send.data[1])
+    torque = to_signed(torque, 16)
   elif mode == Panda.SAFETY_TOYOTA:
     torque = (to_send.data[1] << 8) | (to_send.data[2])
     torque = to_signed(torque, 16)

--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -29,7 +29,7 @@ def is_steering_msg(mode, addr):
 def get_steer_value(mode, to_send):
   torque, angle = 0, 0
   if mode in (Panda.SAFETY_HONDA_NIDEC, Panda.SAFETY_HONDA_BOSCH):
-    torque = (to_send.data[0] << 8) | to_send.data[1])
+    torque = (to_send.data[0] << 8) | to_send.data[1]
     torque = to_signed(torque, 16)
   elif mode == Panda.SAFETY_TOYOTA:
     torque = (to_send.data[1] << 8) | (to_send.data[2])


### PR DESCRIPTION
I think now it´s right!

```
BO_ 228 STEERING_CONTROL: 5 EON
  SG_ STEER_TORQUE : 7|16@0- (1,0) [-4096|4096] "" EPS
```
![image](https://user-images.githubusercontent.com/66435071/225660568-f15de7d2-382a-4f9f-9ebf-dd24a5a0fac3.png)
