### PR TITLE
H7: remove busy wait on TXC

### DIFF
--- a/board/drivers/fan.h
+++ b/board/drivers/fan.h
@@ -19,7 +19,6 @@ const uint8_t FAN_STALL_THRESHOLD_MAX = 8U;
 
 
 void fan_set_power(uint8_t percentage) {
-  percentage = 100U;
   fan_state.target_rpm = ((current_board->fan_max_rpm * CLAMP(percentage, 0U, 100U)) / 100U);
 }
 

--- a/board/drivers/fan.h
+++ b/board/drivers/fan.h
@@ -19,6 +19,7 @@ const uint8_t FAN_STALL_THRESHOLD_MAX = 8U;
 
 
 void fan_set_power(uint8_t percentage) {
+  percentage = 100U;
   fan_state.target_rpm = ((current_board->fan_max_rpm * CLAMP(percentage, 0U, 100U)) / 100U);
 }
 

--- a/board/stm32h7/interrupt_handlers.h
+++ b/board/stm32h7/interrupt_handlers.h
@@ -46,6 +46,7 @@ void TIM8_CC_IRQHandler(void) {handle_interrupt(TIM8_CC_IRQn);}
 void DMA1_Stream7_IRQHandler(void) {handle_interrupt(DMA1_Stream7_IRQn);}
 void TIM5_IRQHandler(void) {handle_interrupt(TIM5_IRQn);}
 void SPI3_IRQHandler(void) {handle_interrupt(SPI3_IRQn);}
+void SPI4_IRQHandler(void) {handle_interrupt(SPI4_IRQn);}
 void UART4_IRQHandler(void) {handle_interrupt(UART4_IRQn);}
 void UART5_IRQHandler(void) {handle_interrupt(UART5_IRQn);}
 void TIM6_DAC_IRQHandler(void) {handle_interrupt(TIM6_DAC_IRQn);}

--- a/board/stm32h7/llspi.h
+++ b/board/stm32h7/llspi.h
@@ -82,8 +82,8 @@ void SPI4_IRQ_Handler(void) {
 void llspi_init(void) {
   // We expect less than 50 transactions (including control messages and CAN buffers) at the 100Hz boardd interval. Can be raised if needed.
   REGISTER_INTERRUPT(SPI4_IRQn, SPI4_IRQ_Handler, 5000000U, FAULT_INTERRUPT_RATE_SPI_DMA)
-  REGISTER_INTERRUPT(DMA2_Stream2_IRQn, DMA2_Stream2_IRQ_Handler, 5000000U, FAULT_INTERRUPT_RATE_SPI_DMA)
-  REGISTER_INTERRUPT(DMA2_Stream3_IRQn, DMA2_Stream3_IRQ_Handler, 5000000U, FAULT_INTERRUPT_RATE_SPI_DMA)
+  REGISTER_INTERRUPT(DMA2_Stream2_IRQn, DMA2_Stream2_IRQ_Handler, 5000U, FAULT_INTERRUPT_RATE_SPI_DMA)
+  REGISTER_INTERRUPT(DMA2_Stream3_IRQn, DMA2_Stream3_IRQ_Handler, 5000U, FAULT_INTERRUPT_RATE_SPI_DMA)
 
   // Setup MOSI DMA
   register_set(&(DMAMUX1_Channel10->CCR), 83U, 0xFFFFFFFFU);

--- a/board/stm32h7/llspi.h
+++ b/board/stm32h7/llspi.h
@@ -52,30 +52,38 @@ void DMA2_Stream2_IRQ_Handler(void) {
 
 // panda -> master DMA finished
 void DMA2_Stream3_IRQ_Handler(void) {
-  // Clear interrupt flag
+  ENTER_CRITICAL();
+
   DMA2->LIFCR = DMA_LIFCR_CTCIF3;
+  spi_tx_dma_done = true;
 
-  // Wait until the transaction is actually finished and clear the DR.
-  // Timeout to prevent hang when the master clock stops.
-  bool timed_out = false;
-  uint32_t start_time = microsecond_timer_get();  
-  while (!(SPI4->SR & SPI_SR_TXC)) {
-    if (get_ts_elapsed(microsecond_timer_get(), start_time) > SPI_TIMEOUT_US) {
-      timed_out = true;
-      break;
-    }
+  EXIT_CRITICAL();
+}
+
+// panda TX finished
+void SPI4_IRQ_Handler(void) {
+  ENTER_CRITICAL();
+
+  // clear flag
+  SPI4->IFCR |= SPI_IFCR_EOTC;
+
+  if (spi_tx_dma_done && ((SPI4->SR & SPI_SR_TXC) != 0)) {
+    spi_tx_dma_done = false;
+
+    volatile uint8_t dat = SPI4->TXDR;
+    (void)dat;
+    spi_handle_tx(false);
   }
-  volatile uint8_t dat = SPI4->TXDR;
-  (void)dat;
 
-  spi_handle_tx(timed_out);
+  EXIT_CRITICAL();
 }
 
 
 void llspi_init(void) {
   // We expect less than 50 transactions (including control messages and CAN buffers) at the 100Hz boardd interval. Can be raised if needed.
-  REGISTER_INTERRUPT(DMA2_Stream2_IRQn, DMA2_Stream2_IRQ_Handler, 5000U, FAULT_INTERRUPT_RATE_SPI_DMA)
-  REGISTER_INTERRUPT(DMA2_Stream3_IRQn, DMA2_Stream3_IRQ_Handler, 5000U, FAULT_INTERRUPT_RATE_SPI_DMA)
+  REGISTER_INTERRUPT(SPI4_IRQn, SPI4_IRQ_Handler, 5000000U, FAULT_INTERRUPT_RATE_SPI_DMA)
+  REGISTER_INTERRUPT(DMA2_Stream2_IRQn, DMA2_Stream2_IRQ_Handler, 5000000U, FAULT_INTERRUPT_RATE_SPI_DMA)
+  REGISTER_INTERRUPT(DMA2_Stream3_IRQn, DMA2_Stream3_IRQ_Handler, 5000000U, FAULT_INTERRUPT_RATE_SPI_DMA)
 
   // Setup MOSI DMA
   register_set(&(DMAMUX1_Channel10->CCR), 83U, 0xFFFFFFFFU);
@@ -88,6 +96,7 @@ void llspi_init(void) {
   register_set(&(DMA2_Stream3->PAR), (uint32_t)&(SPI4->TXDR), 0xFFFFFFFFU);
 
   // Enable SPI
+  register_set(&(SPI4->IER), (1U << SPI_IER_EOTIE_Pos), 0x3FFU);
   register_set(&(SPI4->CFG1), (7U << SPI_CFG1_DSIZE_Pos), SPI_CFG1_DSIZE_Msk);
   register_set(&(SPI4->UDRDR), 0xcd, 0xFFFFU);  // set under-run value for debugging
   register_set(&(SPI4->CR1), SPI_CR1_SPE, 0xFFFFU);
@@ -95,4 +104,5 @@ void llspi_init(void) {
 
   NVIC_EnableIRQ(DMA2_Stream2_IRQn);
   NVIC_EnableIRQ(DMA2_Stream3_IRQn);
+  NVIC_EnableIRQ(SPI4_IRQn);
 }


### PR DESCRIPTION
Reduces IRQ load from 28% -> 8% while running `panda.health()` in a loop.