### PR TITLE
VW PQ: Check steer req bit

### DIFF
--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -197,7 +197,7 @@ static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
       desired_torque *= -1;
     }
 
-    uint32_t hca_status = ((GET_BYTE(to_send, 1) >> 4) & 0xF);
+    uint32_t hca_status = ((GET_BYTE(to_send, 1) >> 4) & 0xFU);
     bool steer_req = (hca_status == 5U);
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, VOLKSWAGEN_PQ_STEERING_LIMITS)) {

--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -197,7 +197,10 @@ static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
       desired_torque *= -1;
     }
 
-    if (steer_torque_cmd_checks(desired_torque, -1, VOLKSWAGEN_PQ_STEERING_LIMITS)) {
+    uint32_t hca_status = ((GET_BYTE(to_send, 1) >> 4) & 0xF);
+    bool steer_req = (hca_status == 5U);
+
+    if (steer_torque_cmd_checks(desired_torque, steer_req, VOLKSWAGEN_PQ_STEERING_LIMITS)) {
       tx = 0;
     }
   }

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -71,7 +71,7 @@ class TestVolkswagenPqSafety(common.PandaSafetyTest, common.DriverTorqueSteering
 
   # openpilot steering output torque
   def _torque_cmd_msg(self, torque, steer_req=1):
-    values = {"LM_Offset": abs(torque), "LM_OffSign": torque < 0}
+    values = {"LM_Offset": abs(torque), "LM_OffSign": torque < 0, "HCA_Status": 5 if steer_req else 3}
     return self.packer.make_can_msg_panda("HCA_1", 0, values)
 
   # ACC engagement and brake light switch status


### PR DESCRIPTION
as far as I can tell, VW doesn't need any special logic around the steer req frames. It only sets HCA_ENABLED to false when apply_steer is zero, which is fine in the current panda logic:

https://github.com/commaai/openpilot/blob/master/selfdrive/car/volkswagen/carcontroller.py#L56
https://github.com/commaai/panda/blob/master/board/safety.h#L573