### PR TITLE
safety tests: clean up setUpClass

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -686,10 +686,12 @@ class PandaSafetyTest(PandaSafetyTestBase):
   FWD_BLACKLISTED_ADDRS: Dict[int, List[int]] = {}  # {bus: [addr]}
   FWD_BUS_LOOKUP: Dict[int, int] = {}
 
+  packer: CANPackerPanda
+  safety: libpanda_py.Panda
+
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "PandaSafetyTest" or cls.__name__.endswith('Base'):
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -53,11 +53,13 @@ def add_regen_tests(cls):
 
 
 class PandaSafetyTestBase(unittest.TestCase):
+
+  packer: CANPackerPanda
+  safety: libpanda_py.Panda
+
   @classmethod
   def setUpClass(cls):
-    if cls.__name__ == "PandaSafetyTestBase":
-      cls.safety = None
-      raise unittest.SkipTest
+    raise NotImplementedError
 
   def _reset_safety_hooks(self):
     self.safety.set_safety_hooks(self.safety.get_current_safety_mode(),
@@ -77,7 +79,6 @@ class InterceptorSafetyTest(PandaSafetyTestBase):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "InterceptorSafetyTest":
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod
@@ -145,7 +146,6 @@ class LongitudinalAccelSafetyTest(PandaSafetyTestBase, abc.ABC):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "LongitudinalAccelSafetyTest":
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod
@@ -191,7 +191,6 @@ class TorqueSteeringSafetyTestBase(PandaSafetyTestBase, abc.ABC):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "TorqueSteeringSafetyTestBase":
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod
@@ -336,7 +335,6 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "DriverTorqueSteeringSafetyTest":
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod
@@ -428,7 +426,6 @@ class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "MotorTorqueSteeringSafetyTest":
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod
@@ -548,7 +545,6 @@ class AngleSteeringSafetyTest(PandaSafetyTestBase):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "AngleSteeringSafetyTest":
-      cls.safety = None
       raise unittest.SkipTest
 
   @abc.abstractmethod
@@ -686,16 +682,13 @@ class PandaSafetyTest(PandaSafetyTestBase):
   FWD_BLACKLISTED_ADDRS: Dict[int, List[int]] = {}  # {bus: [addr]}
   FWD_BUS_LOOKUP: Dict[int, int] = {}
 
-  packer: CANPackerPanda
-  safety: libpanda_py.Panda
-
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "PandaSafetyTest" or cls.__name__.endswith('Base'):
       raise unittest.SkipTest
 
   @abc.abstractmethod
-  def _user_brake_msg(self, brake):
+  def _user_brake_msg(self, brake: bool):
     pass
 
   def _user_regen_msg(self, regen):

--- a/tests/safety/hyundai_common.py
+++ b/tests/safety/hyundai_common.py
@@ -83,7 +83,6 @@ class HyundaiLongitudinalBase(common.LongitudinalAccelSafetyTest):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "HyundaiLongitudinalBase":
-      cls.safety = None
       raise unittest.SkipTest
 
   # override these tests from PandaSafetyTest, hyundai longitudinal uses button enable

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -77,13 +77,6 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
 
   PCM_CRUISE = True  # openpilot is tied to the PCM state if not longitudinal
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestGmSafetyBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
@@ -182,13 +175,6 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
 class TestGmCameraSafetyBase(TestGmSafetyBase):
 
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestGmCameraSafetyBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   def _user_brake_msg(self, brake):
     values = {"BrakePressed": brake}

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -186,13 +186,6 @@ class HondaBase(common.PandaSafetyTest):
   cnt_powertrain_data = 0
   cnt_acc_state = 0
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__.endswith("Base"):
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _powertrain_data_msg(self, cruise_on=None, brake_pressed=None, gas_pressed=None):
     # preserve the state
     if cruise_on is None:

--- a/tests/safety/test_hyundai_canfd.py
+++ b/tests/safety/test_hyundai_canfd.py
@@ -40,13 +40,6 @@ class TestHyundaiCanfdBase(HyundaiButtonBase, common.PandaSafetyTest, common.Dri
   GAS_MSG = ("", "")
   BUTTONS_TX_BUS = 1
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestHyundaiCanfdBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _torque_driver_msg(self, torque):
     values = {"STEERING_COL_TORQUE": torque}
     return self.packer.make_can_msg_panda("MDPS", self.PT_BUS, values)
@@ -96,8 +89,6 @@ class TestHyundaiCanfdHDA1Base(TestHyundaiCanfdBase):
   @classmethod
   def setUpClass(cls):
     if cls.__name__ in ("TestHyundaiCanfdHDA1", "TestHyundaiCanfdHDA1AltButtons") or cls.__name__.endswith('Base'):
-      cls.packer = None
-      cls.safety = None
       raise unittest.SkipTest
 
   def setUp(self):
@@ -154,6 +145,7 @@ class TestHyundaiCanfdHDA1AltButtons(TestHyundaiCanfdHDA1Base):
     """
     for enabled in (True, False):
       for btn in range(8):
+        print('ARE WE NEVER HERE')
         self.safety.set_controls_allowed(enabled)
         self.assertFalse(self._tx(self._button_msg(btn)))
 

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -34,13 +34,6 @@ class TestToyotaSafetyBase(common.PandaSafetyTest, common.InterceptorSafetyTest,
   INTERCEPTOR_THRESHOLD = 805
   EPS_SCALE = 73
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__.endswith("Base"):
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _torque_meas_msg(self, torque):
     values = {"STEER_TORQUE_EPS": (torque / self.EPS_SCALE) * 100.}
     return self.packer.make_can_msg_panda("STEER_TORQUE_SENSOR", 0, values)

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -22,7 +22,7 @@ MSG_ACC_02 = 0x30C      # TX by OP, ACC HUD data to the instrument cluster
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenMqbSafety(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
+class TestVolkswagenMqbSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDR = MSG_HCA_01
   RELAY_MALFUNCTION_BUS = 0
@@ -35,13 +35,6 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest, common.DriverTorqueSteerin
 
   DRIVER_TORQUE_ALLOWANCE = 80
   DRIVER_TORQUE_FACTOR = 3
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestVolkswagenMqbSafety":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   # Wheel speeds _esp_19_msg
   def _speed_msg(self, speed):
@@ -136,7 +129,7 @@ class TestVolkswagenMqbSafety(common.PandaSafetyTest, common.DriverTorqueSteerin
     self.assertEqual(0, self.safety.get_torque_driver_min())
 
 
-class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
+class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafetyBase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
@@ -157,7 +150,7 @@ class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
     self.assertTrue(self._tx(self._gra_acc_01_msg(resume=1)))
 
 
-class TestVolkswagenMqbLongSafety(TestVolkswagenMqbSafety):
+class TestVolkswagenMqbLongSafety(TestVolkswagenMqbSafetyBase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_ACC_02, 0], [MSG_ACC_06, 0], [MSG_ACC_07, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_01, MSG_LDW_02, MSG_ACC_02, MSG_ACC_06, MSG_ACC_07]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -17,7 +17,7 @@ MSG_ACC_GRA_ANZEIGE = 0x56A   # TX by OP, ACC HUD
 MSG_LDW_1 = 0x5BE             # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenPqSafety(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
+class TestVolkswagenPqSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafetyTest):
   cruise_engaged = False
 
   STANDSTILL_THRESHOLD = 0
@@ -32,13 +32,6 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest, common.DriverTorqueSteering
 
   DRIVER_TORQUE_ALLOWANCE = 80
   DRIVER_TORQUE_FACTOR = 3
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestVolkswagenPqSafety":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
@@ -117,7 +110,7 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest, common.DriverTorqueSteering
     self.assertEqual(0, self.safety.get_torque_driver_min())
 
 
-class TestVolkswagenPqStockSafety(TestVolkswagenPqSafety):
+class TestVolkswagenPqStockSafety(TestVolkswagenPqSafetyBase):
   # Transmit of GRA_Neu is allowed on bus 0 and 2 to keep compatibility with gateway and camera integration
   TX_MSGS = [[MSG_HCA_1, 0], [MSG_GRA_NEU, 0], [MSG_GRA_NEU, 2], [MSG_LDW_1, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_1, MSG_LDW_1]}
@@ -139,7 +132,7 @@ class TestVolkswagenPqStockSafety(TestVolkswagenPqSafety):
     self.assertTrue(self._tx(self._button_msg(resume=True)))
 
 
-class TestVolkswagenPqLongSafety(TestVolkswagenPqSafety, common.LongitudinalAccelSafetyTest):
+class TestVolkswagenPqLongSafety(TestVolkswagenPqSafetyBase, common.LongitudinalAccelSafetyTest):
   TX_MSGS = [[MSG_HCA_1, 0], [MSG_LDW_1, 0], [MSG_ACC_SYSTEM, 0], [MSG_ACC_GRA_ANZEIGE, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_1, MSG_LDW_1, MSG_ACC_SYSTEM, MSG_ACC_GRA_ANZEIGE]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}


### PR DESCRIPTION
If `PandaSafetyTest` is the parent class, it will already skip child Base classes. Defining packer and safety as class attributes is needed if a child class subclasses `PandaSafetyTest`, but it is a base and has type annotations on its functions (Ford). mypy then complains that the two variables don't exist