### PR TITLE
CAN health: add IRQ call and core reset counters

### DIFF
--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -102,10 +102,8 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
       can_health[can_number].total_rx_lost_cnt += 1U;
       CAN->RF0R &= ~(CAN_RF0R_FOVR0);
     }
-    if (can_health[can_number].transmit_error_cnt >= 100U) {
-      can_health[can_number].can_core_reset_cnt += 1U;
-      llcan_clear_send(CAN);
-    }
+    can_health[can_number].can_core_reset_cnt += 1U;
+    llcan_clear_send(CAN);
   }
 }
 

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -3,6 +3,11 @@
 //       CAN3_TX, CAN3_RX0, CAN3_SCE
 
 CAN_TypeDef *cans[] = {CAN1, CAN2, CAN3};
+uint8_t can_irq_number[3][3] = {
+  { CAN1_TX_IRQn, CAN1_RX0_IRQn, CAN1_SCE_IRQn },
+  { CAN2_TX_IRQn, CAN2_RX0_IRQn, CAN2_SCE_IRQn },
+  { CAN3_TX_IRQn, CAN3_RX0_IRQn, CAN3_SCE_IRQn },
+};
 
 bool can_set_speed(uint8_t can_number) {
   bool ret = true;
@@ -72,17 +77,6 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
   CAN_TypeDef *CAN = CANIF_FROM_CAN_NUM(can_number);
   uint32_t esr_reg = CAN->ESR;
 
-  if (ir_reg != 0U) {
-    can_health[can_number].total_error_cnt += 1U;
-
-    // RX message lost due to FIFO overrun
-    if ((CAN->RF0R & (CAN_RF0R_FOVR0)) != 0) {
-      can_health[can_number].total_rx_lost_cnt += 1U;
-      CAN->RF0R &= ~(CAN_RF0R_FOVR0);
-    }
-    llcan_clear_send(CAN);
-  }
-
   can_health[can_number].bus_off = ((esr_reg & CAN_ESR_BOFF) >> CAN_ESR_BOFF_Pos);
   can_health[can_number].bus_off_cnt += can_health[can_number].bus_off;
   can_health[can_number].error_warning = ((esr_reg & CAN_ESR_EWGF) >> CAN_ESR_EWGF_Pos);
@@ -95,6 +89,24 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
 
   can_health[can_number].receive_error_cnt = ((esr_reg & CAN_ESR_REC) >> CAN_ESR_REC_Pos);
   can_health[can_number].transmit_error_cnt = ((esr_reg & CAN_ESR_TEC) >> CAN_ESR_TEC_Pos);
+
+  can_health[can_number].irq0_call_rate = interrupts[can_irq_number[can_number][0]].call_rate;
+  can_health[can_number].irq1_call_rate = interrupts[can_irq_number[can_number][1]].call_rate;
+  can_health[can_number].irq2_call_rate = interrupts[can_irq_number[can_number][2]].call_rate;
+
+  if (ir_reg != 0U) {
+    can_health[can_number].total_error_cnt += 1U;
+
+    // RX message lost due to FIFO overrun
+    if ((CAN->RF0R & (CAN_RF0R_FOVR0)) != 0) {
+      can_health[can_number].total_rx_lost_cnt += 1U;
+      CAN->RF0R &= ~(CAN_RF0R_FOVR0);
+    }
+    if (can_health[can_number].transmit_error_cnt >= 100U) {
+      can_health[can_number].can_core_reset_cnt += 1U;
+      llcan_clear_send(CAN);
+    }
+  }
 }
 
 // ***************************** CAN *****************************

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -73,7 +73,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
       can_health[can_number].total_rx_lost_cnt += 1U;
     }
     // Reset CAN core when TX error couter reaches at least 100 errors
-    if (can_health[can_number].transmit_error_cnt >= 100U) {
+    if (((ir_reg & (FDCAN_IR_PED | FDCAN_IR_PEA)) != 0) && (((ecr_reg & FDCAN_ECR_CEL) >> FDCAN_ECR_CEL_Pos) >= 100U)) {
       can_health[can_number].can_core_reset_cnt += 1U;
       can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCAN_TXFQS_TFFL & FDCAN_TXFQS_TFFL_Msk)); // TX FIFO msgs will be lost after reset
       llcan_clear_send(CANx);
@@ -81,6 +81,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
     // Clear error interrupts
     CANx->IR |= (FDCAN_IR_PED | FDCAN_IR_PEA | FDCAN_IR_EP | FDCAN_IR_BO | FDCAN_IR_RF0L);
   }
+
   EXIT_CRITICAL();
 }
 

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -11,6 +11,12 @@ typedef struct {
 
 FDCAN_GlobalTypeDef *cans[] = {FDCAN1, FDCAN2, FDCAN3};
 
+uint8_t can_irq_number[3][2] = {
+  { FDCAN1_IT0_IRQn, FDCAN1_IT1_IRQn },
+  { FDCAN2_IT0_IRQn, FDCAN2_IT1_IRQn },
+  { FDCAN3_IT0_IRQn, FDCAN3_IT1_IRQn },
+};
+
 bool can_set_speed(uint8_t can_number) {
   bool ret = true;
   FDCAN_GlobalTypeDef *CANx = CANIF_FROM_CAN_NUM(can_number);
@@ -57,14 +63,19 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
   can_health[can_number].receive_error_cnt = ((ecr_reg & FDCAN_ECR_REC) >> FDCAN_ECR_REC_Pos);
   can_health[can_number].transmit_error_cnt = ((ecr_reg & FDCAN_ECR_TEC) >> FDCAN_ECR_TEC_Pos);
 
+  can_health[can_number].irq0_call_rate = interrupts[can_irq_number[can_number][0]].call_rate;
+  can_health[can_number].irq1_call_rate = interrupts[can_irq_number[can_number][1]].call_rate;
+
 
   if (ir_reg != 0U) {
     can_health[can_number].total_error_cnt += 1U;
     if ((ir_reg & (FDCAN_IR_RF0L)) != 0) {
       can_health[can_number].total_rx_lost_cnt += 1U;
     }
-    // Actually reset can core only on arbitration or data phase errors and when CEL couter reaches at least 100 errors
-    if (((ir_reg & (FDCAN_IR_PED | FDCAN_IR_PEA)) != 0) && (((ecr_reg & FDCAN_ECR_CEL) >> FDCAN_ECR_CEL_Pos) >= 100U)) {
+    // Reset CAN core when TX error couter reaches at least 100 errors
+    if (can_health[can_number].transmit_error_cnt >= 100U) {
+      can_health[can_number].can_core_reset_cnt += 1U;
+      can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCAN_TXFQS_TFFL & FDCAN_TXFQS_TFFL_Msk)); // TX FIFO msgs will be lost after reset
       llcan_clear_send(CANx);
     }
     // Clear error interrupts
@@ -128,7 +139,6 @@ void process_can(uint8_t can_number) {
         refresh_can_tx_slots_available();
       }
     }
-
     EXIT_CRITICAL();
   }
 }

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -72,7 +72,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
     if ((ir_reg & (FDCAN_IR_RF0L)) != 0) {
       can_health[can_number].total_rx_lost_cnt += 1U;
     }
-    // Reset CAN core when TX error couter reaches at least 100 errors
+    // Reset CAN core when CEL couter reaches at least 100 errors
     if (((ir_reg & (FDCAN_IR_PED | FDCAN_IR_PEA)) != 0) && (((ecr_reg & FDCAN_ECR_CEL) >> FDCAN_ECR_CEL_Pos) >= 100U)) {
       can_health[can_number].can_core_reset_cnt += 1U;
       can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCAN_TXFQS_TFFL & FDCAN_TXFQS_TFFL_Msk)); // TX FIFO msgs will be lost after reset
@@ -81,7 +81,6 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
     // Clear error interrupts
     CANx->IR |= (FDCAN_IR_PED | FDCAN_IR_PEA | FDCAN_IR_EP | FDCAN_IR_BO | FDCAN_IR_RF0L);
   }
-
   EXIT_CRITICAL();
 }
 

--- a/board/health.h
+++ b/board/health.h
@@ -31,7 +31,7 @@ struct __attribute__((packed)) health_t {
   uint16_t sbu2_voltage_mV;
 };
 
-#define CAN_HEALTH_PACKET_VERSION 4
+#define CAN_HEALTH_PACKET_VERSION 5
 typedef struct __attribute__((packed)) {
   uint8_t bus_off;
   uint32_t bus_off_cnt;
@@ -55,4 +55,8 @@ typedef struct __attribute__((packed)) {
   uint8_t canfd_enabled;
   uint8_t brs_enabled;
   uint8_t canfd_non_iso;
+  uint32_t irq0_call_rate;
+  uint32_t irq1_call_rate;
+  uint32_t irq2_call_rate;
+  uint32_t can_core_reset_cnt;
 } can_health_t;

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -201,9 +201,9 @@ class Panda:
 
   CAN_PACKET_VERSION = 4
   HEALTH_PACKET_VERSION = 14
-  CAN_HEALTH_PACKET_VERSION = 4
+  CAN_HEALTH_PACKET_VERSION = 5
   HEALTH_STRUCT = struct.Struct("<IIIIIIIIIBBBBBBHBBBHfBBHBHH")
-  CAN_HEALTH_STRUCT = struct.Struct("<BIBBBBBBBBIIIIIIIHHBBB")
+  CAN_HEALTH_STRUCT = struct.Struct("<BIBBBBBBBBIIIIIIIHHBBBIIII")
 
   F2_DEVICES = (HW_TYPE_PEDAL, )
   F4_DEVICES = (HW_TYPE_WHITE_PANDA, HW_TYPE_GREY_PANDA, HW_TYPE_BLACK_PANDA, HW_TYPE_UNO, HW_TYPE_DOS)
@@ -650,6 +650,10 @@ class Panda:
       "canfd_enabled": a[19],
       "brs_enabled": a[20],
       "canfd_non_iso": a[21],
+      "irq0_call_rate": a[22],
+      "irq1_call_rate": a[23],
+      "irq2_call_rate": a[24],
+      "can_core_reset_count": a[25],
     }
 
   # ******************* control *******************


### PR DESCRIPTION
Would be helpful to have interrupt counter in the CAN health packet
Also data should be updated on request (except when error interrupt was fired). With previous method if CAN core stopped to fire interrupts - health packet won't be updated.