### PR TITLE
H7: reset CAN core on bus off state

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -81,6 +81,13 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
       can_health[can_number].can_core_reset_cnt += 1U;
       can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
       llcan_clear_send(FDCANx);
+    // }
+    // H7 gets stuck in bus off state TODO: figure out why
+    // FIXME: merge with previous if, but keep separate for now.
+    } else if (ir_reg & FDCAN_IR_BO) {
+      can_health[can_number].can_core_reset_cnt += 1U;
+      can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
+      llcan_clear_send(FDCANx);
     }
   }
 }

--- a/board/jungle/main.c
+++ b/board/jungle/main.c
@@ -93,15 +93,6 @@ void tick_handler(void) {
     }
 
 #ifdef FINAL_PROVISIONING
-    // Reset CAN core if it got stuck in bus off state after shorted CANH/L
-    // Looks like an issue with H7 that it doesn't want to recover from bus off
-    // FIXME: this must be fixed on the driver level, temporary workaround
-    for (uint8_t i = 0U; i < 3U; i++) {
-      update_can_health_pkt(i, 0);
-      if (can_health[i].bus_off == 1U) {
-        can_init(i);
-      }
-    }
     // Ignition blinking
     uint8_t ignition_bitmask = 0U;
     for (uint8_t i = 0U; i < 6U; i++) {


### PR DESCRIPTION
After H7 CAN core falls into bus off state it doesn't want to recover (even after 129*11 successful consecutive recessive bits). 

WIP!