### PR TITLE
python: fix slow reconnect

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -408,7 +408,6 @@ class Panda:
   def reconnect(self):
     if self._handle_open:
       self.close()
-      time.sleep(1.0)
 
     success = False
     # wait up to 15 seconds


### PR DESCRIPTION
This adds significant overhead in the HITL tests and slows down openpilot time-to-onroad. Needs testing