### PR TITLE
ford: allow 0 curvature when controls is allowed if not steering

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -262,6 +262,10 @@ static int ford_tx_hook(CANPacket_t *to_send) {
       }
     }
 
+    if (!steer_control_enabled && (desired_curvature != 0)) {
+      violation = true;
+    }
+
     // No curvature command if controls is not allowed
     if (!controls_allowed && ((desired_curvature != 0) || steer_control_enabled)) {
       violation = true;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -255,39 +255,22 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     bool violation = (raw_curvature_rate != INACTIVE_CURVATURE_RATE) || (raw_path_angle != INACTIVE_PATH_ANGLE) || (raw_path_offset != INACTIVE_PATH_OFFSET);
 
     int desired_curvature = raw_curvature - INACTIVE_CURVATURE;  // /FORD_STEERING_LIMITS.angle_deg_to_can to get real curvature
-    if (controls_allowed) {
-      if (steer_control_enabled) {
-        if (vehicle_speed > FORD_CURVATURE_DELTA_LIMIT_SPEED) {
+    if (controls_allowed && steer_control_enabled) {
+      if (vehicle_speed > FORD_CURVATURE_DELTA_LIMIT_SPEED) {
         violation |= angle_dist_to_meas_check(desired_curvature, &angle_meas,
                                               FORD_STEERING_LIMITS.max_angle_error, FORD_STEERING_LIMITS.max_steer);
       }
-      } else {
-        if (desired_curvature != 0) {
-          violation = true;
-        }
-      }
-    } else {
-      if ((desired_curvature != 0) || steer_control_enabled) {
-        violation = true;
-      }
     }
 
-//    int desired_curvature = raw_curvature - INACTIVE_CURVATURE;  // /FORD_STEERING_LIMITS.angle_deg_to_can to get real curvature
-//    if (controls_allowed && steer_control_enabled) {
-//      if (vehicle_speed > FORD_CURVATURE_DELTA_LIMIT_SPEED) {
-//        violation |= angle_dist_to_meas_check(desired_curvature, &angle_meas,
-//                                              FORD_STEERING_LIMITS.max_angle_error, FORD_STEERING_LIMITS.max_steer);
-//      }
-//    }
-//
-//    if (!steer_control_enabled && (desired_curvature != 0)) {
-//      violation = true;
-//    }
-//
-//    // No curvature command if controls is not allowed
-//    if (!controls_allowed && ((desired_curvature != 0) || steer_control_enabled)) {
-//      violation = true;
-//    }
+    // If steer control is not enabled, curvature must be 0
+    if (!steer_control_enabled && (desired_curvature != 0)) {
+      violation = true;
+    }
+
+    // No curvature command if controls is not allowed
+    if (!controls_allowed && ((desired_curvature != 0) || steer_control_enabled)) {
+      violation = true;
+    }
 
     if (violation) {
       tx = 0;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -255,7 +255,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     bool violation = (raw_curvature_rate != INACTIVE_CURVATURE_RATE) || (raw_path_angle != INACTIVE_PATH_ANGLE) || (raw_path_offset != INACTIVE_PATH_OFFSET);
 
     int desired_curvature = raw_curvature - INACTIVE_CURVATURE;  // /FORD_STEERING_LIMITS.angle_deg_to_can to get real curvature
-    if (controls_allowed) {
+    if (controls_allowed && steer_control_enabled) {
       if (vehicle_speed > FORD_CURVATURE_DELTA_LIMIT_SPEED) {
         violation |= angle_dist_to_meas_check(desired_curvature, &angle_meas,
                                               FORD_STEERING_LIMITS.max_angle_error, FORD_STEERING_LIMITS.max_steer);

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -234,15 +234,16 @@ class TestFordSafety(common.PandaSafetyTest):
     """This safety model enforces a maximum distance from measured and commanded curvature, only above a certain speed"""
     self.safety.set_controls_allowed(1)
 
-    for speed in np.linspace(0, 50, 11):
-      for initial_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 51):
-        self._reset_curvature_measurements(initial_curvature, speed)
+    for steer_control_enabled in (True, False):
+      for speed in np.linspace(0, 50, 11):
+        for initial_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 51):
+          self._reset_curvature_measurements(initial_curvature, speed)
 
-        limit_command = speed > self.CURVATURE_DELTA_LIMIT_SPEED
-        for new_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 51):
-          too_far_away = round_curvature_can(abs(new_curvature - initial_curvature)) > self.MAX_CURVATURE_DELTA
-          should_tx = not limit_command or not too_far_away
-          self.assertEqual(should_tx, self._tx(self._tja_command_msg(True, 0, 0, new_curvature, 0)))
+          limit_command = speed > self.CURVATURE_DELTA_LIMIT_SPEED
+          for new_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 51):
+            too_far_away = round_curvature_can(abs(new_curvature - initial_curvature)) > self.MAX_CURVATURE_DELTA
+            should_tx = not limit_command or not too_far_away or not steer_control_enabled
+            self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, 0, 0, new_curvature, 0)))
 
   def test_prevent_lkas_action(self):
     self.safety.set_controls_allowed(1)

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -241,6 +241,8 @@ class TestFordSafety(common.PandaSafetyTest):
 
           limit_command = speed > self.CURVATURE_DELTA_LIMIT_SPEED
           for new_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 51):
+            # if not steer_control_enabled:
+            #   new_curvature = 0
             too_far_away = round_curvature_can(abs(new_curvature - initial_curvature)) > self.MAX_CURVATURE_DELTA
             should_tx = not limit_command or not too_far_away or not steer_control_enabled
             self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, 0, 0, new_curvature, 0)))

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -253,7 +253,7 @@ class TestFordSafety(common.PandaSafetyTest):
               should_tx = new_curvature == 0
             with self.subTest(steer_control_enabled=steer_control_enabled, speed=speed,
                               initial_curvature=initial_curvature, new_curvature=new_curvature):
-              self.assertEqual(should_tx, self._tx(self._tja_command_msg(True, 0, 0, new_curvature, 0)))
+              self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, 0, 0, new_curvature, 0)))
 
   def test_prevent_lkas_action(self):
     self.safety.set_controls_allowed(1)

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -230,10 +230,7 @@ class TestFordSafety(common.PandaSafetyTest):
                   should_tx = should_tx and controls_allowed
                 else:
                   should_tx = should_tx and curvature == 0
-                with self.subTest(controls_allowed=controls_allowed, steer_control_enabled=steer_control_enabled,
-                                  path_offset=path_offset, path_angle=path_angle, curvature_rate=curvature_rate,
-                                  curvature=curvature):
-                  self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
+                self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
 
   def test_steer_meas_delta(self):
     """This safety model enforces a maximum distance from measured and commanded curvature, only above a certain speed"""

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -230,7 +230,10 @@ class TestFordSafety(common.PandaSafetyTest):
                   should_tx = should_tx and controls_allowed
                 else:
                   should_tx = should_tx and curvature == 0
-                self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
+                with self.subTest(controls_allowed=controls_allowed, steer_control_enabled=steer_control_enabled,
+                                  path_offset=path_offset, path_angle=path_angle, curvature_rate=curvature_rate,
+                                  curvature=curvature):
+                  self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
 
   def test_steer_meas_delta(self):
     """This safety model enforces a maximum distance from measured and commanded curvature, only above a certain speed"""

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -252,6 +252,7 @@ class TestFordSafety(common.PandaSafetyTest):
             if steer_control_enabled:
               should_tx = not limit_command or not too_far_away
             else:
+              # enforce angle error limit is disabled when steer request bit is 0
               should_tx = new_curvature == 0
             with self.subTest(steer_control_enabled=steer_control_enabled, speed=speed,
                               initial_curvature=initial_curvature, new_curvature=new_curvature):

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -228,7 +228,10 @@ class TestFordSafety(common.PandaSafetyTest):
 
                 should_tx = path_offset == 0 and path_angle == 0 and curvature_rate == 0
                 should_tx = should_tx and (not enabled or controls_allowed)
-                self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
+                with self.subTest(controls_allowed=controls_allowed, steer_control_enabled=steer_control_enabled,
+                                  path_offset=path_offset, path_angle=path_angle, curvature_rate=curvature_rate,
+                                  curvature=curvature):
+                  self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
 
   def test_steer_meas_delta(self):
     """This safety model enforces a maximum distance from measured and commanded curvature, only above a certain speed"""

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -228,10 +228,7 @@ class TestFordSafety(common.PandaSafetyTest):
 
                 should_tx = path_offset == 0 and path_angle == 0 and curvature_rate == 0
                 should_tx = should_tx and (not enabled or controls_allowed)
-                with self.subTest(controls_allowed=controls_allowed, steer_control_enabled=steer_control_enabled,
-                                  path_offset=path_offset, path_angle=path_angle, curvature_rate=curvature_rate,
-                                  curvature=curvature):
-                  self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
+                self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
 
   def test_steer_meas_delta(self):
     """This safety model enforces a maximum distance from measured and commanded curvature, only above a certain speed"""

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -229,7 +229,7 @@ class TestFordSafety(common.PandaSafetyTest):
                 if steer_control_enabled:
                   should_tx = should_tx and controls_allowed
                 else:
-                  # when request bit is 0, safety only allows curvature of 0 since the signal range
+                  # when request bit is 0, only allow curvature of 0 since the signal range
                   # is not large enough to enforce it tracking measured
                   should_tx = should_tx and curvature == 0
                 with self.subTest(controls_allowed=controls_allowed, steer_control_enabled=steer_control_enabled,

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -246,8 +246,6 @@ class TestFordSafety(common.PandaSafetyTest):
 
           limit_command = speed > self.CURVATURE_DELTA_LIMIT_SPEED
           for new_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 51):
-            # if not steer_control_enabled:
-            #   new_curvature = 0
             too_far_away = round_curvature_can(abs(new_curvature - initial_curvature)) > self.MAX_CURVATURE_DELTA
             if steer_control_enabled:
               should_tx = not limit_command or not too_far_away

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -249,11 +249,13 @@ class TestFordSafety(common.PandaSafetyTest):
           limit_command = speed > self.CURVATURE_DELTA_LIMIT_SPEED
           for new_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 41):
             too_far_away = round_curvature_can(abs(new_curvature - initial_curvature)) > self.MAX_CURVATURE_DELTA
+
             if steer_control_enabled:
               should_tx = not limit_command or not too_far_away
             else:
               # enforce angle error limit is disabled when steer request bit is 0
               should_tx = new_curvature == 0
+
             with self.subTest(steer_control_enabled=steer_control_enabled, speed=speed,
                               initial_curvature=initial_curvature, new_curvature=new_curvature):
               self.assertEqual(should_tx, self._tx(self._tja_command_msg(steer_control_enabled, 0, 0, new_curvature, 0)))

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -229,6 +229,8 @@ class TestFordSafety(common.PandaSafetyTest):
                 if steer_control_enabled:
                   should_tx = should_tx and controls_allowed
                 else:
+                  # when request bit is 0, safety only allows curvature of 0 since the signal range
+                  # is not large enough to enforce it tracking measured
                   should_tx = should_tx and curvature == 0
                 with self.subTest(controls_allowed=controls_allowed, steer_control_enabled=steer_control_enabled,
                                   path_offset=path_offset, path_angle=path_angle, curvature_rate=curvature_rate,


### PR DESCRIPTION
the case this allows is similar to torque control limiting:

- new behavior: if EPS is faulted and controls are allowed (or some other condition to make OP not want to steer), safety should allow OP to send 0 curvature with `steer_control_type=False`
- previous behavior: it only checks `controls_allowed`, so angle error limits likely will block msgs