### PR TITLE
query_fw_versions: sub-address support

### DIFF
--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     else:
       sub_addrs = [int(args.sub_addr, base=16)]
       if sub_addrs[0] > 0xff:
-        print(f"Invalid sub-address: {hex(sub_addrs[0])}, needs to be in range 0x0 to 0xff")
+        print(f"Invalid sub-address: 0x{sub_addrs[0]:X}, needs to be in range 0x0 to 0xff")
         parser.print_help()
         exit()
 

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -21,6 +21,7 @@ if __name__ == "__main__":
   else:
     addrs = [0x700 + i for i in range(256)]
     addrs += [0x18da0000 + (i << 8) + 0xf1 for i in range(256)]
+  results = {}
 
   sub_addrs = [None]
   if args.sub_addr:
@@ -33,16 +34,6 @@ if __name__ == "__main__":
         parser.print_help()
         exit()
 
-  panda_serials = Panda.list()
-  if args.serial is None and len(panda_serials) > 1:
-    print("\nMultiple pandas found, choose one:")
-    for serial in panda_serials:
-      with Panda(serial) as panda:
-        print(f"  {serial}: internal={panda.is_internal()}")
-    print()
-    parser.print_help()
-    exit()
-
   uds_data_ids = {}
   for std_id in DATA_IDENTIFIER_TYPE:
     uds_data_ids[std_id.value] = std_id.name
@@ -54,7 +45,15 @@ if __name__ == "__main__":
     for uds_id in range(0xf1f0, 0xf200):
       uds_data_ids[uds_id] = "IDENTIFICATION_OPTION_SYSTEM_SUPPLIER_SPECIFIC"
 
-  results = {}
+  panda_serials = Panda.list()
+  if args.serial is None and len(panda_serials) > 1:
+    print("\nMultiple pandas found, choose one:")
+    for serial in panda_serials:
+      with Panda(serial) as panda:
+        print(f"  {serial}: internal={panda.is_internal()}")
+    print()
+    parser.print_help()
+    exit()
 
   panda = Panda(serial=args.serial)
   panda.set_safety_mode(Panda.SAFETY_ELM327, 1 if args.no_obd else 0)

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         bus = int(args.bus)
       else:
         bus = 1 if panda.has_obd() else 0
-      rx_addr = (addr + int(args.rxoffset, base=16)) if args.rxoffset else None
+      rx_addr = addr + int(args.rxoffset, base=16) if args.rxoffset else None
 
       for sub_addr in sub_addrs:
         uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2, debug=args.debug)

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -70,6 +70,7 @@ if __name__ == "__main__":
       else:
         bus = 1 if panda.has_obd() else 0
       rx_addr = (addr + int(args.rxoffset, base=16)) if args.rxoffset else None
+
       for sub_addr in sub_addrs:
         uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2, debug=args.debug)
         # Check for anything alive at this address, and switch to the highest
@@ -95,11 +96,12 @@ if __name__ == "__main__":
             pass
 
         if resp.keys():
-          results[addr] = resp
+          results[(addr, sub_addr)] = resp
 
     if len(results.items()):
-      for addr, resp in results.items():
-        print(f"\n\n*** Results for address 0x{addr:X} ***\n\n")
+      for (addr, sub_addr), resp in results.items():
+        sub_addr_str = f", sub-address 0x{sub_addr:X}" if sub_addr is not None else ""
+        print(f"\n\n*** Results for address 0x{addr:X}{sub_addr_str} ***\n\n")
         for rid, dat in resp.items():
           print(f"0x{rid:02X} {uds_data_ids[rid]}: {dat}")
     else:

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
   parser.add_argument("--no-obd", action="store_true", help="Bus 1 will not be multiplexed to the OBD-II port")
   parser.add_argument("--debug", action="store_true")
   parser.add_argument("--addr")
-  parser.add_argument("--sub_addr", "--subaddr", help="A hex sub-address or `scan` to scan the sub-address range")
+  parser.add_argument("--sub_addr", "--subaddr", help="A hex sub-address or `scan` to scan the full sub-address range")
   parser.add_argument("--bus")
   parser.add_argument('-s', '--serial', help="Serial number of panda to use")
   args = parser.parse_args()

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -70,7 +70,6 @@ if __name__ == "__main__":
       else:
         bus = 1 if panda.has_obd() else 0
       rx_addr = (addr + int(args.rxoffset, base=16)) if args.rxoffset else None
-
       for sub_addr in sub_addrs:
         uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2, debug=args.debug)
         # Check for anything alive at this address, and switch to the highest

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -63,7 +63,6 @@ if __name__ == "__main__":
       # skip functional broadcast addrs
       if addr == 0x7df or addr == 0x18db33f1:
         continue
-      t.set_description(hex(addr))
 
       if args.bus:
         bus = int(args.bus)
@@ -73,6 +72,8 @@ if __name__ == "__main__":
 
       # Try all sub-addresses for addr. By default, this is None
       for sub_addr in sub_addrs:
+        sub_addr_str = hex(sub_addr) if sub_addr is not None else None
+        t.set_description(f"{hex(addr)}, {sub_addr_str}")
         uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2, debug=args.debug)
         # Check for anything alive at this address, and switch to the highest
         # available diagnostic session without security access

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -71,6 +71,7 @@ if __name__ == "__main__":
         bus = 1 if panda.has_obd() else 0
       rx_addr = addr + int(args.rxoffset, base=16) if args.rxoffset else None
 
+      # Try all sub-addresses for addr. By default, this is None
       for sub_addr in sub_addrs:
         uds_client = UdsClient(panda, addr, rx_addr, bus, sub_addr=sub_addr, timeout=0.2, debug=args.debug)
         # Check for anything alive at this address, and switch to the highest

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+from typing import List, Optional
 from tqdm import tqdm
 from panda import Panda
 from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
@@ -23,13 +24,13 @@ if __name__ == "__main__":
     addrs += [0x18da0000 + (i << 8) + 0xf1 for i in range(256)]
   results = {}
 
-  sub_addrs = [None]
+  sub_addrs: List[Optional[int]] = [None]
   if args.sub_addr:
     if args.sub_addr == "scan":
       sub_addrs = list(range(0xff + 1))
     else:
       sub_addrs = [int(args.sub_addr, base=16)]
-      if sub_addrs[0] > 0xff:
+      if sub_addrs[0] > 0xff:  # type: ignore
         print(f"Invalid sub-address: 0x{sub_addrs[0]:X}, needs to be in range 0x0 to 0xff")
         parser.print_help()
         exit()


### PR DESCRIPTION
now you can:
- preserve previous behavior, don't use `--subaddr` or `--sub_addr`
- query a sub-address for an address with `--addr 0x750 --subaddr 0xf`
- query a sub-address for all addresses with `--subaddr 0xf`
- scan 0x00-0xff for an address with `--addr 0x750 --subaddr scan`
- scan 0x00-0xff for all addresses with `--subaddr scan`