### PR TITLE
GM: change ignition signal

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -208,7 +208,7 @@ void ignition_can_hook(CANPacket_t *to_push) {
 
   if (bus == 0) {
     // GM exception
-    if ((addr == 0x1f1) && (len == 8)) {
+    if ((addr == 0x1F1) && (len == 8)) {
       // SystemPowerMode (2=Run, 3=Crank Request)
       ignition_can = (GET_BYTE(to_push, 0) & 0x2U) != 0U;
       ignition_can_cnt = 0U;

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -208,9 +208,9 @@ void ignition_can_hook(CANPacket_t *to_push) {
 
   if (bus == 0) {
     // GM exception
-    if ((addr == 0x160) && (len == 5)) {
-      // this message isn't all zeros when ignition is on
-      ignition_can = GET_BYTES(to_push, 0, 4) != 0U;
+    if ((addr == 0x1f1) && (len == 8)) {
+      // SystemPowerMode (2=Run, 3=Crank Request)
+      ignition_can = (GET_BYTE(to_push, 0) & 0x2U) != 0U;
       ignition_can_cnt = 0U;
     }
 


### PR DESCRIPTION
## Background
Previous signal was checking whether the immobilizer ID was being published. New signal is the power mode. The previous signal used before the immobilizer signal was the "backup" power mode which is noisy and doesn't describe cranking or accessory (https://github.com/commaai/panda/pull/845).

This new [`SystemPowerMode`](https://github.com/commaai/opendbc/pull/953) describes the four ignition states: off, accessory, (on, and ignition together), and cranking.

## The problem
The problem with the current signal is that the immobilizer signal remains high in accessory mode, where various ECUs can fault or shut off ([the EBCM on the Chevy Bolt](https://github.com/commaai/panda/assets/25857203/29182ec7-0984-47ad-b0b4-deedbb29d0de), [the PSCM on the ASCM Volt](https://github.com/commaai/panda/assets/25857203/bea25b8c-31b8-4397-b1b7-cddc5719443d), as well as the [Camera ACC Silverado](https://github.com/commaai/panda/assets/25857203/e2712568-f8a8-4afc-8559-8e1e8e088ddb)). Other cars kill power to the camera in this state (Toyota for example).

## The fix
This PR only considers on/ignition and crank request valid ignition states so we go offroad when in accessory mode (enterable by pressing power button in neutral).

## Checks
Checked that the old-preconditioning issue (shows ignition with remote start) is not present in the new signal manually on the Bolt EUV and Volt, thanks to community member nworby:

```
nworby ('18 radarless Volt) — Yesterday at 7:27 AM
@Shane 
806907cd33ef2647|2023-09-14--08-18-38--0 - shifting to neutral and pressing power button
806907cd33ef2647|2023-09-14--08-19-55--0 - entering accessory mode while car is off
806907cd33ef2647|2023-09-14--08-21-17--0 - remote start & stop
```

## Data

This signal also switches off a little under 100ms faster on average, preventing a fault from showing when pandaStates is 10Hz:

<details>
  <summary>View</summary>

<img src="https://github.com/commaai/panda/assets/25857203/dd274a2b-8137-48da-8ef7-7fd7c8681614" width=600px>

</details>

---

Some examples where the user enters accessory mode and the EBCM fault signal (Bolt) or LKA fault (Volt, Silverado) rises:

<details>
  <summary>View</summary>

| -  | - |
| ------------- | ------------- |
| <img src="https://github.com/commaai/panda/assets/25857203/7a9be138-fa52-41da-93f6-c5da7d88295d" width=600px>  | <img src="https://github.com/commaai/panda/assets/25857203/758c5261-9936-4c0e-8e8d-cfda3b2eb96f" width=600px> |
| ![image](https://github.com/commaai/panda/assets/25857203/cbbe7d3f-bbaf-4a6f-ad6e-432b075138c5) | ![image](https://github.com/commaai/panda/assets/25857203/a68b3e93-53ab-4602-b61b-50b21d388260) |
|  ![image](https://github.com/commaai/panda/assets/25857203/46f73234-7ac4-4636-864a-b7ce6715b4f4) | |

</details>

---

Some cases with more rare cars, all expected.
<details>
  <summary>View</summary>

| -  | - |
| ------------- | ------------- |
| ![image](https://github.com/commaai/panda/assets/25857203/1f8f3734-010b-4c09-9b2c-69de13c0eff2) | ![image](https://github.com/commaai/panda/assets/25857203/b5fc0ed2-96f2-4cb5-8c1b-433f435be921) |
|![image](https://github.com/commaai/panda/assets/25857203/fd9c533e-f6da-4fe3-b6df-5e0ec4bab127) | ![image](https://github.com/commaai/panda/assets/25857203/ef9862c6-a474-4226-a433-c6b40ef9774c) |
| ![image](https://github.com/commaai/panda/assets/25857203/ad8c3571-cabe-4f02-943a-fd59bc553123) | ![image](https://github.com/commaai/panda/assets/25857203/a6fbe682-291e-43c9-80ed-14d543dbd3cc) |
| ![image](https://github.com/commaai/panda/assets/25857203/85701563-ae08-479d-917f-f331d22eece8) | |

</details>

---

The other mismatches are small timing differences or expected accessory mode diffs:

<details>
  <summary>View</summary>

| -  | - |
| ------------- | ------------- |
| <img src="https://github.com/commaai/panda/assets/25857203/46dfc1ae-352a-4772-bb8a-04382a0152a1" width=600px> |<img src="https://github.com/commaai/panda/assets/25857203/a2ed9c45-2ca1-488d-a411-1e3ceb2673f2" width=600px> |
| ![image](https://github.com/commaai/panda/assets/25857203/b25362f0-71b1-4d30-9202-46d07ec6c977) | ![image](https://github.com/commaai/panda/assets/25857203/1548e61d-9d1c-41bc-9508-aded5d801ffb) |
| ![image](https://github.com/commaai/panda/assets/25857203/234f04ee-ddec-416b-a5eb-2827eba364d2) | ![image](https://github.com/commaai/panda/assets/25857203/27ca9d96-3a46-4df0-8bd7-5b03e30bf446) |
| ![image](https://github.com/commaai/panda/assets/25857203/a686be03-80a2-48a3-b268-1740c11b2ead) | |

</details>

---

### Interesting notes

- Found a case where user left car in accessory mode and walked away (would go offroad with new signal): https://connect.comma.ai/d2ccdcf33e62cfa0/1682706535809/1682707007116.
- In accessory mode CAN remains valid, but the buttons message goes into an "Indeterminate" state, meaning it's essentially switched off and not to be used: https://github.com/commaai/panda/assets/25857203/1fd1998e-82c6-47dd-aa0e-7c583fe3eaa4
- SystemPowerMode does not have noisy issue that SystemBackupPowerMode does: https://github.com/commaai/panda/assets/25857203/07050faf-c09b-4c52-b97d-694aa64a3758

---

Checked 68,867 rlogs for last 1080 days and only 316 segments mismatch with the conditions above.

```python
Checked segments: 68867, dongles: 323 platforms: {'CHEVROLET VOLT PREMIER 2017': 30521, 'CHEVROLET BOLT EUV 2022': 28454, 'CHEVROLET SILVERADO 1500 2020': 5506, 'GMC ACADIA DENALI 2018': 2608, 'CADILLAC ESCALADE ESV 2016': 1455, 'CADILLAC ESCALADE 2017': 319, 'BUICK LACROSSE 2017': 3, 'CADILLAC ATS Premium Performance 2018': 1}
```