### PR TITLE
Subaru: allow Throttle TX on bus 2 for stop and go

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -26,6 +26,7 @@ const CanMsg SUBARU_TX_MSGS[] = {
   {0x321, 0, 8},
   {0x322, 0, 8},
   {0x323, 0, 8},
+  {0x40,  2, 8},
 };
 #define SUBARU_TX_MSGS_LEN (sizeof(SUBARU_TX_MSGS) / sizeof(SUBARU_TX_MSGS[0]))
 
@@ -151,7 +152,12 @@ static int subaru_fwd_hook(int bus_num, int addr) {
   int bus_fwd = -1;
 
   if (bus_num == 0) {
-    bus_fwd = 2;  // forward to camera
+    // Global platform
+    // 0x40 Throttle
+    int block_msg = (addr == 0x40);
+    if (!block_msg) {
+      bus_fwd = 2;  // Camera CAN
+    }
   }
 
   if (bus_num == 2) {

--- a/board/safety/safety_subaru_legacy.h
+++ b/board/safety/safety_subaru_legacy.h
@@ -11,7 +11,8 @@ const SteeringLimits SUBARU_L_STEERING_LIMITS = {
 
 const CanMsg SUBARU_L_TX_MSGS[] = {
   {0x161, 0, 8},
-  {0x164, 0, 8}
+  {0x164, 0, 8},
+  {0x140, 2, 8},
 };
 #define SUBARU_L_TX_MSGS_LEN (sizeof(SUBARU_L_TX_MSGS) / sizeof(SUBARU_L_TX_MSGS[0]))
 
@@ -87,7 +88,12 @@ static int subaru_legacy_fwd_hook(int bus_num, int addr) {
   int bus_fwd = -1;
 
   if (bus_num == 0) {
-    bus_fwd = 2;  // Camera CAN
+    // Preglobal platform
+    // 0x140 is Throttle
+    int block_msg = (addr == 0x140);
+    if (!block_msg) {
+      bus_fwd = 2;  // Camera CAN
+    }
   }
 
   if (bus_num == 2) {

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -7,11 +7,11 @@ from panda.tests.safety.common import CANPackerPanda
 
 
 class TestSubaruSafety(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
-  TX_MSGS = [[0x122, 0], [0x221, 0], [0x321, 0], [0x322, 0], [0x323, 0]]
+  TX_MSGS = [[0x122, 0], [0x221, 0], [0x321, 0], [0x322, 0], [0x323, 0], [0x40, 2]]
   STANDSTILL_THRESHOLD = 0  # kph
   RELAY_MALFUNCTION_ADDR = 0x122
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [0x122, 0x321, 0x322, 0x323]}
+  FWD_BLACKLISTED_ADDRS = {0: [0x40], 2: [0x122, 0x321, 0x322, 0x323]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   MAX_RATE_UP = 50

--- a/tests/safety/test_subaru_legacy.py
+++ b/tests/safety/test_subaru_legacy.py
@@ -7,11 +7,11 @@ from panda.tests.safety.common import CANPackerPanda
 
 
 class TestSubaruLegacySafety(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
-  TX_MSGS = [[0x161, 0], [0x164, 0]]
+  TX_MSGS = [[0x161, 0], [0x164, 0], [0x140, 2]]
   STANDSTILL_THRESHOLD = 0  # kph
   RELAY_MALFUNCTION_ADDR = 0x164
   RELAY_MALFUNCTION_BUS = 0
-  FWD_BLACKLISTED_ADDRS = {2: [0x161, 0x164]}
+  FWD_BLACKLISTED_ADDRS = {0: [0x140], 2: [0x161, 0x164]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   MAX_RATE_UP = 50


### PR DESCRIPTION
This PR is prerequisite for adding Subaru SNG support for both global and preglobal models.

Subaru stock ACC stops behind stopped cars but does not resume automatically. We send Throttle:Throttle_Pedal signal from openpilot to ACC when car in front starts moving to resume from ACC Hold state (mimicking stock ACC resume using gas press behaviour).

We also tried to resume using ACC resume button signals but that did not work since ACC buttons are directly wired to Eyesight and ACC does not accept the button press input signals from CAN to initiate resume.