### PR TITLE
README: better instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,30 @@ It uses an [STM32F413](http://www.st.com/en/microcontrollers/stm32f413-423.html?
 
 ## Usage
 
-Setup your dependencies:
-
+Setup dependencies:
 ```bash
 # Ubuntu
 sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip
-pip install -r requirements.txt
-
+```
+```bash
 # macOS
 brew tap ArmMbed/homebrew-formulae
 brew install python dfu-util arm-none-eabi-gcc gcc@12
-pip install -r requirements.txt
 ```
 
-### Python
-
-To install the library:
+Clone panda repository:
 ``` bash
 git clone https://github.com/commaai/panda.git
 cd panda
+```
+
+Install requirements:
+```bash
+pip install -r requirements.txt
+```
+
+Install library:
+``` bash
 python setup.py install
 ```
 


### PR DESCRIPTION
The order of the code snippets seem out of place.
You can't `pip install -r requirements.txt` until you clone the repo which is listed a few steps below.

Also separates the dependency code snippets for Ubuntu and macOS for better copy pasting.