### PR TITLE
SPI: send bootstub status in version request

### DIFF
--- a/board/crc.h
+++ b/board/crc.h
@@ -1,3 +1,5 @@
+#pragma once
+
 uint8_t crc_checksum(uint8_t *dat, int len, const uint8_t poly) {
   uint8_t crc = 0xFFU;
   int i;

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -71,8 +71,8 @@ uint16_t spi_version_packet(uint8_t *out) {
   // write serial
   #ifdef UID_BASE
   (void)memcpy(&out[data_pos], ((uint8_t *)UID_BASE), 12);
-  #endif
   data_len += 12U;
+  #endif
 
   // HW type
   out[data_pos + data_len] = hw_type;

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "crc.h"
+
 #define SPI_BUF_SIZE 1024U
 #define SPI_TIMEOUT_US 10000U
 
@@ -51,20 +53,20 @@ void can_tx_comms_resume_spi(void) {
 }
 
 uint16_t spi_version_packet(uint8_t *out) {
-  // this protocol version request is our stable API. its
-  // contents match that of the panda USB descriptors and
-  // are sufficent to list/enumerate a panda, determine
-  // panda type, and bootstub status.
+  // this protocol version request is a stable portion of
+  // our SPI protocol. its contents match that of the
+  // panda USB descriptors and are sufficent to list/enumerate
+  // a panda, determine panda type, and bootstub status.
 
-  // it protocol version request, respond with:
-  // VERSION + 2 byte data length + data + data complement
+  // the response is:
+  // VERSION + 2 byte data length + data + CRC8
 
   // echo "VERSION"
   (void)memcpy(out, "VERSION", 7);
 
   // write response
   uint16_t data_len = 0;
-  uint16_t data_pos = 9;
+  uint16_t data_pos = 7U + 2U;
 
   // write serial
   #ifdef UID_BASE
@@ -90,17 +92,16 @@ uint16_t spi_version_packet(uint8_t *out) {
   out[data_pos + data_len] = 0x1;
   data_len += 1U;
 
-  // response complement
-  for (uint16_t i = 0U; i < data_len; i++) {
-    out[data_pos + data_len + i] = out[data_pos + i] ^ 0xFFU;
-  }
-
   // data length
-  data_len *= 2U;
   out[7] = data_len & 0xFFU;
   out[8] = (data_len >> 8) & 0xFFU;
 
-  return 7 + 2 + data_len;
+  // CRC8
+  uint16_t resp_len = data_pos + data_len;
+  out[resp_len] = crc_checksum(out, resp_len, 0xD5U);
+  resp_len += 1U;
+
+  return resp_len;
 }
 
 void spi_init(void) {

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -50,6 +50,59 @@ void can_tx_comms_resume_spi(void) {
   spi_can_tx_ready = true;
 }
 
+uint16_t spi_version_packet(uint8_t *out) {
+  // this protocol version request is our stable API. its
+  // contents match that of the panda USB descriptors and
+  // are sufficent to list/enumerate a panda, determine
+  // panda type, and bootstub status.
+
+  // it protocol version request, respond with:
+  // VERSION + 2 byte data length + data + data complement
+
+  // echo "VERSION"
+  (void)memcpy(out, "VERSION", 7);
+
+  // write response
+  uint16_t data_len = 0;
+  uint16_t data_pos = 9;
+
+  // write serial
+  #ifdef UID_BASE
+  (void)memcpy(&out[data_pos], ((uint8_t *)UID_BASE), 12);
+  #endif
+  data_len += 12U;
+
+  // HW type
+  out[data_pos + data_len] = hw_type;
+  data_len += 1U;
+
+  /*
+  // bootstub
+  #ifdef BOOTSTUB
+  out[data_pos + data_len] = 0xab;
+  #else
+  out[data_pos + data_len] = 0xab;
+  #endif
+  data_len += 1U;
+  */
+
+  // SPI protocol version
+  out[data_pos + data_len] = 0x1;
+  data_len += 1U;
+
+  // response complement
+  for (uint16_t i = 0U; i < data_len; i++) {
+    out[data_pos + data_len + i] = out[data_pos + i] ^ 0xFFU;
+  }
+
+  // data length
+  data_len *= 2U;
+  out[7] = data_len & 0xFFU;
+  out[8] = (data_len >> 8) & 0xFFU;
+
+  return 7 + 2 + data_len;
+}
+
 void spi_init(void) {
   // platform init
   llspi_init();
@@ -79,41 +132,7 @@ void spi_rx_done(void) {
   spi_data_len_miso = (spi_buf_rx[5] << 8) | spi_buf_rx[4];
 
   if (memcmp(spi_buf_rx, "VERSION", 7) == 0) {
-    // protocol version request, respond with:
-    // VERSION + 2 byte data length + data + data complement
-
-    // echo "VERSION"
-    (void)memcpy(spi_buf_tx, "VERSION", 7);
-
-    // write response
-    uint16_t data_len = 0;
-    uint16_t data_pos = 9;
-
-    // write serial
-    #ifdef UID_BASE
-    (void)memcpy(&spi_buf_tx[data_pos], ((uint8_t *)UID_BASE), 12);
-    #endif
-    data_len += 12U;
-
-    // HW type
-    spi_buf_tx[data_pos + data_len] = hw_type;
-    data_len += 1U;
-
-    // SPI protocol version
-    spi_buf_tx[data_pos + data_len] = 0x1;
-    data_len += 1U;
-
-    // response complement
-    for (uint16_t i = 0U; i < data_len; i++) {
-      spi_buf_tx[data_pos + data_len + i] = spi_buf_tx[data_pos + i] ^ 0xFFU;
-    }
-
-    // data length
-    data_len *= 2U;
-    spi_buf_tx[7] = data_len & 0xFFU;
-    spi_buf_tx[8] = (data_len >> 8) & 0xFFU;
-
-    response_len = 7U + 2U + data_len;
+    response_len = spi_version_packet(spi_buf_tx);
     next_rx_state = SPI_STATE_HEADER_NACK;;
   } else if (spi_state == SPI_STATE_HEADER) {
     checksum_valid = check_checksum(spi_buf_rx, SPI_HEADER_SIZE);

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -78,15 +78,9 @@ uint16_t spi_version_packet(uint8_t *out) {
   out[data_pos + data_len] = hw_type;
   data_len += 1U;
 
-  /*
   // bootstub
-  #ifdef BOOTSTUB
-  out[data_pos + data_len] = 0xab;
-  #else
-  out[data_pos + data_len] = 0xab;
-  #endif
+  out[data_pos + data_len] = USB_PID & 0xFF;
   data_len += 1U;
-  */
 
   // SPI protocol version
   out[data_pos + data_len] = 0x1;

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -79,7 +79,7 @@ uint16_t spi_version_packet(uint8_t *out) {
   data_len += 1U;
 
   // bootstub
-  out[data_pos + data_len] = USB_PID & 0xFF;
+  out[data_pos + data_len] = USB_PID & 0xFFU;
   data_len += 1U;
 
   // SPI protocol version

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -54,7 +54,7 @@ void can_tx_comms_resume_spi(void) {
 
 uint16_t spi_version_packet(uint8_t *out) {
   // this protocol version request is a stable portion of
-  // our SPI protocol. its contents match that of the
+  // the panda's SPI protocol. its contents match that of the
   // panda USB descriptors and are sufficent to list/enumerate
   // a panda, determine panda type, and bootstub status.
 

--- a/python/spi.py
+++ b/python/spi.py
@@ -192,7 +192,7 @@ class PandaSpiHandle(BaseHandle):
 
       dat = spi.readbytes(rlen + 1)
       resp = dat[:-1]
-      calculated_crc = crc8_pedal(bytes(version_bytes + len_bytes + resp)[::-1])
+      calculated_crc = crc8_pedal(bytes(version_bytes + len_bytes + resp))
       if calculated_crc != dat[-1]:
         raise PandaSpiException("CRC doesn't match")
       return bytes(resp)

--- a/python/spi.py
+++ b/python/spi.py
@@ -193,6 +193,7 @@ class PandaSpiHandle(BaseHandle):
       dat = spi.readbytes(rlen + 1)
       resp = dat[:-1]
       calculated_crc = crc8_pedal(bytes(version_bytes + len_bytes + resp))
+      print("***", bytes(version_bytes + len_bytes + resp), calculated_crc, dat[-1])
       if calculated_crc != dat[-1]:
         raise PandaSpiException("CRC doesn't match")
       return bytes(resp)

--- a/python/utils.py
+++ b/python/utils.py
@@ -10,5 +10,3 @@ def crc8_pedal(data):
       else:
         crc <<= 1
   return crc
-
-

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,14 @@
+def crc8_pedal(data):
+  crc = 0xFF    # standard init value
+  poly = 0xD5   # standard crc8: x8+x7+x6+x4+x2+1
+  size = len(data)
+  for i in range(size - 1, -1, -1):
+    crc ^= data[i]
+    for _ in range(8):
+      if ((crc & 0x80) != 0):
+        crc = ((crc << 1) ^ poly) & 0xFF
+      else:
+        crc <<= 1
+  return crc
+
+

--- a/tests/hitl/8_spi.py
+++ b/tests/hitl/8_spi.py
@@ -18,16 +18,22 @@ class TestSpi:
     assert spy.call_count == 2
     mocker.stop(spy)
 
+  @pytest.mark.expected_logs(2)
   def test_protocol_version(self, p):
-    v = p._handle.get_protocol_version()
+    for bootstub in (False, True):
+      p.reset(enter_bootstub=bootstub)
+      v = p._handle.get_protocol_version()
 
-    uid = binascii.hexlify(v[:12]).decode()
-    assert uid == p.get_uid()
+      uid = binascii.hexlify(v[:12]).decode()
+      assert uid == p.get_uid()
 
-    hwtype = v[12]
-    assert hwtype == ord(p.get_type())
+      hwtype = v[12]
+      assert hwtype == ord(p.get_type())
 
-    assert v[-1] == 1
+      bstub = v[13]
+      assert bstub == (0xEE if bootstub else 0xCC)
+
+      assert v[14:] == b"\x01"
 
   def test_all_comm_types(self, mocker, p):
     spy = mocker.spy(p._handle, '_wait_for_ack')


### PR DESCRIPTION
Now the SPI protocol version request contains everything in the USB descriptors and everything that's relevant for enumerating/listing a panda and reflashing a panda.