### PR TITLE
Safety: Rename alt transmission rpm

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -509,10 +509,10 @@ bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limit
   return !get_longitudinal_allowed() && (desired_speed != limits.inactive_speed);
 }
 
-bool longitudinal_alt_checks(int desired_alt, const LongitudinalLimits limits){
-  bool alt_valid = get_longitudinal_allowed() && !max_limit_check(desired_alt, limits.max_alt, limits.min_alt);
-  bool alt_inactive = desired_alt == limits.inactive_alt;
-  return !(alt_valid || alt_inactive);
+bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits){
+  bool transmission_rpm_valid = get_longitudinal_allowed() && !max_limit_check(desired_transmission_rpm, limits.max_transmission_rpm, limits.min_transmission_rpm);
+  bool transmission_rpm_inactive = desired_transmission_rpm == limits.inactive_transmission_rpm;
+  return !(transmission_rpm_valid || transmission_rpm_inactive);
 }
 
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits) {

--- a/board/safety.h
+++ b/board/safety.h
@@ -509,7 +509,7 @@ bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limit
   return !get_longitudinal_allowed() && (desired_speed != limits.inactive_speed);
 }
 
-bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits){
+bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits) {
   bool transmission_rpm_valid = get_longitudinal_allowed() && !max_limit_check(desired_transmission_rpm, limits.max_transmission_rpm, limits.min_transmission_rpm);
   bool transmission_rpm_inactive = desired_transmission_rpm == limits.inactive_transmission_rpm;
   return !(transmission_rpm_valid || transmission_rpm_inactive);

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -90,10 +90,10 @@ typedef struct {
   const int inactive_gas;
   const int max_brake;
 
-  // alternative cmd limits, ex: transmission rpm on subaru
-  const int max_alt;
-  const int min_alt;
-  const int inactive_alt;
+  // transmission rpm limits
+  const int max_transmission_rpm;
+  const int min_transmission_rpm;
+  const int inactive_transmission_rpm;
 
   // speed cmd limits
   const int inactive_speed;

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -168,7 +168,7 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits);
 bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limits);
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits);
-bool longitudinal_alt_checks(int desired_alt, const LongitudinalLimits limits);
+bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits);
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits);
 bool longitudinal_interceptor_checks(CANPacket_t *to_send);
 void pcm_cruise_check(bool cruise_engaged);


### PR DESCRIPTION
rename alt to transmission rpm, to make it more clear