### PR TITLE
replay drive: fixes

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -170,6 +170,10 @@ void safety_tick(const addr_checks *rx_checks) {
       // Quite conservative to not risk false triggers.
       // 2s of lag is worse case, since the function is called at 1Hz
       bool lagging = elapsed_time > MAX(rx_checks->check[i].msg[rx_checks->check[i].index].expected_timestep * MAX_MISSED_MSGS, 1e6);
+      print("address: "); puth(rx_checks->check[i].msg[rx_checks->check[i].index].addr); print(", ");
+      print("lagging: "); puth(lagging); print("\n");
+      print("ts: "); puth(ts); print("\n");
+      print("last_ts: "); puth(rx_checks->check[i].last_timestamp); print("\n");
       rx_checks->check[i].lagging = lagging;
       if (lagging) {
         controls_allowed = 0;
@@ -179,6 +183,7 @@ void safety_tick(const addr_checks *rx_checks) {
         rx_checks_invalid = true;
       }
     }
+    print("\n");
   }
 
   safety_rx_checks_invalid = rx_checks_invalid;

--- a/board/safety.h
+++ b/board/safety.h
@@ -149,11 +149,13 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
       }
     }
 
-    int idx = addr_list[i].index;
-    if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
-        (length == addr_list[i].msg[idx].len)) {
-      index = i;
-      break;
+    if (addr_list[i].msg_seen) {
+      int idx = addr_list[i].index;
+      if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
+          (length == addr_list[i].msg[idx].len)) {
+        index = i;
+        break;
+      }
     }
   }
   return index;

--- a/board/safety.h
+++ b/board/safety.h
@@ -139,24 +139,13 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
   for (int i = 0; i < len; i++) {
     // if multiple msgs are allowed, determine which one is present on the bus
     if (!addr_list[i].msg_seen) {
-      int j = 0;
-//      for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
-      while (1) {
-        print("j idx: "); puth(j); print("\n");
-        print("addr: "); puth(addr_list[i].msg[j].addr); print("\n");
-        print("bus: "); puth(addr_list[i].msg[j].bus); print("\n");
-        print("len: "); puth(addr_list[i].msg[j].len); print("\n\n");
-        if (addr_list[i].msg[j].addr == 0) {
-          break;
-        }
-//        print("j reached: %d\n", j);
+      for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
         if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
               (length == addr_list[i].msg[j].len)) {
           addr_list[i].index = j;
           addr_list[i].msg_seen = true;
-//          break;
+          break;
         }
-        j += 1;
       }
     }
 

--- a/board/safety.h
+++ b/board/safety.h
@@ -139,13 +139,24 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
   for (int i = 0; i < len; i++) {
     // if multiple msgs are allowed, determine which one is present on the bus
     if (!addr_list[i].msg_seen) {
-      for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
+      int j = 0;
+//      for (uint8_t j = 0U; addr_list[i].msg[j].addr != 0; j++) {
+      while (1) {
+        print("j idx: "); puth(j); print("\n");
+        print("addr: "); puth(addr_list[i].msg[j].addr); print("\n");
+        print("bus: "); puth(addr_list[i].msg[j].bus); print("\n");
+        print("len: "); puth(addr_list[i].msg[j].len); print("\n\n");
+        if (addr_list[i].msg[j].addr == 0) {
+          break;
+        }
+//        print("j reached: %d\n", j);
         if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
               (length == addr_list[i].msg[j].len)) {
           addr_list[i].index = j;
           addr_list[i].msg_seen = true;
-          break;
+//          break;
         }
+        j += 1;
       }
     }
 

--- a/board/safety.h
+++ b/board/safety.h
@@ -149,13 +149,11 @@ int get_addr_check_index(CANPacket_t *to_push, AddrCheckStruct addr_list[], cons
       }
     }
 
-    if (addr_list[i].msg_seen) {
-      int idx = addr_list[i].index;
-      if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
-          (length == addr_list[i].msg[idx].len)) {
-        index = i;
-        break;
-      }
+    int idx = addr_list[i].index;
+    if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
+        (length == addr_list[i].msg[idx].len)) {
+      index = i;
+      break;
     }
   }
   return index;

--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -52,6 +52,25 @@ def package_can_msg(msg):
   return libpanda_py.make_CANPacket(msg.address, msg.src % 4, msg.dat)
 
 def init_segment(safety, lr, mode):
+  # start_t = None
+  # for msg in lr:
+  #   if start_t is None:
+  #     start_t = msg.logMonoTime
+  #
+  #   if msg.which() == 'can':
+  #     safety.set_timer((msg.logMonoTime // 1000) % 0xFFFFFFFF)
+  #     if msg.logMonoTime - start_t > 1e3:
+  #       break
+  #
+  #     for canmsg in msg.can:
+  #       if canmsg.src >= 128:
+  #         continue
+  #       to_push = package_can_msg(canmsg)
+  #       safety.safety_rx_hook(to_push)
+
+  # # Tick once to ensure rx checks are valid
+  # safety.safety_tick_current_rx_checks()
+
   sendcan = (msg for msg in lr if msg.which() == 'sendcan')
   steering_msgs = (can for msg in sendcan for can in msg.sendcan if is_steering_msg(mode, can.address))
 


### PR DESCRIPTION
We should only consider CAN messages, and sort, since there can be huge jumps from start_time