### PR TITLE
Controls Allowed Transition reason

### DIFF
--- a/board/health.h
+++ b/board/health.h
@@ -29,6 +29,7 @@ struct __attribute__((packed)) health_t {
   uint8_t fan_stall_count;
   uint16_t sbu1_voltage_mV;
   uint16_t sbu2_voltage_mV;
+  uint8_t controls_transition_reason;
 };
 
 #define CAN_HEALTH_PACKET_VERSION 4

--- a/board/main.c
+++ b/board/main.c
@@ -215,7 +215,7 @@ void tick_handler(void) {
       if (controls_allowed && !heartbeat_engaged) {
         heartbeat_engaged_mismatches += 1U;
         if (heartbeat_engaged_mismatches >= 3U) {
-          controls_allowed = 0U;
+          controls_allowed_transition(false, HeartbeatLost);
         }
       } else {
         heartbeat_engaged_mismatches = 0U;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -17,6 +17,7 @@ int get_health_pkt(void *dat) {
   health->ignition_can_pkt = (uint8_t)(ignition_can);
 
   health->controls_allowed_pkt = controls_allowed;
+  health->controls_transition_reason = controls_transition_reason;
   health->gas_interceptor_detected_pkt = gas_interceptor_detected;
   health->safety_tx_blocked_pkt = safety_tx_blocked;
   health->safety_rx_invalid_pkt = safety_rx_invalid;

--- a/board/safety.h
+++ b/board/safety.h
@@ -674,8 +674,3 @@ void pcm_cruise_check(bool cruise_engaged) {
   }
   cruise_engaged_prev = cruise_engaged;
 }
-
-void controls_allowed_transition(bool allowed, ControlsTransitionReason transition_reason) {
-  controls_allowed = allowed;
-  controls_transition_reason = transition_reason;
-}

--- a/board/safety/safety_body.h
+++ b/board/safety/safety_body.h
@@ -11,7 +11,11 @@ static int body_rx_hook(CANPacket_t *to_push) {
 
   bool valid = addr_safety_check(to_push, &body_rx_checks, NULL, NULL, NULL, NULL);
 
-  controls_allowed = valid;
+  if (valid) {
+    controls_allowed_transition(true, ValidMessage);
+  } else {
+    controls_allowed_transition(true, InvalidMessage);
+  }
 
   return valid;
 }

--- a/board/safety/safety_defaults.h
+++ b/board/safety/safety_defaults.h
@@ -48,7 +48,7 @@ const uint16_t ALLOUTPUT_PARAM_PASSTHROUGH = 1;
 bool alloutput_passthrough = false;
 
 static const addr_checks* alloutput_init(uint16_t param) {
-  controls_allowed = true;
+  controls_allowed_transition(true, AllOutput);
   alloutput_passthrough = GET_FLAG(param, ALLOUTPUT_PARAM_PASSTHROUGH);
   return &default_rx_checks;
 }

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -209,7 +209,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
       // Signal: Veh_V_ActlEng
       float filtered_pcm_speed = ((GET_BYTE(to_push, 6) << 8) | GET_BYTE(to_push, 7)) * 0.01 / 3.6;
       if (ABS(filtered_pcm_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > FORD_MAX_SPEED_DELTA) {
-        controls_allowed = 0;
+        controls_allowed_transition(false, SpeedMismatch);
       }
     }
 

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -95,12 +95,12 @@ static int gm_rx_hook(CANPacket_t *to_push) {
       bool set = (button != GM_BTN_SET) && (cruise_button_prev == GM_BTN_SET);
       bool res = (button == GM_BTN_RESUME) && (cruise_button_prev != GM_BTN_RESUME);
       if (set || res) {
-        controls_allowed = 1;
+        controls_allowed_transition(true, SetPressed);
       }
 
       // exit controls on cancel press
       if (button == GM_BTN_CANCEL) {
-        controls_allowed = 0;
+        controls_allowed_transition(false, CancelPressed);
       }
 
       cruise_button_prev = button;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -142,7 +142,7 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     if ((addr == 0x326) || (addr == 0x1A6)) {
       acc_main_on = GET_BIT(to_push, ((addr == 0x326) ? 28U : 47U));
       if (!acc_main_on) {
-        controls_allowed = 0;
+        controls_allowed_transition(false, CruiseOff);
       }
     }
 
@@ -151,13 +151,13 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       const bool cruise_engaged = GET_BIT(to_push, 38U) != 0U;
       // engage on rising edge
       if (cruise_engaged && !cruise_engaged_prev) {
-        controls_allowed = 1;
+        controls_allowed_transition(true, CruiseEngaged);
       }
 
       // Since some Nidec cars can brake down to 0 after the PCM disengages,
       // we don't disengage when the PCM does.
       if (!cruise_engaged && (honda_hw != HONDA_NIDEC)) {
-        controls_allowed = 0;
+        controls_allowed_transition(false, CruiseOff);
       }
       cruise_engaged_prev = cruise_engaged;
     }
@@ -169,14 +169,14 @@ static int honda_rx_hook(CANPacket_t *to_push) {
 
       // exit controls once main or cancel are pressed
       if ((button == HONDA_BTN_MAIN) || (button == HONDA_BTN_CANCEL)) {
-        controls_allowed = 0;
+        controls_allowed_transition(false, CancelPressed);
       }
 
       // enter controls on the falling edge of set or resume
       bool set = (button == HONDA_BTN_NONE) && (cruise_button_prev == HONDA_BTN_SET);
       bool res = (button == HONDA_BTN_NONE) && (cruise_button_prev == HONDA_BTN_RESUME);
       if (acc_main_on && !pcm_cruise && (set || res)) {
-        controls_allowed = 1;
+        controls_allowed_transition(true, SetPressed);
       }
       cruise_button_prev = button;
     }

--- a/board/safety/safety_hyundai_common.h
+++ b/board/safety/safety_hyundai_common.h
@@ -47,11 +47,11 @@ void hyundai_common_cruise_state_check(const int cruise_engaged) {
   // enter controls on rising edge of ACC and recent user button press, exit controls when ACC off
   if (!hyundai_longitudinal) {
     if (cruise_engaged && !cruise_engaged_prev && (hyundai_last_button_interaction < HYUNDAI_PREV_BUTTON_SAMPLES)) {
-      controls_allowed = 1;
+      controls_allowed_transition(true, CruiseEngaged);
     }
 
     if (!cruise_engaged) {
-      controls_allowed = 0;
+      controls_allowed_transition(false, CruiseOff);
     }
     cruise_engaged_prev = cruise_engaged;
   }
@@ -70,12 +70,12 @@ void hyundai_common_cruise_buttons_check(const int cruise_button, const int main
     bool set = (cruise_button != HYUNDAI_BTN_SET) && (cruise_button_prev == HYUNDAI_BTN_SET);
     bool res = (cruise_button != HYUNDAI_BTN_RESUME) && (cruise_button_prev == HYUNDAI_BTN_RESUME);
     if (set || res) {
-      controls_allowed = 1;
+      controls_allowed_transition(true, SetPressed);
     }
 
     // exit controls on cancel press
     if (cruise_button == HYUNDAI_BTN_CANCEL) {
-      controls_allowed = 0;
+      controls_allowed_transition(false, CancelPressed);
     }
 
     cruise_button_prev = cruise_button;

--- a/board/safety/safety_volkswagen_mqb.h
+++ b/board/safety/safety_volkswagen_mqb.h
@@ -157,7 +157,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
       }
 
       if (!acc_main_on) {
-        controls_allowed = false;
+        controls_allowed_transition(false, CruiseOff);
       }
     }
 
@@ -169,7 +169,11 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
         bool set_button = GET_BIT(to_push, 16U);
         bool resume_button = GET_BIT(to_push, 19U);
         if ((volkswagen_set_button_prev && !set_button) || (volkswagen_resume_button_prev && !resume_button)) {
-          controls_allowed = acc_main_on;
+          if (acc_main_on) {
+            controls_allowed_transition(true, SetPressed);
+          } else {
+            controls_allowed_transition(false, CruiseOff);
+          }
         }
         volkswagen_set_button_prev = set_button;
         volkswagen_resume_button_prev = resume_button;
@@ -177,7 +181,7 @@ static int volkswagen_mqb_rx_hook(CANPacket_t *to_push) {
       // Always exit controls on rising edge of Cancel
       // Signal: GRA_ACC_01.GRA_Abbrechen
       if (GET_BIT(to_push, 13U) == 1U) {
-        controls_allowed = false;
+        controls_allowed_transition(false, CancelPressed);
       }
     }
 

--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -130,7 +130,7 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
         // Signal: Motor_5.GRA_Hauptschalter
         acc_main_on = GET_BIT(to_push, 50U);
         if (!acc_main_on) {
-          controls_allowed = 0;
+          controls_allowed_transition(false, CruiseOff);
         }
       }
 
@@ -141,14 +141,18 @@ static int volkswagen_pq_rx_hook(CANPacket_t *to_push) {
         bool set_button = GET_BIT(to_push, 16U);
         bool resume_button = GET_BIT(to_push, 17U);
         if ((volkswagen_set_button_prev && !set_button) || (volkswagen_resume_button_prev && !resume_button)) {
-          controls_allowed = acc_main_on;
+          if (acc_main_on) {
+            controls_allowed_transition(true, SetPressed);
+          } else {
+            controls_allowed_transition(false, CruiseOff);
+          }
         }
         volkswagen_set_button_prev = set_button;
         volkswagen_resume_button_prev = resume_button;
         // Exit controls on rising edge of Cancel, override Set/Resume if present simultaneously
         // Signal: GRA_ACC_01.GRA_Abbrechen
         if (GET_BIT(to_push, 9U) == 1U) {
-          controls_allowed = 0;
+          controls_allowed_transition(false, CancelPressed);
         }
       }
     } else {

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -183,8 +183,26 @@ typedef struct {
 
 void safety_tick(const addr_checks *addr_checks);
 
+typedef enum {
+  NoTransition,
+  AllOutput,
+  BrakePressed,
+  CancelPressed,
+  CruiseEngaged,
+  CruiseOff,
+  GasPressed,
+  HeartbeatLost,
+  InvalidMessage,
+  LagDetected,
+  RegenBraking,
+  SetPressed,
+  SpeedMismatch,
+  ValidMessage,
+} ControlsTransitionReason;
+
 // This can be set by the safety hooks
 bool controls_allowed = false;
+ControlsTransitionReason controls_transition_reason = NoTransition;
 bool relay_malfunction = false;
 bool gas_interceptor_detected = false;
 int gas_interceptor_prev = 0;

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -203,6 +203,12 @@ typedef enum {
 // This can be set by the safety hooks
 bool controls_allowed = false;
 ControlsTransitionReason controls_transition_reason = NoTransition;
+
+void controls_allowed_transition(bool allowed, ControlsTransitionReason transition_reason) {
+  controls_allowed = allowed;
+  controls_transition_reason = transition_reason;
+}
+
 bool relay_malfunction = false;
 bool gas_interceptor_detected = false;
 int gas_interceptor_prev = 0;

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -611,6 +611,7 @@ class Panda:
       "fan_stall_count": a[24],
       "sbu1_voltage_mV": a[25],
       "sbu2_voltage_mV": a[26],
+      "controls_transition_reason": a[27],
     }
 
   @ensure_can_health_packet_version


### PR DESCRIPTION
A potential precursor for https://github.com/commaai/openpilot/issues/25166

Sets a reason for why a change was made to controls_allowed and sends the value in the healthpacket. The openpilot issue is pretty old so putting this out as a draft for now to gauge interest.