### PR TITLE
README: fix git error while trying to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Setup your dependencies:
 
 ```bash
 # Ubuntu
-sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip libffi-dev
+sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip libffi-dev git
 pip install -r requirements.txt
 
 # macOS


### PR DESCRIPTION
Fixes `git` error when trying to build using the flash/recover scripts on a fresh install of Ubuntu 20.04
```
scons: Reading SConscript files ...
FileNotFoundError: [Errno 2] No such file or directory: 'git':
```