### PR TITLE
ford: disable counter check for second speed

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -29,7 +29,8 @@ const CanMsg FORD_TX_MSGS[] = {
 // this may be the cause of blocked messages
 AddrCheckStruct ford_addr_checks[] = {
   {.msg = {{MSG_BrakeSysFeatures, 0, 8, .check_checksum = true, .max_counter = 15U, .quality_flag=true, .expected_timestep = 20000U}, { 0 }, { 0 }}},
-  {.msg = {{MSG_EngVehicleSpThrottle2, 0, 8, .check_checksum = true, .max_counter = 15U, .quality_flag=true, .expected_timestep = 20000U}, { 0 }, { 0 }}},
+  // TODO: MSG_EngVehicleSpThrottle2 has a counter that skips by 2, understand and enable counter check
+  {.msg = {{MSG_EngVehicleSpThrottle2, 0, 8, .check_checksum = true, .quality_flag=true, .expected_timestep = 20000U}, { 0 }, { 0 }}},
   {.msg = {{MSG_Yaw_Data_FD1, 0, 8, .check_checksum = true, .max_counter = 255U, .quality_flag=true, .expected_timestep = 10000U}, { 0 }, { 0 }}},
   // These messages have no counter or checksum
   {.msg = {{MSG_EngBrakeData, 0, 8, .expected_timestep = 100000U}, { 0 }, { 0 }}},


### PR DESCRIPTION
the lsb is either always 1 or 0 on most cars (varies by route on same car), and I've seen it go from 1 to 0 around the time the ignition fell after a long route, so something weird is going on. on some cars (Escapes), it's set but very inconsistent, bad cable or bad ECU?

think the counter signal def is correct as checksum also decrements by 2 (0xFF - counter), which would make the checksum invalid if we removed the bit

todo: understand from data if it consistently skips by 2, then check the three bit counter, while keeping four bits in the checksum calculation 