### PR TITLE
safety: don't check out of bounds array item

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -139,7 +139,7 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
   for (int i = 0; i < len; i++) {
     // if multiple msgs are allowed, determine which one is present on the bus
     if (!addr_list[i].msg_seen) {
-      for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
+      for (uint8_t j = 0U; (j < MAX_CAN_MSGS) && addr_list[i].msg[j].addr != 0; j++) {
         if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
               (length == addr_list[i].msg[j].len)) {
           addr_list[i].index = j;

--- a/board/safety.h
+++ b/board/safety.h
@@ -139,7 +139,7 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
   for (int i = 0; i < len; i++) {
     // if multiple msgs are allowed, determine which one is present on the bus
     if (!addr_list[i].msg_seen) {
-      for (uint8_t j = 0U; (j < MAX_ADDR_CHECK_MSGS) && addr_list[i].msg[j].addr != 0; j++) {
+      for (uint8_t j = 0U; (j < MAX_ADDR_CHECK_MSGS) && (addr_list[i].msg[j].addr != 0); j++) {
         if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
               (length == addr_list[i].msg[j].len)) {
           addr_list[i].index = j;

--- a/board/safety.h
+++ b/board/safety.h
@@ -139,7 +139,7 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
   for (int i = 0; i < len; i++) {
     // if multiple msgs are allowed, determine which one is present on the bus
     if (!addr_list[i].msg_seen) {
-      for (uint8_t j = 0U; (j < MAX_CAN_MSGS) && addr_list[i].msg[j].addr != 0; j++) {
+      for (uint8_t j = 0U; (j < MAX_ADDR_CHECK_MSGS) && addr_list[i].msg[j].addr != 0; j++) {
         if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
               (length == addr_list[i].msg[j].len)) {
           addr_list[i].index = j;

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -8,7 +8,7 @@
 
 const int MAX_WRONG_COUNTERS = 5;
 const uint8_t MAX_MISSED_MSGS = 10U;
-#define MAX_CAN_MSGS 3
+#define MAX_ADDR_CHECK_MSGS 3
 
 // sample struct that keeps 6 samples in memory
 struct sample_t {
@@ -93,16 +93,16 @@ typedef struct {
 // params and flags about checksum, counter and frequency checks for each monitored address
 typedef struct {
   // const params
-  const CanMsgCheck msg[MAX_CAN_MSGS]; // check either messages (e.g. honda steer)
+  const CanMsgCheck msg[MAX_ADDR_CHECK_MSGS];  // check either messages (e.g. honda steer)
   // dynamic flags
   bool msg_seen;
-  int index;                           // if multiple messages are allowed to be checked, this stores the index of the first one seen. only msg[msg_index] will be used
-  bool valid_checksum;                 // true if and only if checksum check is passed
-  int wrong_counters;                  // counter of wrong counters, saturated between 0 and MAX_WRONG_COUNTERS
-  bool valid_quality_flag;             // true if the message's quality/health/status signals are valid
-  uint8_t last_counter;                // last counter value
-  uint32_t last_timestamp;             // micro-s
-  bool lagging;                        // true if and only if the time between updates is excessive
+  int index;                         // if multiple messages are allowed to be checked, this stores the index of the first one seen. only msg[msg_index] will be used
+  bool valid_checksum;               // true if and only if checksum check is passed
+  int wrong_counters;                // counter of wrong counters, saturated between 0 and MAX_WRONG_COUNTERS
+  bool valid_quality_flag;           // true if the message's quality/health/status signals are valid
+  uint8_t last_counter;              // last counter value
+  uint32_t last_timestamp;           // micro-s
+  bool lagging;                      // true if and only if the time between updates is excessive
 } AddrCheckStruct;
 
 typedef struct {

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -8,7 +8,7 @@
 
 const int MAX_WRONG_COUNTERS = 5;
 const uint8_t MAX_MISSED_MSGS = 10U;
-#define MAX_ADDR_CHECK_MSGS 3
+#define MAX_ADDR_CHECK_MSGS 3U
 
 // sample struct that keeps 6 samples in memory
 struct sample_t {

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -8,6 +8,7 @@
 
 const int MAX_WRONG_COUNTERS = 5;
 const uint8_t MAX_MISSED_MSGS = 10U;
+#define MAX_CAN_MSGS 3
 
 // sample struct that keeps 6 samples in memory
 struct sample_t {
@@ -92,16 +93,16 @@ typedef struct {
 // params and flags about checksum, counter and frequency checks for each monitored address
 typedef struct {
   // const params
-  const CanMsgCheck msg[3];          // check either messages (e.g. honda steer). Array MUST terminate with an empty struct to know its length.
+  const CanMsgCheck msg[MAX_CAN_MSGS]; // check either messages (e.g. honda steer)
   // dynamic flags
   bool msg_seen;
-  int index;                         // if multiple messages are allowed to be checked, this stores the index of the first one seen. only msg[msg_index] will be used
-  bool valid_checksum;               // true if and only if checksum check is passed
-  int wrong_counters;                // counter of wrong counters, saturated between 0 and MAX_WRONG_COUNTERS
-  bool valid_quality_flag;           // true if the message's quality/health/status signals are valid
-  uint8_t last_counter;              // last counter value
-  uint32_t last_timestamp;           // micro-s
-  bool lagging;                      // true if and only if the time between updates is excessive
+  int index;                           // if multiple messages are allowed to be checked, this stores the index of the first one seen. only msg[msg_index] will be used
+  bool valid_checksum;                 // true if and only if checksum check is passed
+  int wrong_counters;                  // counter of wrong counters, saturated between 0 and MAX_WRONG_COUNTERS
+  bool valid_quality_flag;             // true if the message's quality/health/status signals are valid
+  uint8_t last_counter;                // last counter value
+  uint32_t last_timestamp;             // micro-s
+  bool lagging;                        // true if and only if the time between updates is excessive
 } AddrCheckStruct;
 
 typedef struct {


### PR DESCRIPTION
@adeebshihadeh if there are three messages in the array (which is statically allocated length of 3 `const CanMsgCheck msg[3];`), then the addr of the fourth array item is not guaranteed to be 0 since it's out of bounds, right?