### PR TITLE
safety: always allow inactive gas command

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -510,13 +510,9 @@ bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limit
 }
 
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits) {
-  bool violation = false;
-  if (!get_longitudinal_allowed()) {
-    violation |= desired_gas != limits.inactive_gas;
-  } else {
-    violation |= max_limit_check(desired_gas, limits.max_gas, limits.min_gas);
-  }
-  return violation;
+  bool gas_valid = !max_limit_check(desired_gas, limits.max_gas, limits.min_gas);
+  bool gas_inactive = desired_gas == limits.inactive_gas;
+  return !((controls_allowed && gas_valid) || gas_inactive);
 }
 
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits) {

--- a/board/safety.h
+++ b/board/safety.h
@@ -500,9 +500,9 @@ int ROUND(float val) {
 
 // Safety checks for longitudinal actuation
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits) {
-  bool accel_valid = get_longitudinal_allowed() && !max_limit_check(desired_accel, limits.max_accel, limits.min_accel);
+  bool accel_valid = !max_limit_check(desired_accel, limits.max_accel, limits.min_accel);
   bool accel_inactive = desired_accel == limits.inactive_accel;
-  return !(accel_valid || accel_inactive);
+  return !((controls_allowed && accel_valid) || accel_inactive);
 }
 
 bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limits) {

--- a/board/safety.h
+++ b/board/safety.h
@@ -500,9 +500,9 @@ int ROUND(float val) {
 
 // Safety checks for longitudinal actuation
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits) {
-  bool accel_valid = !max_limit_check(desired_accel, limits.max_accel, limits.min_accel);
+  bool accel_valid = get_longitudinal_allowed() && !max_limit_check(desired_accel, limits.max_accel, limits.min_accel);
   bool accel_inactive = desired_accel == limits.inactive_accel;
-  return !((controls_allowed && accel_valid) || accel_inactive);
+  return !(accel_valid || accel_inactive);
 }
 
 bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limits) {
@@ -510,9 +510,9 @@ bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limit
 }
 
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits) {
-  bool gas_valid = !max_limit_check(desired_gas, limits.max_gas, limits.min_gas);
+  bool gas_valid = get_longitudinal_allowed() && !max_limit_check(desired_gas, limits.max_gas, limits.min_gas);
   bool gas_inactive = desired_gas == limits.inactive_gas;
-  return !((controls_allowed && gas_valid) || gas_inactive);
+  return !(gas_valid || gas_inactive);
 }
 
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits) {

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -23,7 +23,6 @@ const LongitudinalLimits HONDA_BOSCH_LONG_LIMITS = {
   .min_accel = -350,
 
   .max_gas = 2000,
-  .min_gas = -30000,
   .inactive_gas = -30000,
 };
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -153,7 +153,7 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
       for gas_regen in range(0, 2 ** 12 - 1):
         self.safety.set_controls_allowed(enabled)
         should_tx = ((enabled and self.MAX_REGEN <= gas_regen <= self.MAX_GAS) or
-                     (not enabled and gas_regen == self.INACTIVE_REGEN))
+                     gas_regen == self.INACTIVE_REGEN)
         self.assertEqual(should_tx, self._tx(self._send_gas_msg(gas_regen)), (enabled, gas_regen))
 
 

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -296,7 +296,7 @@ class TestHondaNidecSafetyBase(HondaBase):
       self.safety.set_controls_allowed(controls_allowed)
       for pcm_gas in range(0, 255):
         for pcm_speed in range(0, 100):
-          send = pcm_gas <= self.MAX_GAS if controls_allowed else pcm_gas == 0 and pcm_speed == 0
+          send = (controls_allowed and pcm_gas <= self.MAX_GAS) or (pcm_gas == 0 and pcm_speed == 0)
           self.assertEqual(send, self._tx(self._send_acc_hud_msg(pcm_gas, pcm_speed)))
 
   def test_fwd_hook(self):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -499,7 +499,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
       for gas in np.arange(self.NO_GAS, self.MAX_GAS + 2000, 100):
         accel = 0 if gas < 0 else gas / 1000
         self.safety.set_controls_allowed(controls_allowed)
-        send = gas <= self.MAX_GAS if controls_allowed else gas == self.NO_GAS
+        send = (controls_allowed and 0 <= gas <= self.MAX_GAS) or gas == self.NO_GAS
         self.assertEqual(send, self._tx(self._send_gas_brake_msg(gas, accel)), (controls_allowed, gas, accel))
 
   def test_brake_safety_check(self):


### PR DESCRIPTION
- GM wasn't affected because its inactive gas/regen was above min gas,
- Bosch Honda wasn't affected because it specifically sets min_gas to -30000 in the safety, when it should be 0,
- and Nidec Honda wasn't affected because inactive gas is 0.

ford may be affected as its inactive gas is below min gas