### PR TITLE
Ford: don't check vehicle roll quality flag

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -126,7 +126,7 @@ static bool ford_get_quality_flag_valid(CANPacket_t *to_push) {
   } else if (addr == MSG_EngVehicleSpThrottle2) {
     valid = ((GET_BYTE(to_push, 4) >> 5) & 0x3U) == 0x3U;  // VehVActlEng_D_Qf
   } else if (addr == MSG_Yaw_Data_FD1) {
-    valid = (GET_BYTE(to_push, 6) >> 4) == 0xFU;           // VehRolWActl_D_Qf & VehYawWActl_D_Qf
+    valid = ((GET_BYTE(to_push, 6) >> 4) & 0x3U) == 0x3U;  // VehYawWActl_D_Qf
   } else {
   }
   return valid;

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -131,7 +131,7 @@ class TestFordSafetyBase(common.PandaSafetyTest):
   # Current curvature
   def _yaw_rate_msg(self, curvature: float, speed: float, quality_flag=True):
     values = {"VehYaw_W_Actl": curvature * speed, "VehYawWActl_D_Qf": 3 if quality_flag else 0,
-              "VehRolWActl_D_Qf": 3 if quality_flag else 0, "VehRollYaw_No_Cnt": self.cnt_yaw_rate % 256}
+              "VehRollYaw_No_Cnt": self.cnt_yaw_rate % 256}
     self.__class__.cnt_yaw_rate += 1
     return self.packer.make_can_msg_panda("Yaw_Data_FD1", 0, values, fix_checksum=checksum)
 


### PR DESCRIPTION
The roll signal isn't used in openpilot, and isn't populated on the Ford Focus Mk4 (it is always [`6.6086` No data exists](https://github.com/commaai/opendbc/blob/master/ford_lincoln_base_pt.dbc#L12423)). We still have the yaw signal.

Route: `e886087f430e7fe7|2023-06-14--13-19-55`

![image](https://github.com/commaai/panda/assets/4038174/77c31e77-1fd0-427d-bf38-30c5b2582307)
