### PR TITLE
H7: Rx FIFO lost counter

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -61,9 +61,6 @@ void update_can_health_pkt(uint8_t can_number, bool error_irq) {
 
   if (error_irq) {
     can_health[can_number].total_error_cnt += 1U;
-    if ((CANx->IR & (FDCAN_IR_RF0L)) != 0) {
-      can_health[can_number].total_rx_lost_cnt += 1U;
-    }
     if ((CANx->IR & (FDCAN_IR_TEFL)) != 0) {
       can_health[can_number].total_tx_lost_cnt += 1U;
     }
@@ -152,6 +149,7 @@ void can_rx(uint8_t can_number) {
       // Recommended to offset get index by at least +1 if RX FIFO is in overwrite mode and full (datasheet)
       if((CANx->RXF0S & FDCAN_RXF0S_F0F) == FDCAN_RXF0S_F0F) {
         rx_fifo_idx = ((rx_fifo_idx + 1U) >= FDCAN_RX_FIFO_0_EL_CNT) ? 0U : (rx_fifo_idx + 1U);
+        can_health[can_number].total_rx_lost_cnt += 1U; // At least one message was lost
       }
 
       uint32_t RxFIFO0SA = FDCAN_START_ADDRESS + (can_number * FDCAN_OFFSET);

--- a/board/health.h
+++ b/board/health.h
@@ -38,9 +38,9 @@ typedef struct __attribute__((packed)) {
   uint8_t last_stored_error; // last LEC positive error code stored
   uint8_t last_data_error; // DLEC (for CANFD only)
   uint8_t last_data_stored_error; // last DLEC positive error code stored (for CANFD only)
-  uint8_t receive_error_cnt; // REC
-  uint8_t transmit_error_cnt; // TEC
-  uint32_t total_error_cnt; // How many times any error interrupt were invoked
+  uint8_t receive_error_cnt; // Actual state of the receive error counter, values between 0 and 127. FDCAN_ECR.REC
+  uint8_t transmit_error_cnt; // Actual state of the transmit error counter, values between 0 and 255. FDCAN_ECR.TEC
+  uint32_t total_error_cnt; // How many times any error interrupt was invoked
   uint32_t total_tx_lost_cnt; // Tx event FIFO element lost
   uint32_t total_rx_lost_cnt; // Rx FIFO 0 message lost due to FIFO full condition
   uint32_t total_tx_cnt;

--- a/board/health.h
+++ b/board/health.h
@@ -41,8 +41,8 @@ typedef struct __attribute__((packed)) {
   uint8_t receive_error_cnt; // REC
   uint8_t transmit_error_cnt; // TEC
   uint32_t total_error_cnt; // How many times any error interrupt were invoked
-  uint32_t total_tx_lost_cnt; // Tx event FIFO element Lost
-  uint32_t total_rx_lost_cnt; // Rx FIFO 0 message Lost
+  uint32_t total_tx_lost_cnt; // Tx event FIFO element lost
+  uint32_t total_rx_lost_cnt; // Rx FIFO 0 message lost due to FIFO full condition
   uint32_t total_tx_cnt;
   uint32_t total_rx_cnt;
   uint32_t total_fwd_cnt; // Messages forwarded from one bus to another


### PR DESCRIPTION
Previous implementation wasn't working as supposed.
Now it will show how many messages were lost due to get index offset and full FIFO.