### PR TITLE
MacOS: Homebrew GCC is now version 13

### DIFF
--- a/tests/libpanda/SConscript
+++ b/tests/libpanda/SConscript
@@ -5,7 +5,7 @@ system = platform.system()
 if system == 'Darwin':
   # gcc installed by homebrew has version suffix (e.g. gcc-12) in order to be
   # distinguishable from system one - which acts as a symlink to clang
-  CC += '-12'
+  CC += '-13'
 
 env = Environment(
   CC=CC,


### PR DESCRIPTION
https://formulae.brew.sh/formula/gcc