### PR TITLE
Hyundai CAN FD: fix PCM cruise check

### DIFF
--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -226,8 +226,9 @@ static int hyundai_canfd_rx_hook(CANPacket_t *to_push) {
   if (valid && (bus == scc_bus)) {
     // cruise state
     if ((addr == 0x1a0) && !hyundai_longitudinal) {
+      // 1=enabled, 2=driver override
       int cruise_status = ((GET_BYTE(to_push, 8) >> 4) & 0x7U);
-      bool cruise_engaged = (cruise_status == 1U) || (cruise_status == 2U);
+      bool cruise_engaged = (cruise_status == 1) || (cruise_status == 2);
       hyundai_common_cruise_state_check(cruise_engaged);
     }
   }

--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -226,8 +226,8 @@ static int hyundai_canfd_rx_hook(CANPacket_t *to_push) {
   if (valid && (bus == scc_bus)) {
     // cruise state
     if ((addr == 0x1a0) && !hyundai_longitudinal) {
-      int cruise_status = ((GET_BYTE(to_push, 8) >> 4) & 0x3U);
-      bool cruise_engaged = cruise_status == 1U || cruise_status == 2U;
+      int cruise_status = ((GET_BYTE(to_push, 8) >> 4) & 0x7U);
+      bool cruise_engaged = (cruise_status == 1U) || (cruise_status == 2U);
       hyundai_common_cruise_state_check(cruise_engaged);
     }
   }

--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -226,7 +226,8 @@ static int hyundai_canfd_rx_hook(CANPacket_t *to_push) {
   if (valid && (bus == scc_bus)) {
     // cruise state
     if ((addr == 0x1a0) && !hyundai_longitudinal) {
-      bool cruise_engaged = ((GET_BYTE(to_push, 8) >> 4) & 0x3U) != 0U;
+      int cruise_status = ((GET_BYTE(to_push, 8) >> 4) & 0x3U);
+      bool cruise_engaged = cruise_status == 1U || cruise_status == 2U;
       hyundai_common_cruise_state_check(cruise_engaged);
     }
   }

--- a/board/safety/safety_hyundai_common.h
+++ b/board/safety/safety_hyundai_common.h
@@ -23,7 +23,6 @@ bool hyundai_hybrid_gas_signal = false;
 bool hyundai_longitudinal = false;
 bool hyundai_camera_scc = false;
 bool hyundai_alt_limits = false;
-bool hyundai_pcm_cruise = false;  // TODO: think we can just use hyundai_longitudinal, right?
 uint8_t hyundai_last_button_interaction;  // button messages since the user pressed an enable button
 
 void hyundai_common_init(uint16_t param) {
@@ -39,7 +38,6 @@ void hyundai_common_init(uint16_t param) {
 #else
   hyundai_longitudinal = false;
 #endif
-  hyundai_pcm_cruise = !hyundai_longitudinal;
 }
 
 void hyundai_common_cruise_state_check(const int cruise_engaged) {

--- a/board/safety/safety_hyundai_common.h
+++ b/board/safety/safety_hyundai_common.h
@@ -23,6 +23,7 @@ bool hyundai_hybrid_gas_signal = false;
 bool hyundai_longitudinal = false;
 bool hyundai_camera_scc = false;
 bool hyundai_alt_limits = false;
+bool hyundai_pcm_cruise = false;  // TODO: think we can just use hyundai_longitudinal, right?
 uint8_t hyundai_last_button_interaction;  // button messages since the user pressed an enable button
 
 void hyundai_common_init(uint16_t param) {
@@ -38,6 +39,7 @@ void hyundai_common_init(uint16_t param) {
 #else
   hyundai_longitudinal = false;
 #endif
+  hyundai_pcm_cruise = !hyundai_longitudinal;
 }
 
 void hyundai_common_cruise_state_check(const int cruise_engaged) {


### PR DESCRIPTION
The parsing of the CANFD `ACC_STATUS->ACCMode` signal only considers the first two bits (0x3 instead of 0x7), so it would consider any value from 1 to 3 to be enaged, and 0 and 4 to be disengaged. Which is mostly correct, since the EV6 route I found has it at 4 when disabled.

When the car enters a fault status (3), only then is there a mismatch between openpilot and panda. Will fix this by:
- correctly parsing the whole 3 bit signal,
- checking the same specific values openpilot does, 
- and adding a test to test_models to check cruise state, not only controlsAllowed, which shows a mismatch in most HKG routes (doesn't need the fault status to come up) - https://github.com/commaai/openpilot/pull/29423