### PR TITLE
H7: reorganize RAM

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -52,17 +52,21 @@ void process_can(uint8_t can_number);
   CANPacket_t elems_##x[size]; \
   can_ring can_##x = { .w_ptr = 0, .r_ptr = 0, .fifo_size = (size), .elems = (CANPacket_t *)&(elems_##x) };
 
+#define CAN_RX_BUFFER_SIZE 4096U
+#define CAN_TX_BUFFER_SIZE 416U
+#define GMLAN_TX_BUFFER_SIZE 416U
+
 #ifdef STM32H7
-__attribute__((section(".axisram"))) can_buffer(rx_q, 0x1000)
-__attribute__((section(".axisram"))) can_buffer(tx2_q, 0x1A0)
-__attribute__((section(".sram12"))) can_buffer(txgmlan_q, 0x1A0)
+__attribute__((section(".axisram"))) can_buffer(rx_q, CAN_RX_BUFFER_SIZE)
+__attribute__((section(".itcmram"))) can_buffer(tx1_q, CAN_TX_BUFFER_SIZE)
+__attribute__((section(".itcmram"))) can_buffer(tx2_q, CAN_TX_BUFFER_SIZE)
 #else
-can_buffer(rx_q, 0x1000)
-can_buffer(tx2_q, 0x1A0)
-can_buffer(txgmlan_q, 0x1A0)
+can_buffer(rx_q, CAN_RX_BUFFER_SIZE)
+can_buffer(tx1_q, CAN_TX_BUFFER_SIZE)
+can_buffer(tx2_q, CAN_TX_BUFFER_SIZE)
 #endif
-can_buffer(tx1_q, 0x1A0)
-can_buffer(tx3_q, 0x1A0)
+can_buffer(tx3_q, CAN_TX_BUFFER_SIZE)
+can_buffer(txgmlan_q, GMLAN_TX_BUFFER_SIZE)
 // FIXME:
 // cppcheck-suppress misra-c2012-9.3
 can_ring *can_queues[] = {&can_tx1_q, &can_tx2_q, &can_tx3_q, &can_txgmlan_q};

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -10,7 +10,7 @@
 
 #ifdef STM32H7
 #define SPI_BUF_SIZE 2048U
-__attribute__((section(".axisram"))) uint8_t spi_buf_rx[SPI_BUF_SIZE];
+__attribute__((section(".sram12"))) uint8_t spi_buf_rx[SPI_BUF_SIZE];
 __attribute__((section(".sram12"))) uint8_t spi_buf_tx[SPI_BUF_SIZE];
 #else
 #define SPI_BUF_SIZE 1024U


### PR DESCRIPTION
Reasoning for SPI:
DMA is in D2 domain, so SRAM1 and SRAM2 are the fastest.

Reasoning for FDCAN:
ITCM RAM and DTCM RAM are the fastest for cortex core access, no need to use cross domain links.

Also AXI SRAM will be needed for SDMMC driver buffer soon. (next PR)

=======SUMMARY FOR H7 FILE ../board/obj/panda_h7.elf=======
SECTION: .flash size: 1048576 USED: 64308(6.13%) FREE: 984268
SECTION: .dtcmram size: 131072 USED: 100400(76.60%) FREE: 30672
SECTION: .itcmram size: 65536 USED: 59904(91.41%) FREE: 5632
SECTION: .axisram size: 327680 USED: 294912(90.00%) FREE: 32768
SECTION: .sram12 size: 32768 USED: 4096(12.50%) FREE: 28672
SECTION: .sram4 size: 16384 USED: 0(0.00%) FREE: 16384
SECTION: .backup_sram size: 4096 USED: 0(0.00%) FREE: 4096

