### PR TITLE
GM: clean up longitudinal safety test

### DIFF
--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -17,6 +17,11 @@ class Buttons:
 class GmLongitudinalBase(common.PandaSafetyTest):
   # pylint: disable=no-member,abstract-method
 
+  MAX_GAS = 0
+  MAX_REGEN = 0
+  INACTIVE_REGEN = 0
+  MAX_BRAKE = 0
+
   PCM_CRUISE = False  # openpilot can control the PCM state if longitudinal
 
   def test_set_resume_buttons(self):
@@ -87,11 +92,6 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
   RT_INTERVAL = 250000
   DRIVER_TORQUE_ALLOWANCE = 65
   DRIVER_TORQUE_FACTOR = 4
-
-  MAX_GAS = 0
-  MAX_REGEN = 0
-  INACTIVE_REGEN = 0
-  MAX_BRAKE = 0
 
   PCM_CRUISE = True  # openpilot is tied to the PCM state if not longitudinal
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -20,7 +20,7 @@ class GmLongitudinalBase(common.PandaSafetyTest):
   MAX_GAS = 0
   MAX_REGEN = 0
   INACTIVE_REGEN = 0
-  MAX_BRAKE = 0
+  MAX_BRAKE = 400
 
   PCM_CRUISE = False  # openpilot can control the PCM state if longitudinal
 
@@ -169,7 +169,6 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
   MAX_GAS = 3072
   MAX_REGEN = 1404
   INACTIVE_REGEN = 1404
-  MAX_BRAKE = 400
 
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
@@ -232,7 +231,6 @@ class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase)
   MAX_GAS = 3400
   MAX_REGEN = 1514
   INACTIVE_REGEN = 1554
-  MAX_BRAKE = 400
 
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")


### PR DESCRIPTION
Moved longitudinal-only tests to the longitudinal class. What other safety modes do. GM Camera skips these already