### PR TITLE
Fix CAN message corruption on H7 under high load

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -146,13 +146,13 @@ void can_rx(uint8_t can_number) {
       // can is live
       pending_can_live = 1;
 
-      uint8_t get_index_offset = 0U;
-      if((CANx->RXF0S & FDCAN_RXF0S_F0F) == FDCAN_RXF0S_F0F) {
-        get_index_offset = 2U; // Recommended by datasheet if RX FIFO is in overwrite mode and full
-      }
       // get the index of the next RX FIFO element (0 to FDCAN_RX_FIFO_0_EL_CNT - 1)
-      uint8_t rx_fifo_idx = (uint8_t)((CANx->RXF0S >> FDCAN_RXF0S_F0GI_Pos) & 0x3F) + get_index_offset;
-      rx_fifo_idx = (rx_fifo_idx >= FDCAN_RX_FIFO_0_EL_CNT) ? (rx_fifo_idx - FDCAN_RX_FIFO_0_EL_CNT) : rx_fifo_idx;
+      uint8_t rx_fifo_idx = (uint8_t)((CANx->RXF0S >> FDCAN_RXF0S_F0GI_Pos) & 0x3F);
+
+      if((CANx->RXF0S & FDCAN_RXF0S_F0F) == FDCAN_RXF0S_F0F) {
+        rx_fifo_idx += 1U; // Recommended get index offset by datasheet if RX FIFO is in overwrite mode and full
+      }
+      rx_fifo_idx = ((rx_fifo_idx >= FDCAN_RX_FIFO_0_EL_CNT) ? (rx_fifo_idx - FDCAN_RX_FIFO_0_EL_CNT) : rx_fifo_idx);
 
       uint32_t RxFIFO0SA = FDCAN_START_ADDRESS + (can_number * FDCAN_OFFSET);
       CANPacket_t to_push;

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -149,10 +149,10 @@ void can_rx(uint8_t can_number) {
       // get the index of the next RX FIFO element (0 to FDCAN_RX_FIFO_0_EL_CNT - 1)
       uint8_t rx_fifo_idx = (uint8_t)((CANx->RXF0S >> FDCAN_RXF0S_F0GI_Pos) & 0x3F);
 
+      // Recommended to offset get index by at least +1 if RX FIFO is in overwrite mode and full (datasheet)
       if((CANx->RXF0S & FDCAN_RXF0S_F0F) == FDCAN_RXF0S_F0F) {
-        rx_fifo_idx += 1U; // Recommended get index offset by datasheet if RX FIFO is in overwrite mode and full
+        rx_fifo_idx = ((rx_fifo_idx + 1U) >= FDCAN_RX_FIFO_0_EL_CNT) ? 0U : (rx_fifo_idx + 1U);
       }
-      rx_fifo_idx = ((rx_fifo_idx >= FDCAN_RX_FIFO_0_EL_CNT) ? (rx_fifo_idx - FDCAN_RX_FIFO_0_EL_CNT) : rx_fifo_idx);
 
       uint32_t RxFIFO0SA = FDCAN_START_ADDRESS + (can_number * FDCAN_OFFSET);
       CANPacket_t to_push;

--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -13,12 +13,14 @@
 // FDCAN core settings
 #define FDCAN_MESSAGE_RAM_SIZE 0x2800UL
 #define FDCAN_START_ADDRESS 0x4000AC00UL
-#define FDCAN_OFFSET 3412UL // bytes for each FDCAN module
-#define FDCAN_OFFSET_W 853UL // words for each FDCAN module
-#define FDCAN_END_ADDRESS 0x4000D3FCUL // Message RAM has a width of 4 Bytes
+#define FDCAN_OFFSET 3384UL // bytes for each FDCAN module, equally
+#define FDCAN_OFFSET_W 846UL // words for each FDCAN module, equally
+#define FDCAN_END_ADDRESS 0x4000D3FCUL // Message RAM has a width of 4 bytes
+
+// FDCAN_RX_FIFO_0_EL_CNT + FDCAN_TX_FIFO_EL_CNT can't exceed 47 elements (47 * 72 bytes = 3,384 bytes) per FDCAN module
 
 // RX FIFO 0
-#define FDCAN_RX_FIFO_0_EL_CNT 24UL
+#define FDCAN_RX_FIFO_0_EL_CNT 30UL
 #define FDCAN_RX_FIFO_0_HEAD_SIZE 8UL // bytes
 #define FDCAN_RX_FIFO_0_DATA_SIZE 64UL // bytes
 #define FDCAN_RX_FIFO_0_EL_SIZE (FDCAN_RX_FIFO_0_HEAD_SIZE + FDCAN_RX_FIFO_0_DATA_SIZE)
@@ -26,7 +28,7 @@
 #define FDCAN_RX_FIFO_0_OFFSET 0UL
 
 // TX FIFO
-#define FDCAN_TX_FIFO_EL_CNT 16UL
+#define FDCAN_TX_FIFO_EL_CNT 17UL
 #define FDCAN_TX_FIFO_HEAD_SIZE 8UL // bytes
 #define FDCAN_TX_FIFO_DATA_SIZE 64UL // bytes
 #define FDCAN_TX_FIFO_EL_SIZE (FDCAN_TX_FIFO_HEAD_SIZE + FDCAN_TX_FIFO_DATA_SIZE)

--- a/tests/canfd/test_canfd.py
+++ b/tests/canfd/test_canfd.py
@@ -59,7 +59,7 @@ def canfd_test(p_send, p_recv):
         if len(data) >= 2:
           data[0] = calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8"))
         to_send.append([address, 0, data, bus])
-        sent_msgs[bus].add((address, data))
+        sent_msgs[bus].add((address, bytes(data)))
 
     p_send.can_send_many(to_send, timeout=0)
 

--- a/tests/canfd/test_canfd.py
+++ b/tests/canfd/test_canfd.py
@@ -3,7 +3,7 @@ import os
 import time
 import random
 from collections import defaultdict
-from panda import Panda
+from panda import Panda, calculate_checksum
 from panda_jungle import PandaJungle  # pylint: disable=import-error
 
 H7_HW_TYPES = [Panda.HW_TYPE_RED_PANDA, Panda.HW_TYPE_RED_PANDA_V2]
@@ -55,7 +55,8 @@ def canfd_test(p_send, p_recv):
       bus = random.randrange(3)
       for dlc in range(len(DLC_TO_LEN)):
         address = random.randrange(1, 1<<29)
-        data = bytes([random.getrandbits(8) for _ in range(DLC_TO_LEN[dlc])])
+        data = bytearray(random.getrandbits(8) for _ in range(DLC_TO_LEN[dlc]))
+        data[0] = calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8"))
         to_send.append([address, 0, data, bus])
         sent_msgs[bus].add((address, data))
 
@@ -66,6 +67,7 @@ def canfd_test(p_send, p_recv):
       incoming = p_recv.can_recv()
       for msg in incoming:
         address, _, data, bus = msg
+        assert calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8")) == data[0]
         k = (address, bytes(data))
         assert k in sent_msgs[bus], f"message {k} was never sent on bus {bus}"
         sent_msgs[bus].discard(k)

--- a/tests/canfd/test_canfd.py
+++ b/tests/canfd/test_canfd.py
@@ -56,7 +56,8 @@ def canfd_test(p_send, p_recv):
       for dlc in range(len(DLC_TO_LEN)):
         address = random.randrange(1, 1<<29)
         data = bytearray(random.getrandbits(8) for _ in range(DLC_TO_LEN[dlc]))
-        data[0] = calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8"))
+        if len(data) >= 2:
+          data[0] = calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8"))
         to_send.append([address, 0, data, bus])
         sent_msgs[bus].add((address, data))
 
@@ -67,7 +68,8 @@ def canfd_test(p_send, p_recv):
       incoming = p_recv.can_recv()
       for msg in incoming:
         address, _, data, bus = msg
-        assert calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8")) == data[0]
+        if len(data) >= 2:
+          assert calculate_checksum(data[1:] + bytes(str(address), encoding="utf-8")) == data[0]
         k = (address, bytes(data))
         assert k in sent_msgs[bus], f"message {k} was never sent on bus {bus}"
         sent_msgs[bus].discard(k)


### PR DESCRIPTION
From datasheet:

`When an Rx FIFO is operated in overwrite mode and an Rx FIFO full condition is signaled,
reading of the Rx FIFO elements should start at least at get index + 1. The reason for that is
that it can happen that a received message is written to the message RAM (put index) while
the CPU is reading from the message RAM (get index). In this case inconsistent data may
be read from the respective Rx FIFO element. Adding an offset to the get index when
reading from the Rx FIFO avoids this problem. The offset depends on how fast the CPU
accesses the Rx FIFO.`

