### PR TITLE
STM32H7 DFU bug workaround

### DIFF
--- a/board/bootstub.c
+++ b/board/bootstub.c
@@ -38,14 +38,14 @@ int main(void) {
   init_interrupts(true);
 
   disable_interrupts();
-  clock_init();
+  clock_init(true);
   detect_board_type();
 
 #ifdef PANDA_JUNGLE
   current_board->set_panda_power(true);
 #endif
 
-  if (enter_bootloader_mode == ENTER_SOFTLOADER_MAGIC) {
+  if ((enter_bootloader_mode == ENTER_SOFTLOADER_MAGIC) || failed_clock_init) {
     enter_bootloader_mode = 0;
     soft_flasher_start();
   }

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -12,7 +12,11 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
 
   // flasher machine
   memset(resp, 0, 4);
-  memcpy(resp+4, "\xde\xad\xd0\x0d", 4);
+  if (failed_clock_init) {
+    memcpy(resp+4, "\xab\xad\xb0\x07", 4);
+  } else {
+    memcpy(resp+4, "\xde\xad\xd0\x0d", 4);
+  }
   resp[0] = 0xff;
   resp[2] = req->request;
   resp[3] = ~req->request;

--- a/board/jungle/main.c
+++ b/board/jungle/main.c
@@ -138,7 +138,7 @@ int main(void) {
   disable_interrupts();
 
   // init early devices
-  clock_init();
+  clock_init(false);
   peripherals_init();
   detect_board_type();
 

--- a/board/main.c
+++ b/board/main.c
@@ -308,7 +308,7 @@ void tick_handler(void) {
 void EXTI_IRQ_Handler(void) {
   if (check_exti_irq()) {
     exti_irq_clear();
-    clock_init();
+    clock_init(false);
 
     set_power_save_state(POWER_SAVE_STATUS_DISABLED);
     deepsleep_allowed = false;
@@ -322,7 +322,7 @@ void EXTI_IRQ_Handler(void) {
 uint8_t rtc_counter = 0;
 void RTC_WKUP_IRQ_Handler(void) {
   exti_irq_clear();
-  clock_init();
+  clock_init(false);
 
   rtc_counter++;
   if ((rtc_counter % 2U) == 0U) {
@@ -345,7 +345,7 @@ int main(void) {
   disable_interrupts();
 
   // init early devices
-  clock_init();
+  clock_init(false);
   peripherals_init();
   detect_board_type();
   adc_init();

--- a/board/pedal/main.c
+++ b/board/pedal/main.c
@@ -266,14 +266,14 @@ int main(void) {
   REGISTER_INTERRUPT(CAN1_TX_IRQn, CAN1_TX_IRQ_Handler, CAN_INTERRUPT_RATE, FAULT_INTERRUPT_RATE_CAN_1)
   REGISTER_INTERRUPT(CAN1_RX0_IRQn, CAN1_RX0_IRQ_Handler, CAN_INTERRUPT_RATE, FAULT_INTERRUPT_RATE_CAN_1)
   REGISTER_INTERRUPT(CAN1_SCE_IRQn, CAN1_SCE_IRQ_Handler, CAN_INTERRUPT_RATE, FAULT_INTERRUPT_RATE_CAN_1)
-  
+
   // Should run at around 732Hz (see init below)
   REGISTER_INTERRUPT(TIM3_IRQn, TIM3_IRQ_Handler, 1000U, FAULT_INTERRUPT_RATE_TIM3)
 
   disable_interrupts();
 
   // init devices
-  clock_init();
+  clock_init(false);
   peripherals_init();
   detect_board_type();
 

--- a/board/stm32fx/clock.h
+++ b/board/stm32fx/clock.h
@@ -1,4 +1,8 @@
-void clock_init(void) {
+bool failed_clock_init = false;
+
+void clock_init(bool allow_vos3) {
+  UNUSED(allow_vos3);
+
   // enable external oscillator
   register_set_bits(&(RCC->CR), RCC_CR_HSEON);
   while ((RCC->CR & RCC_CR_HSERDY) == 0);

--- a/board/stm32h7/clock.h
+++ b/board/stm32h7/clock.h
@@ -30,7 +30,7 @@ void clock_init(bool allow_vos3) {
   // In this case, we can continue in VOS3, but not everything is expected to work.
   uint32_t counter = 0U;
   while ((PWR->CSR1 & PWR_CSR1_ACTVOSRDY) == 0) {
-    if ((counter >= 0x10000000U) && allow_vos3) {
+    if ((counter >= 0x100000U) && allow_vos3) {
       failed_clock_init = true;
       break;
     }
@@ -39,7 +39,7 @@ void clock_init(bool allow_vos3) {
 
   counter = 0U;
   while ((PWR->CSR1 & PWR_CSR1_ACTVOS) != (PWR->D3CR & PWR_D3CR_VOS)) {
-    if ((counter >= 0x10000000U) && allow_vos3) {
+    if ((counter >= 0x100000U) && allow_vos3) {
       failed_clock_init = true;
       break;
     }

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -481,7 +481,9 @@ class Panda:
   @staticmethod
   def flasher_present(handle: BaseHandle) -> bool:
     fr = handle.controlRead(Panda.REQUEST_IN, 0xb0, 0, 0, 0xc)
-    return fr[4:8] == b"\xde\xad\xd0\x0d"
+    if fr[4:8] == b"\xab\xad\xb0\x07":
+      logging.warning("Hit DFU bug, will NOT jump to application code. Power cycle the board to recover.")
+    return fr[4:8] in [b"\xde\xad\xd0\x0d", b"\xab\xad\xb0\x07"]
 
   @staticmethod
   def flash_static(handle, code, mcu_type):


### PR DESCRIPTION
The issue with the H7 not coming up when DFU-ing straight after a power cycle comes down to a bug in their dfu routine, which leaves PWR->CR3 unwritable until the next power-on reset. This means that the bootstub / application code gets stuck waiting in the while loop for the LDO to turn off and the switch from VOC3 to VOC1. While technically outside of the operating range of some of the PLLs, everything seems to work fine if we just skip the check and stay at VOC3.