### PR TITLE
log device boot time

### DIFF
--- a/board/boards/board_declarations.h
+++ b/board/boards/board_declarations.h
@@ -11,7 +11,7 @@ typedef void (*board_set_ir_power)(uint8_t percentage);
 typedef void (*board_set_fan_enabled)(bool enabled);
 typedef void (*board_set_phone_power)(bool enabled);
 typedef void (*board_set_siren)(bool enabled);
-typedef void (*board_board_tick)(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted);
+typedef bool (*board_board_tick)(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted);
 typedef bool (*board_read_som_gpio)(void);
 
 struct board {

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -53,9 +53,11 @@ void dos_set_bootkick(bool enabled){
   set_gpio_output(GPIOC, 4, !enabled);
 }
 
-void dos_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
+bool dos_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
+  bool ret = false;
   if ((ignition && !usb_enum) || harness_inserted) {
     // enable bootkick if ignition seen or if plugged into a harness
+    ret = true;
     dos_set_bootkick(true);
   } else if (heartbeat_seen) {
     // disable once openpilot is up
@@ -63,6 +65,7 @@ void dos_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harn
   } else {
 
   }
+  return ret;
 }
 
 void dos_set_can_mode(uint8_t mode){

--- a/board/boards/red_v2.h
+++ b/board/boards/red_v2.h
@@ -36,5 +36,6 @@ const board board_red_v2 = {
   .set_fan_enabled = unused_set_fan_enabled,
   .set_ir_power = unused_set_ir_power,
   .set_phone_power = unused_set_phone_power,
-  .set_siren = unused_set_siren
+  .set_siren = unused_set_siren,
+  .read_som_gpio = unused_read_som_gpio
 };

--- a/board/boards/tres.h
+++ b/board/boards/tres.h
@@ -19,10 +19,12 @@ void tres_set_bootkick(bool enabled){
 }
 
 bool tres_ignition_prev = false;
-void tres_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
+bool tres_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
   UNUSED(usb_enum);
+  bool ret = false;
   if ((ignition && !tres_ignition_prev) || harness_inserted) {
     // enable bootkick on rising edge of ignition
+    ret = true;
     tres_set_bootkick(true);
   } else if (heartbeat_seen) {
     // disable once openpilot is up
@@ -31,6 +33,7 @@ void tres_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool har
 
   }
   tres_ignition_prev = ignition;
+  return ret;
 }
 
 void tres_set_fan_enabled(bool enabled) {

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -126,7 +126,7 @@ void uno_set_can_mode(uint8_t mode){
   }
 }
 
-void uno_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
+bool uno_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
   UNUSED(ignition);
   UNUSED(usb_enum);
   UNUSED(heartbeat_seen);
@@ -136,6 +136,7 @@ void uno_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harn
   } else {
     uno_set_bootkick(false);
   }
+  return false;
 }
 
 bool uno_check_ignition(void){

--- a/board/boards/unused_funcs.h
+++ b/board/boards/unused_funcs.h
@@ -22,11 +22,12 @@ uint32_t unused_read_current(void) {
   return 0U;
 }
 
-void unused_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
+bool unused_board_tick(bool ignition, bool usb_enum, bool heartbeat_seen, bool harness_inserted) {
   UNUSED(ignition);
   UNUSED(usb_enum);
   UNUSED(heartbeat_seen);
   UNUSED(harness_inserted);
+  return false;
 }
 
 bool unused_read_som_gpio(void) {

--- a/board/main.c
+++ b/board/main.c
@@ -203,6 +203,8 @@ void tick_handler(void) {
           waiting_to_boot = false;
         } else if (waiting_to_boot_count == 10U) {
           log("not booted after 10s");
+        } else {
+
         }
         waiting_to_boot_count += 1U;
       }

--- a/board/main.c
+++ b/board/main.c
@@ -194,11 +194,12 @@ void tick_handler(void) {
       previous_harness_status = harness.status;
 
       // log device boot time
-      if (just_bootkicked) {
+      const bool som_running = current_board->read_som_gpio();
+      if (just_bootkicked && !som_running) {
         waiting_to_boot = true;
       }
       if (waiting_to_boot) {
-        if (current_board->read_som_gpio()) {
+        if (som_running) {
           log("device booted");
           waiting_to_boot = false;
         } else if (waiting_to_boot_count == 10U) {

--- a/board/main.c
+++ b/board/main.c
@@ -147,6 +147,8 @@ void __attribute__ ((noinline)) enable_fpu(void) {
 // called at 8Hz
 uint8_t loop_counter = 0U;
 uint8_t previous_harness_status = HARNESS_STATUS_NC;
+uint32_t waiting_to_boot_count = 0;
+bool waiting_to_boot = true;
 void tick_handler(void) {
   if (TICK_TIMER->SR != 0) {
     // siren
@@ -187,8 +189,23 @@ void tick_handler(void) {
       logging_tick();
 
       const bool recent_heartbeat = heartbeat_counter == 0U;
-      current_board->board_tick(check_started(), usb_enumerated, recent_heartbeat, ((harness.status != previous_harness_status) && (harness.status != HARNESS_STATUS_NC)));
+      const bool harness_inserted = (harness.status != previous_harness_status) && (harness.status != HARNESS_STATUS_NC);
+      const bool just_bootkicked = current_board->board_tick(check_started(), usb_enumerated, recent_heartbeat, harness_inserted);
       previous_harness_status = harness.status;
+
+      // log device boot time
+      if (just_bootkicked) {
+        waiting_to_boot = true;
+      }
+      if (waiting_to_boot) {
+        if (current_board->read_som_gpio()) {
+          log("device booted");
+          waiting_to_boot = false;
+        } else if (waiting_to_boot_count == 10U) {
+          log("not booted after 10s");
+        }
+        waiting_to_boot_count += 1U;
+      }
 
       // increase heartbeat counter and cap it at the uint32 limit
       if (heartbeat_counter < __UINT32_MAX__) {

--- a/board/main.c
+++ b/board/main.c
@@ -196,6 +196,7 @@ void tick_handler(void) {
       // log device boot time
       const bool som_running = current_board->read_som_gpio();
       if (just_bootkicked && !som_running) {
+        log("bootkick");
         waiting_to_boot = true;
       }
       if (waiting_to_boot) {

--- a/board/main.c
+++ b/board/main.c
@@ -148,7 +148,7 @@ void __attribute__ ((noinline)) enable_fpu(void) {
 uint8_t loop_counter = 0U;
 uint8_t previous_harness_status = HARNESS_STATUS_NC;
 uint32_t waiting_to_boot_count = 0;
-bool waiting_to_boot = true;
+bool waiting_to_boot = false;
 void tick_handler(void) {
   if (TICK_TIMER->SR != 0) {
     // siren

--- a/tests/print_logs.py
+++ b/tests/print_logs.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+from panda import Panda
+
+if __name__ == "__main__":
+  p = Panda()
+  for l in p.get_logs():
+    print(f"{l['id']:<6d} {l['timestamp']} {l['uptime']:6d} - {l['msg']}")

--- a/tests/setup_device_ci.sh
+++ b/tests/setup_device_ci.sh
@@ -60,6 +60,12 @@ git fetch --all
 git checkout -f master
 git reset --hard origin/master
 
+# setup device/SOM state
+SOM_ST_IO=49
+echo $SOM_ST_IO > /sys/class/gpio/export
+echo out > /sys/class/gpio/gpio${SOM_ST_IO}/direction
+echo 1 > /sys/class/gpio/gpio${SOM_ST_IO}/value
+
 # checkout panda commit
 cd $SOURCE_DIR
 

--- a/tests/setup_device_ci.sh
+++ b/tests/setup_device_ci.sh
@@ -62,7 +62,7 @@ git reset --hard origin/master
 
 # setup device/SOM state
 SOM_ST_IO=49
-echo $SOM_ST_IO > /sys/class/gpio/export
+echo $SOM_ST_IO > /sys/class/gpio/export || true
 echo out > /sys/class/gpio/gpio${SOM_ST_IO}/direction
 echo 1 > /sys/class/gpio/gpio${SOM_ST_IO}/value
 


### PR DESCRIPTION
Logs the time from panda bootkick to the ABL triggering the SOM GPIO. Looks like this:
```
65     2023-07-12 22:09:30      0 - main start
66     2023-07-12 22:10:17     47 - bootkick
67     2023-07-12 22:10:20     50 - device booted
```