### PR TITLE
H7: fix CAN FD IRQ rate

### DIFF
--- a/board/stm32h7/stm32h7_config.h
+++ b/board/stm32h7/stm32h7_config.h
@@ -14,8 +14,19 @@
 
 #define BOOTLOADER_ADDRESS 0x1FF09804U
 
-// Around (1Mbps / 8 bits/byte / 12 bytes per message)
-#define CAN_INTERRUPT_RATE 12000U // FIXME: should raise to 16000 ?
+/*
+An IRQ is received on message RX/TX (or RX errors), with
+separate IRQs for RX and TX.
+
+0-byte CAN FD frame as the worst case:
+- 17 slow bits = SOF + 11 ID + R1 + IDE + EDL + R0 + BRS
+- 23 fast bits = ESI + 4 DLC + 0 DATA + 17 CRC + CRC delimeter
+- 12 slow bits = ACK + DEL + 7 EOF + 3 IFS
+- all currently supported cars are 500Kbps / 2Mbps
+
+1 / ((29 bits / 0.5Mbps) + (23 bits / 2Mbps)) = 14388Hz
+*/
+#define CAN_INTERRUPT_RATE 16000U
 
 #define MAX_LED_FADE 10240U
 

--- a/board/stm32h7/stm32h7_config.h
+++ b/board/stm32h7/stm32h7_config.h
@@ -22,7 +22,7 @@ separate IRQs for RX and TX.
 - 17 slow bits = SOF + 11 ID + R1 + IDE + EDL + R0 + BRS
 - 23 fast bits = ESI + 4 DLC + 0 DATA + 17 CRC + CRC delimeter
 - 12 slow bits = ACK + DEL + 7 EOF + 3 IFS
-- all currently supported cars are 500Kbps / 2Mbps
+- all currently supported cars are 0.5 Mbps / 2 Mbps
 
 1 / ((29 bits / 0.5Mbps) + (23 bits / 2Mbps)) = 14388Hz
 */


### PR DESCRIPTION
Draft, needs some more thought.  We're seeing some rare interrupt rate faults on all three buses.

I think we ideally want to set the interrupt rate based on the set speed.