### PR TITLE
Honda: remove duplicated relay transition time check

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -235,19 +235,17 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     int bus_rdr_car = (honda_hw == HONDA_BOSCH) ? 0 : 2;  // radar bus, car side
     bool stock_ecu_detected = false;
 
-    if (safety_mode_cnt > RELAY_TRNS_TIMEOUT) {
-      // If steering controls messages are received on the destination bus, it's an indication
-      // that the relay might be malfunctioning
-      if ((addr == 0xE4) || (addr == 0x194)) {
-        if (((honda_hw != HONDA_NIDEC) && (bus == bus_rdr_car)) || ((honda_hw == HONDA_NIDEC) && (bus == 0))) {
-          stock_ecu_detected = true;
-        }
-      }
-      // If Honda Bosch longitudinal mode is selected we need to ensure the radar is turned off
-      // Verify this by ensuring ACC_CONTROL (0x1DF) is not received on the PT bus
-      if (honda_bosch_long && !honda_bosch_radarless && (bus == pt_bus) && (addr == 0x1DF)) {
+    // If steering controls messages are received on the destination bus, it's an indication
+    // that the relay might be malfunctioning
+    if ((addr == 0xE4) || (addr == 0x194)) {
+      if (((honda_hw != HONDA_NIDEC) && (bus == bus_rdr_car)) || ((honda_hw == HONDA_NIDEC) && (bus == 0))) {
         stock_ecu_detected = true;
       }
+    }
+    // If Honda Bosch longitudinal mode is selected we need to ensure the radar is turned off
+    // Verify this by ensuring ACC_CONTROL (0x1DF) is not received on the PT bus
+    if (honda_bosch_long && !honda_bosch_radarless && (bus == pt_bus) && (addr == 0x1DF)) {
+      stock_ecu_detected = true;
     }
 
     generic_rx_checks(stock_ecu_detected);


### PR DESCRIPTION
Made common with safety.h's `generic_rx_checks` here (deletion in honda was simply forgotten about): https://github.com/commaai/panda/commit/5b1494514042721b63f71254700ddcf94dbbd9c7

You can see we only use this boolean when the same check is true:

https://github.com/commaai/panda/blob/1154eb2d75f6a0b416d587b22177c759acf5f8e4/board/safety.h#L254-L277