### PR TITLE
H7: fix lockup on disconnected bus

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -64,7 +64,12 @@ void update_can_health_pkt(uint8_t can_number, bool error_irq) {
     if ((CANx->IR & (FDCAN_IR_TEFL)) != 0) {
       can_health[can_number].total_tx_lost_cnt += 1U;
     }
-    llcan_clear_send(CANx);
+    // Actually reset can core only on arbitration or data phase errors
+    if ((CANx->IR & (FDCAN_IR_PED | FDCAN_IR_PEA)) != 0) {
+      llcan_clear_send(CANx);
+    }
+    // Clear error interrupts
+    CANx->IR |= (FDCAN_IR_PED | FDCAN_IR_PEA | FDCAN_IR_EW | FDCAN_IR_EP | FDCAN_IR_ELO | FDCAN_IR_BO | FDCAN_IR_TEFL | FDCAN_IR_RF0L);
   }
   EXIT_CRITICAL();
 }

--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -244,10 +244,8 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
 }
 
 void llcan_clear_send(FDCAN_GlobalTypeDef *CANx) {
-  // Transmit cancellation is not intended for Tx FIFO operation.
-  // Clear error interrupts
-  CANx->IR |= (FDCAN_IR_PED | FDCAN_IR_PEA | FDCAN_IR_EW | FDCAN_IR_EP | FDCAN_IR_ELO | FDCAN_IR_BO | FDCAN_IR_TEFL | FDCAN_IR_RF0L);
-
+  // from datasheet: "Transmit cancellation is not intended for Tx FIFO operation."
+  // so we need to clear pending transmission manually by resetting FDCAN core
   bool ret = llcan_init(CANx);
   UNUSED(ret);
 }

--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -248,5 +248,6 @@ void llcan_clear_send(FDCAN_GlobalTypeDef *CANx) {
   // Clear error interrupts
   CANx->IR |= (FDCAN_IR_PED | FDCAN_IR_PEA | FDCAN_IR_EW | FDCAN_IR_EP | FDCAN_IR_ELO | FDCAN_IR_BO | FDCAN_IR_TEFL | FDCAN_IR_RF0L);
 
-  llcan_init(CANx);
+  bool ret = llcan_init(CANx);
+  UNUSED(ret);
 }

--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -244,7 +244,9 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
 }
 
 void llcan_clear_send(FDCAN_GlobalTypeDef *CANx) {
-  CANx->TXBCR = 0xFFFFU; // Abort message transmission on error interrupt
+  // Transmit cancellation is not intended for Tx FIFO operation.
   // Clear error interrupts
   CANx->IR |= (FDCAN_IR_PED | FDCAN_IR_PEA | FDCAN_IR_EW | FDCAN_IR_EP | FDCAN_IR_ELO | FDCAN_IR_BO | FDCAN_IR_TEFL | FDCAN_IR_RF0L);
+
+  llcan_init(CANx);
 }


### PR DESCRIPTION
Main problem is that H7 with FDCAN FIFO for TX doesn't support transmission cancellation. So if we send messages on the bus that is not connected to anything - panda will lockup because of high call rate from Arbitration Error interrupt. 
On F4 we can cancel retransmission on error.