### PR TITLE
enable red and green leds until USB/SPI init

### DIFF
--- a/board/jungle/main.c
+++ b/board/jungle/main.c
@@ -150,6 +150,8 @@ int main(void) {
   clock_init();
   peripherals_init();
   detect_board_type();
+  // red led enabled until succesful USB init, as a debug indicator
+  current_board->set_led(LED_RED, true);
 
   // print hello
   print("\n\n\n************************ MAIN START ************************\n");
@@ -180,6 +182,8 @@ int main(void) {
 #endif
   // enable USB (right before interrupts or enum can fail!)
   usb_init();
+
+  current_board->set_led(LED_RED, false);
 
   print("**** INTERRUPTS ON ****\n");
   enable_interrupts();

--- a/board/jungle/main.c
+++ b/board/jungle/main.c
@@ -150,8 +150,9 @@ int main(void) {
   clock_init();
   peripherals_init();
   detect_board_type();
-  // red led enabled until succesful USB init, as a debug indicator
+  // red+green leds enabled until succesful USB init, as a debug indicator
   current_board->set_led(LED_RED, true);
+  current_board->set_led(LED_GREEN, true);
 
   // print hello
   print("\n\n\n************************ MAIN START ************************\n");
@@ -184,6 +185,7 @@ int main(void) {
   usb_init();
 
   current_board->set_led(LED_RED, false);
+  current_board->set_led(LED_GREEN, false);
 
   print("**** INTERRUPTS ON ****\n");
   enable_interrupts();

--- a/board/main.c
+++ b/board/main.c
@@ -348,8 +348,9 @@ int main(void) {
   clock_init();
   peripherals_init();
   detect_board_type();
-  // red led enabled until succesful USB/SPI init, as a debug indicator
+  // red+green leds enabled until succesful USB/SPI init, as a debug indicator
   current_board->set_led(LED_RED, true);
+  current_board->set_led(LED_GREEN, true);
   adc_init();
   logging_init();
 
@@ -413,6 +414,7 @@ int main(void) {
 #endif
 
   current_board->set_led(LED_RED, false);
+  current_board->set_led(LED_GREEN, false);
 
   print("**** INTERRUPTS ON ****\n");
   enable_interrupts();

--- a/board/main.c
+++ b/board/main.c
@@ -348,6 +348,8 @@ int main(void) {
   clock_init();
   peripherals_init();
   detect_board_type();
+  // red led enabled until succesful USB/SPI init, as a debug indicator
+  current_board->set_led(LED_RED, true);
   adc_init();
   logging_init();
 
@@ -409,6 +411,8 @@ int main(void) {
     spi_init();
   }
 #endif
+
+  current_board->set_led(LED_RED, false);
 
   print("**** INTERRUPTS ON ****\n");
   enable_interrupts();


### PR DESCRIPTION
Will help support to better understand if panda froze before USB/SPI init