### PR TITLE
angle safety: enforce disabled angle when not steering

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -644,7 +644,7 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
   desired_angle_last = desired_angle;
 
   // Angle should be the same as current angle while not steering
-  violation |= (!controls_allowed &&
+  violation |= (!steer_control_enabled &&
                   ((desired_angle < (angle_meas.min - 1)) ||
                   (desired_angle > (angle_meas.max + 1))));
 

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -586,26 +586,20 @@ class AngleSteeringSafetyTest(PandaSafetyTestBase):
   def test_angle_cmd_when_disabled(self):
     # Tests that only angles close to the meas are allowed while
     # steer actuation bit is 0, regardless of controls allowed.
-
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
 
-      for angle_meas in np.arange(-90, 91, 10):
-        self._angle_meas_msg_array(angle_meas)
+      for steer_control_enabled in (True, False):
 
-        for angle_cmd in np.arange(-90, 91, 10):
-          should_tx = angle_meas == angle_cmd
-          self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, False)))
+        for angle_meas in np.arange(-90, 91, 10):
+          self._angle_meas_msg_array(angle_meas)
 
-  def test_steer_control_enabled(self):
-    # Tests steer actuation bit
-    for controls_allowed in (True, False):
-      self.safety.set_controls_allowed(controls_allowed)
+          for angle_cmd in np.arange(-90, 91, 10):
+            self._set_prev_desired_angle(angle_cmd)
 
-      for steer_control_allowed in (True, False):
-
-        should_tx = not steer_control_allowed or controls_allowed
-        self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(0, steer_control_allowed)))
+            # Allow message if controls are allowed if bit is 1, or if not angle is inactive (close to meas)
+            should_tx = controls_allowed if steer_control_enabled else angle_cmd == angle_meas
+            self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, steer_control_enabled)))
 
 
 @add_regen_tests

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -584,11 +584,18 @@ class AngleSteeringSafetyTest(PandaSafetyTestBase):
         self.assertTrue(self._tx(self._angle_cmd_msg(a, False)))
 
   def test_angle_cmd_when_disabled(self):
-    self.safety.set_controls_allowed(0)
+    # Tests that only angles close to the meas are allowed while
+    # steer actuation bit is 0, regardless of controls allowed.
 
-    self._set_prev_desired_angle(0)
-    self.assertFalse(self._tx(self._angle_cmd_msg(0, True)))
-    self.assertFalse(self.safety.get_controls_allowed())
+    for controls_allowed in (True, False):
+      self.safety.set_controls_allowed(controls_allowed)
+
+      for angle_meas in np.arange(-90, 91, 10):
+        self._angle_meas_msg_array(angle_meas)
+
+        for angle_cmd in np.arange(-90, 91, 10):
+          should_tx = angle_meas == angle_cmd
+          self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, False)))
 
 
 @add_regen_tests

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -590,14 +590,13 @@ class AngleSteeringSafetyTest(PandaSafetyTestBase):
       self.safety.set_controls_allowed(controls_allowed)
 
       for steer_control_enabled in (True, False):
-
         for angle_meas in np.arange(-90, 91, 10):
           self._angle_meas_msg_array(angle_meas)
 
           for angle_cmd in np.arange(-90, 91, 10):
             self._set_prev_desired_angle(angle_cmd)
 
-            # Allow message if controls are allowed if bit is 1, or if not angle is inactive (close to meas)
+            # controls_allowed is checked if actuation bit is 1, else the angle must be close to meas (inactive)
             should_tx = controls_allowed if steer_control_enabled else angle_cmd == angle_meas
             self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, steer_control_enabled)))
 

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -597,6 +597,16 @@ class AngleSteeringSafetyTest(PandaSafetyTestBase):
           should_tx = angle_meas == angle_cmd
           self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, False)))
 
+  def test_steer_control_enabled(self):
+    # Tests steer actuation bit
+    for controls_allowed in (True, False):
+      self.safety.set_controls_allowed(controls_allowed)
+
+      for steer_control_allowed in (True, False):
+
+        should_tx = not steer_control_allowed or controls_allowed
+        self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(0, steer_control_allowed)))
+
 
 @add_regen_tests
 class PandaSafetyTest(PandaSafetyTestBase):


### PR DESCRIPTION
Previously we were enforcing a disabled angle only when controls were not allowed. When `steer_control_enabled` bit is 0, you could set it to whatever you wanted. Not a huge deal unless an EPS has a bug where it actuates on that, or winds up torque on set of the bit again.

todo:
- [x] test

split from https://github.com/commaai/panda/pull/1369