### PR TITLE
IsoTpMessage: fix rx_len sanity checks

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -460,7 +460,7 @@ class IsoTpMessage():
     # single rx_frame
     if rx_data[0] >> 4 == 0x0:
       self.rx_len = rx_data[0] & 0xFF
-      assert self.rx_len <= 0x7, f"isotp - rx: invalid single frame length: {self.rx_len}"
+      assert self.rx_len < self.max_len, f"isotp - rx: invalid single frame length: {self.rx_len}"
       self.rx_dat = rx_data[1:1 + self.rx_len]
       self.rx_idx = 0
       self.rx_done = True
@@ -470,7 +470,7 @@ class IsoTpMessage():
     # first rx_frame
     elif rx_data[0] >> 4 == 0x1:
       self.rx_len = ((rx_data[0] & 0x0F) << 8) + rx_data[1]
-      assert 0x8 <= self.rx_len, f"isotp - rx: invalid first frame length: {self.rx_len}"
+      assert self.max_len <= self.rx_len, f"isotp - rx: invalid first frame length: {self.rx_len}"
       self.rx_dat = rx_data[2:]
       self.rx_idx = 0
       self.rx_done = False


### PR DESCRIPTION
Fix a length bug from https://github.com/commaai/panda/pull/1311 when using subaddresses

Tests pass in https://github.com/commaai/panda/pull/1316