### PR TITLE
README: fix error while installing requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Setup your dependencies:
 
 ```bash
 # Ubuntu
-sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip
+sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip libffi-dev
 pip install -r requirements.txt
 
 # macOS


### PR DESCRIPTION
Fixes `fatal error: ffi.h: No such file or directory` when installing requirements on a fresh install of Ubuntu 20.04