### PR TITLE
H7: adjust FDCAN3 priority

### DIFF
--- a/board/stm32h7/llfdcan.h
+++ b/board/stm32h7/llfdcan.h
@@ -231,6 +231,11 @@ bool llcan_init(FDCAN_GlobalTypeDef *CANx) {
       NVIC_EnableIRQ(FDCAN2_IT0_IRQn);
       NVIC_EnableIRQ(FDCAN2_IT1_IRQn);
     } else if (CANx == FDCAN3) {
+      // defaults to nearly the lowest priority,
+      // adjust to be right below FDCAN1 and FDCAN2
+      NVIC_SetPriority(FDCAN3_IT0_IRQn, 30);
+      NVIC_SetPriority(FDCAN3_IT1_IRQn, 31);
+
       NVIC_EnableIRQ(FDCAN3_IT0_IRQn);
       NVIC_EnableIRQ(FDCAN3_IT1_IRQn);
     } else {


### PR DESCRIPTION
Optima had some spotty bus 2 traffic, while the other buses looked fine. The messages were lost due to the RX FIFO being full. H7 defaults the FDCAN2 priority to nearly the bottom (166-167), while the other two buses' IRQs are near the top (26-29).