### PR TITLE
Ford safety: prevent disable AEB

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -286,11 +286,9 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     // Safety checks for stock AEB
     violation |= cmbb_deny != 0U; // do not disable stock AEB
     if (ford_stock_aeb) {
-      print("ford stock aeb: "); puth(cmbb_engine_torque_min); print("\n");
       violation |= accel != FORD_LONG_LIMITS.inactive_accel;
       violation |= gas != FORD_LONG_LIMITS.inactive_gas;
       violation |= cmbb_engine_torque_min != 1U;
-      print("cmbb_engine_torque_min: "); puth(cmbb_engine_torque_min); print("\n");
     }
 
     if (violation) {

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -44,7 +44,6 @@ AddrCheckStruct ford_addr_checks[] = {
   // TODO: MSG_EngVehicleSpThrottle2 has a counter that skips by 2, understand and enable counter check
   {.msg = {{MSG_EngVehicleSpThrottle2, 0, 8, .check_checksum = true, .quality_flag=true, .expected_timestep = 20000U}, { 0 }, { 0 }}},
   {.msg = {{MSG_Yaw_Data_FD1, 0, 8, .check_checksum = true, .max_counter = 255U, .quality_flag=true, .expected_timestep = 10000U}, { 0 }, { 0 }}},
-  {.msg = {{MSG_ACCDATA_2, 2, 8, .expected_timestep = 20000U}, { 0 }, { 0 }}},  // TODO: counter/checksum
   // These messages have no counter or checksum
   {.msg = {{MSG_EngBrakeData, 0, 8, .expected_timestep = 100000U}, { 0 }, { 0 }}},
   {.msg = {{MSG_EngVehicleSpThrottle, 0, 8, .expected_timestep = 10000U}, { 0 }, { 0 }}},

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -265,7 +265,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     // Signal: AccBrkTot_A_Rq
     int accel = ((GET_BYTE(to_send, 0) & 0x1FU) << 8) | GET_BYTE(to_send, 1);
     // Signal: CmbbDeny_B_Actl
-    int cmbb_deny = GET_BIT(to_send, 37);
+    int cmbb_deny = GET_BIT(to_send, 37U);
 
     bool violation = false;
     violation |= longitudinal_accel_checks(accel, FORD_LONG_LIMITS);

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -272,7 +272,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     violation |= longitudinal_gas_checks(gas, FORD_LONG_LIMITS);
 
     // Safety check for stock AEB
-    violation |= cmbb_deny != 0U; // do not disable stock AEB
+    violation |= cmbb_deny != 0; // do not disable stock AEB
 
     if (violation) {
       tx = 0;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -284,7 +284,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     violation |= longitudinal_gas_checks(gas, FORD_LONG_LIMITS);
 
     // Safety checks for stock AEB
-    violation |= cmbb_deny != 1U; // do not disable stock AEB
+    violation |= cmbb_deny != 0U; // do not disable stock AEB
     if (ford_stock_aeb) {
       violation |= accel != FORD_LONG_LIMITS.inactive_accel;
       violation |= gas != FORD_LONG_LIMITS.inactive_gas;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -277,7 +277,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     // Signal: CmbbDeny_B_Actl
     int cmbb_deny = GET_BIT(to_send, 37);
     // Signal: CmbbEngTqMn_B_Rq
-//    int cmbb_engine_torque_min = GET_BIT(to_send, 52);
+    int cmbb_engine_torque_min = GET_BIT(to_send, 52);
 
     bool violation = false;
     violation |= longitudinal_accel_checks(accel, FORD_LONG_LIMITS);
@@ -286,9 +286,11 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     // Safety checks for stock AEB
     violation |= cmbb_deny != 0U; // do not disable stock AEB
     if (ford_stock_aeb) {
+      print("ford stock aeb: "); puth(cmbb_engine_torque_min); print("\n");
       violation |= accel != FORD_LONG_LIMITS.inactive_accel;
       violation |= gas != FORD_LONG_LIMITS.inactive_gas;
-//      violation |= cmbb_engine_torque_min != 1U;
+      violation |= cmbb_engine_torque_min != 1U;
+      print("cmbb_engine_torque_min: "); puth(cmbb_engine_torque_min); print("\n");
     }
 
     if (violation) {

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -273,23 +273,16 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     int gas = ((GET_BYTE(to_send, 6) & 0x3U) << 8) | GET_BYTE(to_send, 7);
     // Signal: AccBrkTot_A_Rq
     int accel = ((GET_BYTE(to_send, 0) & 0x1FU) << 8) | GET_BYTE(to_send, 1);
-
     // Signal: CmbbDeny_B_Actl
     int cmbb_deny = GET_BIT(to_send, 37);
-    // Signal: CmbbEngTqMn_B_Rq
-    int cmbb_engine_torque_min = GET_BIT(to_send, 52);
 
     bool violation = false;
     violation |= longitudinal_accel_checks(accel, FORD_LONG_LIMITS);
     violation |= longitudinal_gas_checks(gas, FORD_LONG_LIMITS);
 
-    // Safety checks for stock AEB
+    // Safety check for stock AEB
+    // Signal: CmbbDeny_B_Actl
     violation |= cmbb_deny != 0U; // do not disable stock AEB
-    if (ford_stock_aeb) {
-      violation |= accel != FORD_LONG_LIMITS.inactive_accel;
-      violation |= gas != FORD_LONG_LIMITS.inactive_gas;
-      violation |= cmbb_engine_torque_min != 1U;
-    }
 
     if (violation) {
       tx = 0;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -272,7 +272,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     violation |= longitudinal_gas_checks(gas, FORD_LONG_LIMITS);
 
     // Safety check for stock AEB
-    violation |= cmbb_deny != 0; // do not disable stock AEB
+    violation |= cmbb_deny != 0; // do not prevent stock AEB actuation
 
     if (violation) {
       tx = 0;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -277,7 +277,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     // Signal: CmbbDeny_B_Actl
     int cmbb_deny = GET_BIT(to_send, 37);
     // Signal: CmbbEngTqMn_B_Rq
-    int cmbb_engine_torque_min = GET_BIT(to_send, 52);
+//    int cmbb_engine_torque_min = GET_BIT(to_send, 52);
 
     bool violation = false;
     violation |= longitudinal_accel_checks(accel, FORD_LONG_LIMITS);
@@ -288,7 +288,7 @@ static int ford_tx_hook(CANPacket_t *to_send) {
     if (ford_stock_aeb) {
       violation |= accel != FORD_LONG_LIMITS.inactive_accel;
       violation |= gas != FORD_LONG_LIMITS.inactive_gas;
-      violation |= cmbb_engine_torque_min != 1U;
+//      violation |= cmbb_engine_torque_min != 1U;
     }
 
     if (violation) {

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -399,7 +399,7 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
             # cmbb_deny should always be false, and min_engine_torque should be true only when AEB
             should_tx = not cmbb_deny and (not aeb or min_engine_torque)
             self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, self.INACTIVE_ACCEL,
-                                                                       cmbb_deny, min_engine_torque)), (aeb, cmbb_deny, min_engine_torque))
+                                                                       cmbb_deny, min_engine_torque)))
 
   def test_gas_safety_check(self):
     for controls_allowed in (True, False):

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -391,37 +391,32 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
   def test_stock_aeb(self):
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
-      for aeb, cmbb_deny, min_engine_torque in itertools.product([True, False], [True, False], [True, False]):
-        self._rx(self._stock_aeb_msg(aeb))
-        should_tx = not cmbb_deny and (min_engine_torque or not aeb)
-        self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, self.INACTIVE_ACCEL, cmbb_deny, min_engine_torque)))
+      for aeb in (True, False):
+        self.assertTrue(self._rx(self._stock_aeb_msg(aeb)))
+
+        for cmbb_deny in (True, False):
+          for min_engine_torque in (True, False):
+            # cmbb_deny should always be false, and min_engine_torque should be true when AEB
+            should_tx = not cmbb_deny and (not aeb or min_engine_torque)
+            self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, self.INACTIVE_ACCEL,
+                                                                       cmbb_deny, min_engine_torque)), (aeb, cmbb_deny, min_engine_torque))
 
   def test_gas_safety_check(self):
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
-      for aeb in (True, False):
-        self.assertTrue(self._rx(self._stock_aeb_msg(aeb)))
-        for min_engine_torque in (True, False):
-          for gas in np.concatenate((np.arange(self.MIN_GAS - 2, self.MAX_GAS + 2, 0.05), [self.INACTIVE_GAS])):
-            gas = round(gas, 2)  # floats might not hit exact boundary conditions without rounding
-            should_tx = (controls_allowed and not aeb and self.MIN_GAS <= gas <= self.MAX_GAS) or gas == self.INACTIVE_GAS
-            if aeb and not min_engine_torque:
-              should_tx = False
-            self.assertEqual(should_tx, self._tx(self._acc_command_msg(gas, self.INACTIVE_ACCEL, False, min_engine_torque)))
+      for gas in np.concatenate((np.arange(self.MIN_GAS - 2, self.MAX_GAS + 2, 0.05), [self.INACTIVE_GAS])):
+        gas = round(gas, 2)  # floats might not hit exact boundary conditions without rounding
+        should_tx = (controls_allowed and self.MIN_GAS <= gas <= self.MAX_GAS) or gas == self.INACTIVE_GAS
+        self.assertEqual(should_tx, self._tx(self._acc_command_msg(gas, self.INACTIVE_ACCEL)))
 
   def test_brake_safety_check(self):
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
-      for aeb in (True, False):
-        self.assertTrue(self._rx(self._stock_aeb_msg(aeb)))
-        for min_engine_torque in (True, False):
-          for brake in np.arange(self.MIN_ACCEL - 2, self.MAX_ACCEL + 2, 0.05):
-            brake = round(brake, 2)  # floats might not hit exact boundary conditions without rounding
-            should_tx = (controls_allowed and not aeb and self.MIN_ACCEL <= brake <= self.MAX_ACCEL) or brake == self.INACTIVE_ACCEL
-            if aeb and not min_engine_torque:
-              should_tx = False
-            self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, brake, False, min_engine_torque)),
-                             (controls_allowed, aeb, brake))
+      for min_engine_torque in (True, False):
+        for brake in np.arange(self.MIN_ACCEL - 2, self.MAX_ACCEL + 2, 0.05):
+          brake = round(brake, 2)  # floats might not hit exact boundary conditions without rounding
+          should_tx = (controls_allowed and self.MIN_ACCEL <= brake <= self.MAX_ACCEL) or brake == self.INACTIVE_ACCEL
+          self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, brake)))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -3,7 +3,6 @@ import numpy as np
 import unittest
 
 import panda.tests.safety.common as common
-import time
 
 from panda import Panda
 from panda.tests.libpanda import libpanda_py
@@ -388,7 +387,6 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
     return self.packer.make_can_msg_panda("ACCDATA", 0, values)
 
   def test_gas_safety_check(self):
-    # TODO: why isn't aeb affecting gas
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
       for aeb in (True, False):
@@ -397,25 +395,23 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
           for gas in np.concatenate((np.arange(self.MIN_GAS - 2, self.MAX_GAS + 2, 0.05), [self.INACTIVE_GAS])):
             gas = round(gas, 2)  # floats might not hit exact boundary conditions without rounding
             should_tx = (controls_allowed and not aeb and self.MIN_GAS <= gas <= self.MAX_GAS) or gas == self.INACTIVE_GAS
-            # if aeb and not min_engine_torque:
-            #   should_tx = False
-            time.sleep(0.01)
-            print('controls_allowed', controls_allowed, 'aeb', aeb, 'min_engine_torque', min_engine_torque, 'gas', gas, 'should_tx', should_tx)
+            if aeb and not min_engine_torque:
+              should_tx = False
             self.assertEqual(should_tx, self._tx(self._acc_command_msg(gas, self.INACTIVE_ACCEL, min_engine_torque)))
 
-  # def test_brake_safety_check(self):
-  #   for controls_allowed in (True, False):
-  #     self.safety.set_controls_allowed(controls_allowed)
-  #     for aeb in (True, False):
-  #       self.assertTrue(self._rx(self._stock_aeb_msg(aeb)))
-  #       for min_engine_torque in (True, False):
-  #         for brake in np.arange(self.MIN_ACCEL - 2, self.MAX_ACCEL + 2, 0.05):
-  #           brake = round(brake, 2)  # floats might not hit exact boundary conditions without rounding
-  #           should_tx = (controls_allowed and not aeb and self.MIN_ACCEL <= brake <= self.MAX_ACCEL) or brake == self.INACTIVE_ACCEL
-  #           if aeb and not min_engine_torque:
-  #             should_tx = False
-  #           self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, brake, min_engine_torque)),
-  #                            (controls_allowed, aeb, brake))
+  def test_brake_safety_check(self):
+    for controls_allowed in (True, False):
+      self.safety.set_controls_allowed(controls_allowed)
+      for aeb in (True, False):
+        self.assertTrue(self._rx(self._stock_aeb_msg(aeb)))
+        for min_engine_torque in (True, False):
+          for brake in np.arange(self.MIN_ACCEL - 2, self.MAX_ACCEL + 2, 0.05):
+            brake = round(brake, 2)  # floats might not hit exact boundary conditions without rounding
+            should_tx = (controls_allowed and not aeb and self.MIN_ACCEL <= brake <= self.MAX_ACCEL) or brake == self.INACTIVE_ACCEL
+            if aeb and not min_engine_torque:
+              should_tx = False
+            self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, brake, min_engine_torque)),
+                             (controls_allowed, aeb, brake))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import itertools
 import numpy as np
 import unittest
 
@@ -14,7 +13,6 @@ MSG_EngVehicleSpThrottle = 0x204   # RX from PCM, for driver throttle input
 MSG_BrakeSysFeatures = 0x415       # RX from ABS, for vehicle speed
 MSG_EngVehicleSpThrottle2 = 0x202  # RX from PCM, for second vehicle speed
 MSG_Yaw_Data_FD1 = 0x91            # RX from RCM, for yaw rate
-MSG_ACCDATA_2 = 0x187              # RX from IPMA, for AEB status
 MSG_Steering_Data_FD1 = 0x083      # TX by OP, various driver switches and LKAS/CC buttons
 MSG_ACCDATA = 0x186                # TX by OP, ACC controls
 MSG_ACCDATA_3 = 0x18A              # TX by OP, ACC/TJA user interface
@@ -136,10 +134,6 @@ class TestFordSafetyBase(common.PandaSafetyTest):
               "VehRolWActl_D_Qf": 3 if quality_flag else 0, "VehRollYaw_No_Cnt": self.cnt_yaw_rate % 256}
     self.__class__.cnt_yaw_rate += 1
     return self.packer.make_can_msg_panda("Yaw_Data_FD1", 0, values, fix_checksum=checksum)
-
-  def _stock_aeb_msg(self, aeb: bool):
-    values = {"CmbbBrkDecel_B_Rq": 1 if aeb else 0}
-    return self.packer.make_can_msg_panda("ACCDATA_2", 0, values)
 
   # Drive throttle input
   def _user_gas_msg(self, gas: float):

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -396,7 +396,7 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
 
         for cmbb_deny in (True, False):
           for min_engine_torque in (True, False):
-            # cmbb_deny should always be false, and min_engine_torque should be true when AEB
+            # cmbb_deny should always be false, and min_engine_torque should be true only when AEB
             should_tx = not cmbb_deny and (not aeb or min_engine_torque)
             self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, self.INACTIVE_ACCEL,
                                                                        cmbb_deny, min_engine_torque)), (aeb, cmbb_deny, min_engine_torque))

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -412,11 +412,10 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
   def test_brake_safety_check(self):
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
-      for min_engine_torque in (True, False):
-        for brake in np.arange(self.MIN_ACCEL - 2, self.MAX_ACCEL + 2, 0.05):
-          brake = round(brake, 2)  # floats might not hit exact boundary conditions without rounding
-          should_tx = (controls_allowed and self.MIN_ACCEL <= brake <= self.MAX_ACCEL) or brake == self.INACTIVE_ACCEL
-          self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, brake)))
+      for brake in np.arange(self.MIN_ACCEL - 2, self.MAX_ACCEL + 2, 0.05):
+        brake = round(brake, 2)  # floats might not hit exact boundary conditions without rounding
+        should_tx = (controls_allowed and self.MIN_ACCEL <= brake <= self.MAX_ACCEL) or brake == self.INACTIVE_ACCEL
+        self.assertEqual(should_tx, self._tx(self._acc_command_msg(self.INACTIVE_GAS, brake)))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -388,7 +388,7 @@ class TestFordLongitudinalSafety(TestFordSafetyBase):
     return self.packer.make_can_msg_panda("ACCDATA", 0, values)
 
   def test_stock_aeb(self):
-    # Test that CmbbDeny_B_Actl is never 1, it prevents the ABS from actuating AEB requests from ACCDATA_2
+    # Test that CmbbDeny_B_Actl is never 1, it prevents the ABS module from actuating AEB requests from ACCDATA_2
     for controls_allowed in (True, False):
       self.safety.set_controls_allowed(controls_allowed)
       for cmbb_deny in (True, False):


### PR DESCRIPTION
Split from https://github.com/commaai/panda/pull/1427

If this signal is 1, the camera will still send AEB commands on `ACCDATA_2` but the ABS doesn't actuate it.

More data/plots: https://github.com/commaai/openpilot/pull/28196#issuecomment-1552845171