### PR TITLE
CI: Upload hitl test report to codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,8 +63,6 @@ jobs:
         run: $RUN "cd tests/usbprotocol && ./test.sh"
       - name: Test logging
         run: $RUN "cd tests/logging && ./test.sh"
-      - name: Test hitl
-        run: $RUN "cd tests/hitl && ./test.sh"
 
   safety:
     name: safety

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,6 +63,8 @@ jobs:
         run: $RUN "cd tests/usbprotocol && ./test.sh"
       - name: Test logging
         run: $RUN "cd tests/logging && ./test.sh"
+      - name: Test hitl
+        run: $RUN "cd tests/hitl && ./test.sh"
 
   safety:
     name: safety

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ scons==4.4.0
 flaky
 spidev
 pytest-mock
+coverage==7.2.7

--- a/tests/hitl/test.sh
+++ b/tests/hitl/test.sh
@@ -4,4 +4,6 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
-pytest --durations=0 --maxfail=1 *.py
+coverage run -m pytest --durations=0 --maxfail=1 *.py
+coverage report -m
+# codecov -t <your_token>


### PR DESCRIPTION
Giving this [issue ](https://github.com/commaai/openpilot/issues/28570) a try.
I am not super aware of the whole codebase, so idk if I can run the HITL tests in github actions. I see that they are executed in Jenkins but if GA works, I probably can manage the coverage report.

Edit:
As I expected, cant run without hardware in actions? I'am also not sure if this is the right approach. This would need coverage to be installed and to pass the token to it. Not as easy as I thought.

Edit:
And I dont think I have the setup to run Jenkins locally. I'm missing various secrets probably.
![image](https://github.com/commaai/panda/assets/53004139/ae5830d4-fd5f-4298-b1db-a255374001fc)

