### PR TITLE
set OBD to False after test

### DIFF
--- a/tests/hitl/4_can_loopback.py
+++ b/tests/hitl/4_can_loopback.py
@@ -135,6 +135,7 @@ def test_gen2_loopback(p, panda_jungle):
   test(p, panda_jungle, 0x18DB33F1)
   test(panda_jungle, p, 0x18DB33F1)
 
+  # TODO: why it's not being reset by fixtures reinit?
   p.set_obd(False)
   panda_jungle.set_obd(False)
 

--- a/tests/hitl/4_can_loopback.py
+++ b/tests/hitl/4_can_loopback.py
@@ -135,6 +135,9 @@ def test_gen2_loopback(p, panda_jungle):
   test(p, panda_jungle, 0x18DB33F1)
   test(panda_jungle, p, 0x18DB33F1)
 
+  p.set_obd(False)
+  panda_jungle.set_obd(False)
+
 def test_bulk_write(p, panda_jungle):
   # The TX buffers on pandas is 0x100 in length.
   NUM_MESSAGES_PER_BUS = 10000


### PR DESCRIPTION
That's the fix I found for CI issue with total_error_cnt, not yet sure why it is not being reset with fixtures reinit. Still think this is real bus disturbance.