### PR TITLE
Ford: remove unused function

### DIFF
--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -50,11 +50,6 @@ def checksum(msg):
   return addr, t, ret, bus
 
 
-def round_curvature_can(curvature):
-  # rounds curvature as if it was sent on CAN
-  return round(curvature * 5, 4) / 5
-
-
 class Buttons:
   CANCEL = 0
   RESUME = 1
@@ -200,7 +195,7 @@ class TestFordSafety(common.PandaSafetyTest):
 
   def test_rx_hook_speed_mismatch(self):
     # Ford relies on speed for driver curvature limiting, so it checks two sources
-    for speed in np.arange(0, 40, 1):
+    for speed in np.arange(0, 40, 0.5):
       for speed_delta in np.arange(-5, 5, 0.1):
         speed_2 = round(max(speed + speed_delta, 0), 1)
         # Set controls allowed in between rx since first message can reset it
@@ -245,7 +240,7 @@ class TestFordSafety(common.PandaSafetyTest):
 
           limit_command = speed > self.CURVATURE_ERROR_MIN_SPEED
           for new_curvature in np.linspace(-self.MAX_CURVATURE, self.MAX_CURVATURE, 41):
-            too_far_away = round_curvature_can(abs(new_curvature - initial_curvature)) > self.MAX_CURVATURE_ERROR
+            too_far_away = round(abs(new_curvature - initial_curvature), 5) > self.MAX_CURVATURE_ERROR
 
             if steer_control_enabled:
               should_tx = not limit_command or not too_far_away


### PR DESCRIPTION
Think it was used in two places but got rid of one usage before merging, not really needed. It's just the python floats that need to be rounded a bit `0.014000000000000002`