### PR TITLE
CanClient: check invalid sub-addresses

### DIFF
--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -86,7 +86,6 @@ if __name__ == "__main__":
         except NegativeResponseError:
           pass
         except (MessageTimeoutError, InvalidSubAddressError):
-          print('Skipped for timeout or invalid sub-address')
           continue
 
         # Run queries against all standard UDS data identifiers, plus selected

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -85,8 +85,10 @@ if __name__ == "__main__":
           uds_client.diagnostic_session_control(SESSION_TYPE.EXTENDED_DIAGNOSTIC)
         except NegativeResponseError:
           pass
-        except (MessageTimeoutError, InvalidSubAddressError):
+        except MessageTimeoutError:
           continue
+        except InvalidSubAddressError:
+          break
 
         # Run queries against all standard UDS data identifiers, plus selected
         # non-standardized identifier ranges if requested

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -3,7 +3,8 @@ import argparse
 from typing import List, Optional
 from tqdm import tqdm
 from panda import Panda
-from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, SESSION_TYPE, DATA_IDENTIFIER_TYPE
+from panda.python.uds import UdsClient, MessageTimeoutError, NegativeResponseError, InvalidSubAddressError, \
+                             SESSION_TYPE, DATA_IDENTIFIER_TYPE
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
@@ -84,7 +85,8 @@ if __name__ == "__main__":
           uds_client.diagnostic_session_control(SESSION_TYPE.EXTENDED_DIAGNOSTIC)
         except NegativeResponseError:
           pass
-        except MessageTimeoutError:
+        except (MessageTimeoutError, InvalidSubAddressError):
+          print('Skipped for timeout or invalid sub-address')
           continue
 
         # Run queries against all standard UDS data identifiers, plus selected
@@ -95,7 +97,7 @@ if __name__ == "__main__":
             data = uds_client.read_data_by_identifier(uds_data_id)  # type: ignore
             if data:
               resp[uds_data_id] = data
-          except (NegativeResponseError, MessageTimeoutError):
+          except (NegativeResponseError, MessageTimeoutError, InvalidSubAddressError):
             pass
 
         if resp.keys():

--- a/python/uds.py
+++ b/python/uds.py
@@ -232,6 +232,9 @@ class InvalidServiceIdError(Exception):
 class InvalidSubFunctionError(Exception):
   pass
 
+class InvalidSubAddressError(Exception):
+  pass
+
 _negative_response_codes = {
     0x00: 'positive response',
     0x10: 'general reject',
@@ -345,6 +348,8 @@ class CanClient():
 
             # Cut off sub addr in first byte
             if self.sub_addr is not None:
+              if rx_data[0] != self.sub_addr:
+                raise InvalidSubAddressError(f"isotp - rx: invalid sub-address: {rx_data[0]}, expected: {self.sub_addr}")
               rx_data = rx_data[1:]
 
             self.rx_buff.append(rx_data)


### PR DESCRIPTION
We weren't checking if the sub-address acknowledgement in the response was correct. This adds a sanity check, and catches in query_fw_versions.py for when you're querying the whole address space for sub-addresses (to find addresses which have them).

Before this you'd get something like:

```python
comma@tici:/data/openpilot/panda/examples$ ./query_fw_versions.py --bus 0 --addr 0x710 --subaddr 0x1                                                                                                               
querying addresses ...                                                                                                                                                                                             
0x710, 0x1:   0%|                                                                                                                                                                            | 0/1 [00:00<?, ?it/s]
can_client recv_buffer: b'\x03\x7f\x01\x11\x00\x00\x00\x00'                                                                                                                                                        
isotp_rx_next rx_data: b'\x7f\x01\x11\x00\x00\x00\x00'                                                                                                                                                             
0x710, 0x1:   0%|                                                                                                                                                                            | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):                                                                                                                                                                                 
  File "./query_fw_versions.py", line 84, in <module>                                                                                                                                                                  uds_client.tester_present()                                                                                                                                                                                    
  File "/data/pythonpath/panda/python/uds.py", line 674, in tester_present                                                                                                                                             self._uds_request(SERVICE_TYPE.TESTER_PRESENT, subfunction=None)                                                                                                                                               
  File "/data/pythonpath/panda/python/uds.py", line 602, in _uds_request                                                                                                                                               resp, _ = isotp_msg.recv(timeout)                                                                                                                                                                              
  File "/data/pythonpath/panda/python/uds.py", line 455, in recv                                                                                                                                                       frame_type = self._isotp_rx_next(msg)                                                                                                                                                                          
  File "/data/pythonpath/panda/python/uds.py", line 552, in _isotp_rx_next                                                                                                                                             raise Exception(f"isotp - rx: invalid frame type: {rx_data[0] >> 4}, {rx_data}")                                                                                                                               
Exception: isotp - rx: invalid frame type: 7, b'\x7f\x01\x11\x00\x00\x00\x00'
```