### PR TITLE
uds: fix TypeError for invalid subfunctions

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -229,7 +229,7 @@ class NegativeResponseError(Exception):
 class InvalidServiceIdError(Exception):
   pass
 
-class InvalidSubFunctioneError(Exception):
+class InvalidSubFunctionError(Exception):
   pass
 
 _negative_response_codes = {
@@ -630,7 +630,7 @@ class UdsClient():
         resp_sfn = resp[1] if len(resp) > 1 else None
         if subfunction != resp_sfn:
           resp_sfn_hex = hex(resp_sfn) if resp_sfn is not None else None
-          raise InvalidSubFunctioneError(f'invalid response subfunction: {resp_sfn_hex:x}')
+          raise InvalidSubFunctionError(f'invalid response subfunction: {resp_sfn_hex}')
 
       # return data (exclude service id and sub-function id)
       return resp[(1 if subfunction is None else 2):]


### PR DESCRIPTION
`TypeError: unsupported format string passed to NoneType.__format__`

either way, this would fail. None can't be formatted like this and hex(int) is a string, not int (required int by the `:x` specifer)