### PR TITLE
Subaru: convert measured angle to centigrees

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -108,7 +108,8 @@ static int subaru_rx_hook(CANPacket_t *to_push) {
       update_sample(&torque_driver, torque_driver_new);
 
       int angle_meas_new = (GET_BYTES(to_push, 4, 2) & 0xFFFFU);
-      angle_meas_new = ROUND(to_signed(angle_meas_new, 16));
+      // convert Steering_Torque -> Steering_Angle to centidegrees, to match the ES_LKAS_ANGLE angle request units
+      angle_meas_new = ROUND(to_signed(angle_meas_new, 16) * 2.17);
       update_sample(&angle_meas, angle_meas_new);
     }
 

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -52,7 +52,7 @@ class TestSubaruSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSa
 
   ALT_BUS = SUBARU_MAIN_BUS
 
-  DEG_TO_CAN = -46.08
+  DEG_TO_CAN = -100
 
   def setUp(self):
     self.packer = CANPackerPanda("subaru_global_2017_generated")


### PR DESCRIPTION
ES_LKAS_ANGLE uses centigrees as its measurement, so convert the measured steering angle to centigrees