### PR TITLE
README: fix scons error while trying to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Setup your dependencies:
 
 ```bash
 # Ubuntu
-sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip
+sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip scons
 pip install -r requirements.txt
 
 # macOS


### PR DESCRIPTION
Fixes `scons: not found` error when trying to build using the flash/recover scripts on a fresh install of Ubuntu 20.04