### PR TITLE
iso-tp: revert CAN frame length check

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -463,8 +463,9 @@ class IsoTpMessage():
         print(f"ISO-TP: RESPONSE - {hex(self._can_client.rx_addr)} 0x{bytes.hex(self.rx_dat)}")
 
   def _isotp_rx_next(self, rx_data: bytes) -> ISOTP_FRAME_TYPE:
-    # ISO 15765-2 specifies an eight byte CAN frame for ISO-TP communication
-    assert len(rx_data) == self.max_len, f"isotp - rx: invalid CAN frame length: {len(rx_data)}"
+    # TODO: Handle CAN frame data optimization, which is allowed with some frame types
+    # # ISO 15765-2 specifies an eight byte CAN frame for ISO-TP communication
+    # assert len(rx_data) == self.max_len, f"isotp - rx: invalid CAN frame length: {len(rx_data)}"
 
     if rx_data[0] >> 4 == ISOTP_FRAME_TYPE.SINGLE:
       self.rx_len = rx_data[0] & 0xFF


### PR DESCRIPTION
Reverts https://github.com/commaai/panda/pull/1315

The iso-tp spec allows optimization of the data field only with certain frame types. So while we know of no cases where this is a problem, we should revert until we handle properly

```
10.4.2.2	 CAN frame data optimization (TX_DL = 8)
If this solution is used, the DLC does not always need to be 8. If the N_PDU to be transmitted is shorter
than 8 bytes, then the sender may optimize the CAN bus load by shortening the CAN frame data to
contain only the number of bytes occupied by the N_PDU (no padding of unused data bytes). CAN frame
data optimization can only be used for an SF, FC frame or the last CF of a segmented message.
```