### PR TITLE
Subaru: cancel safety

### DIFF
--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -166,6 +166,14 @@ static int subaru_tx_hook(CANPacket_t *to_send) {
     violation |= steer_torque_cmd_checks(desired_torque, -1, limits);
   }
 
+  // Only allow ES_Distance when Cruise_Cancel is true, and Cruise_Throttle is "inactive" (1818)
+  if (addr == MSG_SUBARU_ES_Distance){
+    int cruise_throttle = (GET_BYTES(to_send, 2, 2) & 0xFFFU);
+    bool cruise_cancel = GET_BIT(to_send, 56U);
+    violation |= (cruise_throttle != 1818);
+    violation |= (cruise_cancel != 1);
+  }
+
   if (violation){
     tx = 0;
   }

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -169,9 +169,9 @@ static int subaru_tx_hook(CANPacket_t *to_send) {
   // Only allow ES_Distance when Cruise_Cancel is true, and Cruise_Throttle is "inactive" (1818)
   if (addr == MSG_SUBARU_ES_Distance){
     int cruise_throttle = (GET_BYTES(to_send, 2, 2) & 0xFFFU);
-    bool cruise_cancel = GET_BIT(to_send, 56U);
+    bool cruise_cancel = GET_BIT(to_send, 56U) != 0U;
     violation |= (cruise_throttle != 1818);
-    violation |= (cruise_cancel != 1);
+    violation |= (!cruise_cancel);
   }
 
   if (violation){

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -4,6 +4,7 @@ from panda import Panda
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
 from panda.tests.safety.common import CANPackerPanda, MeasurementSafetyTest
+from functools import partial
 
 
 MSG_SUBARU_Brake_Status     = 0x13c
@@ -54,6 +55,8 @@ class TestSubaruSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSa
 
   DEG_TO_CAN = -100
 
+  INACTIVE_GAS = 1818
+
   def setUp(self):
     self.packer = CANPackerPanda("subaru_global_2017_generated")
     self.safety = libpanda_py.libpanda
@@ -92,6 +95,15 @@ class TestSubaruSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSa
   def _pcm_status_msg(self, enable):
     values = {"Cruise_Activated": enable}
     return self.packer.make_can_msg_panda("CruiseControl", self.ALT_BUS, values)
+
+  def _cancel_msg(self, cancel, cruise_throttle=0):
+    values = {"Cruise_Cancel": cancel, "Cruise_Throttle": cruise_throttle}
+    return self.packer.make_can_msg_panda("ES_Distance", self.ALT_BUS, values)
+
+  def test_cancel_message(self):
+    # test that we can only send the cancel message (ES_Distance) with inactive throttle (1818) and Cruise_Cancel=1
+    for cancel in [True, False]:
+      self._generic_limit_safety_check(partial(self._cancel_msg, cancel), self.INACTIVE_GAS, self.INACTIVE_GAS, 0, 2**12, 1, self.INACTIVE_GAS, cancel)
 
 
 class TestSubaruGen2SafetyBase(TestSubaruSafetyBase):


### PR DESCRIPTION
Current cancel request method (using simulated buttons) uses the same message that contains Cruise_Throttle meaning we could have sent any throttle we wanted