### PR TITLE
VW PQ: add HCA mode 7 as conditional for steer_req

### DIFF
--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -198,7 +198,7 @@ static int volkswagen_pq_tx_hook(CANPacket_t *to_send) {
     }
 
     uint32_t hca_status = ((GET_BYTE(to_send, 1) >> 4) & 0xFU);
-    bool steer_req = (hca_status == 5U);
+    bool steer_req = ((hca_status == 5U) || (hca_status == 7U));
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, VOLKSWAGEN_PQ_STEERING_LIMITS)) {
       tx = 0;


### PR DESCRIPTION
Adding new HCA steering mode 7 under boolean steer_req for VW PQ panda safety.

Working route:
`578742b26807f756|2023-09-25--17-08-37`

@jyoung8607 will work on / complete the CI test's :)