### PR TITLE
H7: fix FDCAN_IR register check

### DIFF
--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -69,7 +69,6 @@ void can_set_gmlan(uint8_t bus) {
 }
 
 void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
-  UNUSED(ir_reg);
   CAN_TypeDef *CAN = CANIF_FROM_CAN_NUM(can_number);
   uint32_t esr_reg = CAN->ESR;
 

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -96,7 +96,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
 // CANx_SCE IRQ Handler
 void can_sce(uint8_t can_number) {
   ENTER_CRITICAL();
-  update_can_health_pkt(can_number, 0U);
+  update_can_health_pkt(can_number, 1U);
   EXIT_CRITICAL();
 }
 

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -73,7 +73,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
   CAN_TypeDef *CAN = CANIF_FROM_CAN_NUM(can_number);
   uint32_t esr_reg = CAN->ESR;
 
-  if (ir_reg) {
+  if (ir_reg != 0U) {
     can_health[can_number].total_error_cnt += 1U;
     llcan_clear_send(CAN);
   }

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -68,11 +68,12 @@ void can_set_gmlan(uint8_t bus) {
   }
 }
 
-void update_can_health_pkt(uint8_t can_number, bool error_irq) {
+void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
+  UNUSED(ir_reg);
   CAN_TypeDef *CAN = CANIF_FROM_CAN_NUM(can_number);
   uint32_t esr_reg = CAN->ESR;
 
-  if (error_irq) {
+  if (ir_reg) {
     can_health[can_number].total_error_cnt += 1U;
     llcan_clear_send(CAN);
   }
@@ -95,7 +96,7 @@ void update_can_health_pkt(uint8_t can_number, bool error_irq) {
 // CANx_SCE IRQ Handler
 void can_sce(uint8_t can_number) {
   ENTER_CRITICAL();
-  update_can_health_pkt(can_number, true);
+  update_can_health_pkt(can_number, 0U);
   EXIT_CRITICAL();
 }
 

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -58,7 +58,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
   can_health[can_number].transmit_error_cnt = ((ecr_reg & FDCAN_ECR_TEC) >> FDCAN_ECR_TEC_Pos);
 
 
-  if (ir_reg) {
+  if (ir_reg != 0U) {
     can_health[can_number].total_error_cnt += 1U;
     if ((ir_reg & (FDCAN_IR_RF0L)) != 0) {
       can_health[can_number].total_rx_lost_cnt += 1U;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -167,7 +167,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
     case 0xc2:
       COMPILE_TIME_ASSERT(sizeof(can_health_t) <= USBPACKET_MAX_SIZE);
       if (req->param1 < 3U) {
-        update_can_health_pkt(req->param1, false);
+        update_can_health_pkt(req->param1, 0U);
         can_health[req->param1].can_speed = (bus_config[req->param1].can_speed / 10U);
         can_health[req->param1].can_data_speed = (bus_config[req->param1].can_data_speed / 10U);
         can_health[req->param1].canfd_enabled = bus_config[req->param1].canfd_enabled;


### PR DESCRIPTION
FDCAN_IR register gets erased after writing even just one flag. Because of that we were not recording all errors fired.