### PR TITLE
Honda: match openpilot button enable check

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -173,8 +173,8 @@ static int honda_rx_hook(CANPacket_t *to_push) {
       }
 
       // enter controls on the falling edge of set or resume
-      bool set = (button == HONDA_BTN_NONE) && (cruise_button_prev == HONDA_BTN_SET);
-      bool res = (button == HONDA_BTN_NONE) && (cruise_button_prev == HONDA_BTN_RESUME);
+      bool set = (button != HONDA_BTN_SET) && (cruise_button_prev == HONDA_BTN_SET);
+      bool res = (button != HONDA_BTN_RESUME) && (cruise_button_prev == HONDA_BTN_RESUME);
       if (acc_main_on && !pcm_cruise && (set || res)) {
         controls_allowed = true;
       }

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -167,16 +167,16 @@ static int honda_rx_hook(CANPacket_t *to_push) {
     if (((addr == 0x1A6) || (addr == 0x296)) && (bus == pt_bus)) {
       int button = (GET_BYTE(to_push, 0) & 0xE0U) >> 5;
 
-      // exit controls once main or cancel are pressed
-      if ((button == HONDA_BTN_MAIN) || (button == HONDA_BTN_CANCEL)) {
-        controls_allowed = false;
-      }
-
       // enter controls on the falling edge of set or resume
       bool set = (button != HONDA_BTN_SET) && (cruise_button_prev == HONDA_BTN_SET);
       bool res = (button != HONDA_BTN_RESUME) && (cruise_button_prev == HONDA_BTN_RESUME);
       if (acc_main_on && !pcm_cruise && (set || res)) {
         controls_allowed = true;
+      }
+
+      // exit controls once main or cancel are pressed
+      if ((button == HONDA_BTN_MAIN) || (button == HONDA_BTN_CANCEL)) {
+        controls_allowed = false;
       }
       cruise_button_prev = button;
     }

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -77,8 +77,8 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
           # should enter controls allowed on falling edge and not transitioning to cancel or main
           should_enable = (main_on and
                            btn_cur != btn_prev and
-                           btn_cur not in (Btn.CANCEL, Btn.MAIN) and
-                           btn_prev in (Btn.RESUME, Btn.SET))
+                           btn_prev in (Btn.RESUME, Btn.SET) and
+                           btn_cur not in (Btn.CANCEL, Btn.MAIN))
 
           self._rx(self._button_msg(btn_cur))
           self.assertEqual(should_enable, self.safety.get_controls_allowed(), msg=f"{main_on=} {btn_prev=} {btn_cur=}")

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -64,18 +64,24 @@ class HondaButtonEnableBase(common.PandaSafetyTest):
     """
       Both SET and RES should enter controls allowed on their falling edge.
     """
-    for btn in (Btn.SET, Btn.RESUME):
-      for main_on in (True, False):
-        self._rx(self._acc_state_msg(main_on))
-        self.safety.set_controls_allowed(0)
+    for main_on in (True, False):
+      self._rx(self._acc_state_msg(main_on))
+      for btn_prev in range(8):
+        for btn_cur in range(8):
+          self._rx(self._button_msg(Btn.NONE))
+          self.safety.set_controls_allowed(0)
+          for _ in range(10):
+            self._rx(self._button_msg(btn_prev))
+            self.assertFalse(self.safety.get_controls_allowed())
 
-        # nothing until falling edge
-        for _ in range(10):
-          self._rx(self._button_msg(btn, main_on=main_on))
-        self.assertFalse(self.safety.get_controls_allowed())
+          # should enter controls allowed on falling edge and not transitioning to cancel or main
+          should_enable = (main_on and
+                           btn_cur != btn_prev and
+                           btn_cur not in (Btn.CANCEL, Btn.MAIN) and
+                           btn_prev in (Btn.RESUME, Btn.SET))
 
-        self._rx(self._button_msg(Btn.NONE, main_on=main_on))
-        self.assertEqual(main_on, self.safety.get_controls_allowed(), msg=f"{main_on=} {btn=}")
+          self._rx(self._button_msg(btn_cur))
+          self.assertEqual(should_enable, self.safety.get_controls_allowed(), msg=f"{main_on=} {btn_prev=} {btn_cur=}")
 
   def test_main_cancel_buttons(self):
     """


### PR DESCRIPTION
Only relevant with https://github.com/commaai/openpilot/pull/26463. Enables on falling edge of button to any other button, except cancel.

See PR for Hyundai: https://github.com/commaai/panda/pull/1152