### PR TITLE
Make Toyota safety tests more modular

### DIFF
--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -48,9 +48,11 @@ const uint32_t TOYOTA_PARAM_OFFSET = 8U;
 const uint32_t TOYOTA_EPS_FACTOR = (1U << TOYOTA_PARAM_OFFSET) - 1U;
 const uint32_t TOYOTA_PARAM_ALT_BRAKE = 1U << TOYOTA_PARAM_OFFSET;
 const uint32_t TOYOTA_PARAM_STOCK_LONGITUDINAL = 2U << TOYOTA_PARAM_OFFSET;
+const uint32_t TOYOTA_PARAM_LTA = 4U << TOYOTA_PARAM_OFFSET;
 
 bool toyota_alt_brake = false;
 bool toyota_stock_longitudinal = false;
+bool toyota_lta = false;
 int toyota_dbc_eps_torque_factor = 100;   // conversion factor for STEER_TORQUE_EPS in %: see dbc file
 
 static uint32_t toyota_compute_checksum(CANPacket_t *to_push) {
@@ -208,6 +210,10 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
       if (steer_torque_cmd_checks(desired_torque, steer_req, TOYOTA_STEERING_LIMITS)) {
         tx = 0;
       }
+      // When using LTA (angle control), assert no actuation on LKA message
+      if (toyota_lta && ((desired_torque != 0) || steer_req)) {
+        tx = 0;
+      }
     }
   }
 
@@ -218,6 +224,7 @@ static const addr_checks* toyota_init(uint16_t param) {
   gas_interceptor_detected = 0;
   toyota_alt_brake = GET_FLAG(param, TOYOTA_PARAM_ALT_BRAKE);
   toyota_stock_longitudinal = GET_FLAG(param, TOYOTA_PARAM_STOCK_LONGITUDINAL);
+  toyota_lta = GET_FLAG(param, TOYOTA_PARAM_LTA);
   toyota_dbc_eps_torque_factor = param & TOYOTA_EPS_FACTOR;
   return &toyota_rx_checks;
 }

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -197,6 +197,7 @@ class Panda:
   # first byte is for EPS scaling factor
   FLAG_TOYOTA_ALT_BRAKE = (1 << 8)
   FLAG_TOYOTA_STOCK_LONGITUDINAL = (2 << 8)
+  FLAG_TOYOTA_LTA = (4 << 8)
 
   FLAG_HONDA_ALT_BRAKE = 1
   FLAG_HONDA_BOSCH_LONG = 2

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -778,7 +778,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
             # No point in comparing different Tesla safety modes
             if 'Tesla' in attr and 'Tesla' in current_test:
               continue
-            if {attr, current_test}.issubset({'TestToyotaSafety', 'TestToyotaAltBrakeSafety', 'TestToyotaStockLongitudinal', 'TestToyotaLTA', 'TestToyotaStockLongitudinalLTA'}):
+            if {attr, current_test}.issubset({'TestToyotaSafety', 'TestToyotaSafetyTorque', 'TestToyotaAltBrakeSafety', 'TestToyotaStockLongitudinal', 'TestToyotaLTA', 'TestToyotaStockLongitudinalLTA'}):
               continue
             if {attr, current_test}.issubset({'TestSubaruSafety', 'TestSubaruGen2Safety'}):
               continue

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -778,7 +778,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
             # No point in comparing different Tesla safety modes
             if 'Tesla' in attr and 'Tesla' in current_test:
               continue
-            if {attr, current_test}.issubset({'TestToyotaSafety', 'TestToyotaAltBrakeSafety', 'TestToyotaStockLongitudinal'}):
+            if {attr, current_test}.issubset({'TestToyotaSafety', 'TestToyotaAltBrakeSafety', 'TestToyotaStockLongitudinal', 'TestToyotaLTA', 'TestToyotaStockLongitudinalLTA'}):
               continue
             if {attr, current_test}.issubset({'TestSubaruSafety', 'TestSubaruGen2Safety'}):
               continue

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -201,49 +201,49 @@ class TestToyotaSafetyTorque(TestToyotaSafetyBase, common.MotorTorqueSteeringSaf
         self.assertEqual(should_tx, self._tx(self._lta_msg(req, req2, angle)))
 
 
-# class TestToyotaAltBrakeSafety(TestToyotaSafety):
-#   def setUp(self):
-#     self.packer = CANPackerPanda("toyota_new_mc_pt_generated")
-#     self.safety = libpanda_py.libpanda
-#     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_ALT_BRAKE)
-#     self.safety.init_tests()
-#
-#   def _user_brake_msg(self, brake):
-#     values = {"BRAKE_PRESSED": brake}
-#     return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
-#
-#   # No LTA on these cars
-#   def test_lta_steer_cmd(self):
-#     pass
-#
-#
-# class TestToyotaStockLongitudinal(TestToyotaSafety):
-#   def setUp(self):
-#     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
-#     self.safety = libpanda_py.libpanda
-#     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL)
-#     self.safety.init_tests()
-#
-#   def test_accel_actuation_limits(self, stock_longitudinal=True):
-#     super().test_accel_actuation_limits(stock_longitudinal=stock_longitudinal)
-#
-#   def test_acc_cancel(self):
-#     """
-#       Regardless of controls allowed, never allow ACC_CONTROL if cancel bit isn't set
-#     """
-#     for controls_allowed in [True, False]:
-#       self.safety.set_controls_allowed(controls_allowed)
-#       for accel in np.arange(MIN_ACCEL - 1, MAX_ACCEL + 1, 0.1):
-#         self.assertFalse(self._tx(self._accel_msg(accel)))
-#         should_tx = np.isclose(accel, 0, atol=0.0001)
-#         self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
-#
-#   def test_fwd_hook(self):
-#     # forward ACC_CONTROL
-#     self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
-#     super().test_fwd_hook()
-#
-#
+class TestToyotaAltBrakeSafety(TestToyotaSafetyTorque):
+  def setUp(self):
+    self.packer = CANPackerPanda("toyota_new_mc_pt_generated")
+    self.safety = libpanda_py.libpanda
+    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_ALT_BRAKE)
+    self.safety.init_tests()
+
+  def _user_brake_msg(self, brake):
+    values = {"BRAKE_PRESSED": brake}
+    return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
+
+  # No LTA message in the DBC
+  def test_lta_steer_cmd(self):
+    pass
+
+
+class TestToyotaStockLongitudinal(TestToyotaSafetyTorque):
+  def setUp(self):
+    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+    self.safety = libpanda_py.libpanda
+    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL)
+    self.safety.init_tests()
+
+  def test_accel_actuation_limits(self, stock_longitudinal=True):
+    super().test_accel_actuation_limits(stock_longitudinal=stock_longitudinal)
+
+  def test_acc_cancel(self):
+    """
+      Regardless of controls allowed, never allow ACC_CONTROL if cancel bit isn't set
+    """
+    for controls_allowed in [True, False]:
+      self.safety.set_controls_allowed(controls_allowed)
+      for accel in np.arange(MIN_ACCEL - 1, MAX_ACCEL + 1, 0.1):
+        self.assertFalse(self._tx(self._accel_msg(accel)))
+        should_tx = np.isclose(accel, 0, atol=0.0001)
+        self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
+
+  def test_fwd_hook(self):
+    # forward ACC_CONTROL
+    self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
+    super().test_fwd_hook()
+
+
 # class TestToyotaLTA(TestToyotaSafety):
 #   MAX_TORQUE = 0
 #   MIN_VALID_STEERING_FRAMES = 0

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -21,13 +21,13 @@ def interceptor_msg(gas, addr):
   return to_send
 
 
-class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
-                       common.MotorTorqueSteeringSafetyTest):
+class TestToyotaSafetyBase(common.PandaSafetyTest, common.InterceptorSafetyTest):
 
   TX_MSGS = [[0x283, 0], [0x2E6, 0], [0x2E7, 0], [0x33E, 0], [0x344, 0], [0x365, 0], [0x366, 0], [0x4CB, 0],  # DSU bus 0
              [0x128, 1], [0x141, 1], [0x160, 1], [0x161, 1], [0x470, 1],  # DSU bus 1
              [0x2E4, 0], [0x191, 0], [0x411, 0], [0x412, 0], [0x343, 0], [0x1D2, 0],  # LKAS + ACC
              [0x200, 0], [0x750, 0]]  # interceptor + blindspot monitor
+
   STANDSTILL_THRESHOLD = 0  # kph
   RELAY_MALFUNCTION_ADDR = 0x2E4
   RELAY_MALFUNCTION_BUS = 0
@@ -35,30 +35,14 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
   INTERCEPTOR_THRESHOLD = 805
 
-  MAX_RATE_UP = 15
-  MAX_RATE_DOWN = 25
-  MAX_TORQUE = 1500
-  MAX_RT_DELTA = 450
-  RT_INTERVAL = 250000
-  MAX_TORQUE_ERROR = 350
-  TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conservative for rounding
-  EPS_SCALE = 73
+  @classmethod
+  def setUpClass(cls):
+    if cls.__name__ == "TestToyotaSafetyBase":
+      cls.packer = None
+      cls.safety = None
+      raise unittest.SkipTest
 
-  # Safety around steering req bit
-  MIN_VALID_STEERING_FRAMES = 18
-  MAX_INVALID_STEERING_FRAMES = 1
-  MIN_VALID_STEERING_RT_INTERVAL = 170000  # a ~10% buffer, can send steer up to 110Hz
-
-  def setUp(self):
-    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
-    self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE)
-    self.safety.init_tests()
-
-  def _torque_meas_msg(self, torque):
-    values = {"STEER_TORQUE_EPS": (torque / self.EPS_SCALE) * 100.}
-    return self.packer.make_can_msg_panda("STEER_TORQUE_SENSOR", 0, values)
-
+  # Both torque and angle safety modes test with torque and angle cmds
   def _torque_cmd_msg(self, torque, steer_req=1):
     values = {"STEER_TORQUE_CMD": torque, "STEER_REQUEST": steer_req}
     return self.packer.make_can_msg_panda("STEERING_LKA", 0, values)
@@ -67,6 +51,7 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
     values = {"STEER_REQUEST": req, "STEER_REQUEST_2": req2, "STEER_ANGLE_CMD": angle_cmd}
     return self.packer.make_can_msg_panda("STEERING_LTA", 0, values)
 
+  # TODO: ensure order is same as before
   def _accel_msg(self, accel, cancel_req=0):
     values = {"ACCEL_CMD": accel, "CANCEL_REQ": cancel_req}
     return self.packer.make_can_msg_panda("ACC_CONTROL", 0, values)
@@ -94,17 +79,6 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   def _interceptor_user_gas(self, gas):
     return interceptor_msg(gas, 0x201)
 
-  def test_block_aeb(self):
-    for controls_allowed in (True, False):
-      for bad in (True, False):
-        for _ in range(10):
-          self.safety.set_controls_allowed(controls_allowed)
-          dat = [random.randint(1, 255) for _ in range(7)]
-          if not bad:
-            dat = [0]*6 + dat[-1:]
-          msg = libpanda_py.make_CANPacket(0x283, 0, bytes(dat))
-          self.assertEqual(not bad, self._tx(msg))
-
   def test_accel_actuation_limits(self, stock_longitudinal=False):
     limits = ((MIN_ACCEL, MAX_ACCEL, ALTERNATIVE_EXPERIENCE.DEFAULT),
               (MIN_ACCEL, MAX_ACCEL, ALTERNATIVE_EXPERIENCE.RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX))
@@ -121,6 +95,90 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
           else:
             should_tx = np.isclose(accel, 0, atol=0.0001)
           self.assertEqual(should_tx, self._tx(self._accel_msg(accel)))
+
+  def test_block_aeb(self):
+    for controls_allowed in (True, False):
+      for bad in (True, False):
+        for _ in range(10):
+          self.safety.set_controls_allowed(controls_allowed)
+          dat = [random.randint(1, 255) for _ in range(7)]
+          if not bad:
+            dat = [0]*6 + dat[-1:]
+          msg = libpanda_py.make_CANPacket(0x283, 0, bytes(dat))
+          self.assertEqual(not bad, self._tx(msg))
+
+  def test_rx_hook(self):
+    # checksum checks
+    for msg in ["trq", "pcm"]:
+      self.safety.set_controls_allowed(1)
+      if msg == "trq":
+        to_push = self._torque_meas_msg(0)
+      if msg == "pcm":
+        to_push = self._pcm_status_msg(True)
+      self.assertTrue(self._rx(to_push))
+      to_push[0].data[4] = 0
+      to_push[0].data[5] = 0
+      to_push[0].data[6] = 0
+      to_push[0].data[7] = 0
+      self.assertFalse(self._rx(to_push))
+      self.assertFalse(self.safety.get_controls_allowed())
+
+
+# class TestToyotaSafety(TestToyotaSafetyBase):
+#   pass
+
+
+# class TestToyotaSafety(TestToyotaSafetyBase, common.MotorTorqueSteeringSafetyTest):
+#   MAX_RATE_UP = 15
+#   MAX_RATE_DOWN = 25
+#   MAX_TORQUE = 1500
+#   MAX_RT_DELTA = 450
+#   RT_INTERVAL = 250000
+#   MAX_TORQUE_ERROR = 350
+#   TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conservative for rounding
+#   EPS_SCALE = 73
+#
+#   # Safety around steering req bit
+#   MIN_VALID_STEERING_FRAMES = 18
+#   MAX_INVALID_STEERING_FRAMES = 1
+#   MIN_VALID_STEERING_RT_INTERVAL = 170000  # a ~10% buffer, can send steer up to 110Hz
+#
+#   def setUp(self):
+#     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+#     self.safety = libpanda_py.libpanda
+#     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE)
+#     self.safety.init_tests()
+#
+#   def _torque_meas_msg(self, torque):
+#     values = {"STEER_TORQUE_EPS": (torque / self.EPS_SCALE) * 100.}
+#     return self.packer.make_can_msg_panda("STEER_TORQUE_SENSOR", 0, values)
+
+
+class TestToyotaSafetyTorque(TestToyotaSafetyBase, common.MotorTorqueSteeringSafetyTest):
+
+  MAX_RATE_UP = 15
+  MAX_RATE_DOWN = 25
+  MAX_TORQUE = 1500
+  MAX_RT_DELTA = 450
+  RT_INTERVAL = 250000
+  MAX_TORQUE_ERROR = 350
+  TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conservative for rounding
+  EPS_SCALE = 73
+
+  # Safety around steering req bit
+  MIN_VALID_STEERING_FRAMES = 18
+  MAX_INVALID_STEERING_FRAMES = 1
+  MIN_VALID_STEERING_RT_INTERVAL = 170000  # a ~10% buffer, can send steer up to 110Hz
+
+  def setUp(self):
+    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+    self.safety = libpanda_py.libpanda
+    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE)
+    self.safety.init_tests()
+
+  def _torque_meas_msg(self, torque):
+    values = {"STEER_TORQUE_EPS": (torque / self.EPS_SCALE) * 100.}
+    return self.packer.make_can_msg_panda("STEER_TORQUE_SENSOR", 0, values)
 
   # Only allow LTA msgs with no actuation
   def test_lta_steer_cmd(self):
@@ -142,64 +200,98 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
         should_tx = not req and not req2 and angle == 0
         self.assertEqual(should_tx, self._tx(self._lta_msg(req, req2, angle)))
 
-  def test_rx_hook(self):
-    # checksum checks
-    for msg in ["trq", "pcm"]:
-      self.safety.set_controls_allowed(1)
-      if msg == "trq":
-        to_push = self._torque_meas_msg(0)
-      if msg == "pcm":
-        to_push = self._pcm_status_msg(True)
-      self.assertTrue(self._rx(to_push))
-      to_push[0].data[4] = 0
-      to_push[0].data[5] = 0
-      to_push[0].data[6] = 0
-      to_push[0].data[7] = 0
-      self.assertFalse(self._rx(to_push))
-      self.assertFalse(self.safety.get_controls_allowed())
 
-
-class TestToyotaAltBrakeSafety(TestToyotaSafety):
-  def setUp(self):
-    self.packer = CANPackerPanda("toyota_new_mc_pt_generated")
-    self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_ALT_BRAKE)
-    self.safety.init_tests()
-
-  def _user_brake_msg(self, brake):
-    values = {"BRAKE_PRESSED": brake}
-    return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
-
-  # No LTA on these cars
-  def test_lta_steer_cmd(self):
-    pass
-
-
-class TestToyotaStockLongitudinal(TestToyotaSafety):
-  def setUp(self):
-    self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
-    self.safety = libpanda_py.libpanda
-    self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL)
-    self.safety.init_tests()
-
-  def test_accel_actuation_limits(self, stock_longitudinal=True):
-    super().test_accel_actuation_limits(stock_longitudinal=stock_longitudinal)
-
-  def test_acc_cancel(self):
-    """
-      Regardless of controls allowed, never allow ACC_CONTROL if cancel bit isn't set
-    """
-    for controls_allowed in [True, False]:
-      self.safety.set_controls_allowed(controls_allowed)
-      for accel in np.arange(MIN_ACCEL - 1, MAX_ACCEL + 1, 0.1):
-        self.assertFalse(self._tx(self._accel_msg(accel)))
-        should_tx = np.isclose(accel, 0, atol=0.0001)
-        self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
-
-  def test_fwd_hook(self):
-    # forward ACC_CONTROL
-    self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
-    super().test_fwd_hook()
+# class TestToyotaAltBrakeSafety(TestToyotaSafety):
+#   def setUp(self):
+#     self.packer = CANPackerPanda("toyota_new_mc_pt_generated")
+#     self.safety = libpanda_py.libpanda
+#     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_ALT_BRAKE)
+#     self.safety.init_tests()
+#
+#   def _user_brake_msg(self, brake):
+#     values = {"BRAKE_PRESSED": brake}
+#     return self.packer.make_can_msg_panda("BRAKE_MODULE", 0, values)
+#
+#   # No LTA on these cars
+#   def test_lta_steer_cmd(self):
+#     pass
+#
+#
+# class TestToyotaStockLongitudinal(TestToyotaSafety):
+#   def setUp(self):
+#     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+#     self.safety = libpanda_py.libpanda
+#     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL)
+#     self.safety.init_tests()
+#
+#   def test_accel_actuation_limits(self, stock_longitudinal=True):
+#     super().test_accel_actuation_limits(stock_longitudinal=stock_longitudinal)
+#
+#   def test_acc_cancel(self):
+#     """
+#       Regardless of controls allowed, never allow ACC_CONTROL if cancel bit isn't set
+#     """
+#     for controls_allowed in [True, False]:
+#       self.safety.set_controls_allowed(controls_allowed)
+#       for accel in np.arange(MIN_ACCEL - 1, MAX_ACCEL + 1, 0.1):
+#         self.assertFalse(self._tx(self._accel_msg(accel)))
+#         should_tx = np.isclose(accel, 0, atol=0.0001)
+#         self.assertEqual(should_tx, self._tx(self._accel_msg(accel, cancel_req=1)))
+#
+#   def test_fwd_hook(self):
+#     # forward ACC_CONTROL
+#     self.FWD_BLACKLISTED_ADDRS[2].remove(0x343)
+#     super().test_fwd_hook()
+#
+#
+# class TestToyotaLTA(TestToyotaSafety):
+#   MAX_TORQUE = 0
+#   MIN_VALID_STEERING_FRAMES = 0
+#   MAX_INVALID_STEERING_FRAMES = 0
+#   MIN_VALID_STEERING_RT_INTERVAL = 0
+#
+#   MAX_RT_DELTA = 0
+#   MAX_RATE_UP = 0
+#   MAX_RATE_DOWN = 0
+#
+#   def setUp(self):
+#     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+#     self.safety = libpanda_py.libpanda
+#     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_LTA)
+#     self.safety.init_tests()
+#
+#   # def test_torque_absolute_limits(self):
+#   #   pass
+#
+#   # Only allow LKA msgs with no actuation
+#   def test_lka_steer_cmd(self):
+#     for engaged in [True, False]:
+#       self.safety.set_controls_allowed(engaged)
+#
+#       # good msg
+#       # self.assertTrue(self._tx(self._lta_msg(0, 0, 0)))
+#       self.assertTrue(self._tx(self._torque_cmd_msg(0, 0)))
+#
+#       # bad msgs
+#       self.assertFalse(self._tx(self._torque_cmd_msg(1, 0)))
+#       self.assertFalse(self._tx(self._torque_cmd_msg(0, 1)))
+#       # self.assertFalse(self._tx(self._torque_cmd_msg(1, 1)))
+#
+#       # for _ in range(20):
+#       #   req = random.choice([0, 1])
+#       #   torque = random.randint(-1500, 1500)
+#       #   should_tx = not req and torque == 0
+#       #   self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(torque, req)))
+#
+#
+# # class TestToyotaStockLongitudinalLTA(TestToyotaStockLongitudinal, TestToyotaLTA):
+# #   # TODO: make sure this works
+# #   def setUp(self):
+# #     self.packer = CANPackerPanda("toyota_nodsu_pt_generated")
+# #     self.safety = libpanda_py.libpanda
+# #     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE |
+# #                                  Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL | Panda.FLAG_TOYOTA_LTA)
+# #     self.safety.init_tests()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Toyota will have a base class that's not tested, but provides a bunch of helper rx message functions, and some base tests for all safety modes/params. This is similar to other brands

Think this will be separate from the extra LTA safety in this PR, WIP

Safety tests:

- Torque + Interceptor
- Torque + Interceptor + Alt brake
- Torque + Interceptor + Stock long
- Angle + Interceptor
- Angle + Interceptor + Stock long