### PR TITLE
safety: make addr index getter more explicit

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -149,11 +149,13 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
       }
     }
 
-    int idx = addr_list[i].index;
-    if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
-        (length == addr_list[i].msg[idx].len)) {
-      index = i;
-      break;
+    if (addr_list[i].msg_seen) {
+      int idx = addr_list[i].index;
+      if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
+          (length == addr_list[i].msg[idx].len)) {
+        index = i;
+        break;
+      }
     }
   }
   return index;


### PR DESCRIPTION
Just a refactor PR to make behavior more apparent. It wasn't clear to me immediately how this worked, since the index is defaulted to 0. It only worked since the if statement above was identical. This makes it more explicit and easier to understand how it doesn't select incorrect indices.

For example, above, if this check never evaluates, msg_seen is never set and index is left at 0:

```c
        if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
              (length == addr_list[i].msg[j].len)) {
          addr_list[i].index = j;
          addr_list[i].msg_seen = true;
          break;
        }
```

But below, it still checks if the message matches the index 0 `CanMsgCheck`, which looks like it may evaluate, but doesn't because the check is the same as above.

```c
      if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
          (length == addr_list[i].msg[idx].len)) {
        index = i;
        break;
      }
```