### PR TITLE
Safety: Only allow tester present TX with openpilot longitudinal

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -368,7 +368,7 @@ static int honda_tx_hook(CANPacket_t *to_send) {
   // Only tester present ("\x02\x3E\x80\x00\x00\x00\x00\x00") allowed on diagnostics address
   if (addr == 0x18DAB0F1) {
     if ((GET_BYTES(to_send, 0, 4) != 0x00803E02U) || (GET_BYTES(to_send, 4, 4) != 0x0U)) {
-      tx = 0;
+      tx = honda_bosch_long;
     }
   }
 

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -281,7 +281,7 @@ static int hyundai_tx_hook(CANPacket_t *to_send) {
   // UDS: Only tester present ("\x02\x3E\x80\x00\x00\x00\x00\x00") allowed on diagnostics address
   if (addr == 0x7D0) {
     if ((GET_BYTES(to_send, 0, 4) != 0x00803E02U) || (GET_BYTES(to_send, 4, 4) != 0x0U)) {
-      tx = 0;
+      tx = hyundai_longitudinal;
     }
   }
 

--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -308,7 +308,7 @@ static int hyundai_canfd_tx_hook(CANPacket_t *to_send) {
   // UDS: only tester present ("\x02\x3E\x80\x00\x00\x00\x00\x00") allowed on diagnostics address
   if ((addr == 0x730) && hyundai_canfd_hda2) {
     if ((GET_BYTES(to_send, 0, 4) != 0x00803E02U) || (GET_BYTES(to_send, 4, 4) != 0x0U)) {
-      tx = 0;
+      tx = hyundai_longitudinal;
     }
   }
 

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -232,7 +232,7 @@ static int subaru_tx_hook(CANPacket_t *to_send) {
   if (addr == MSG_SUBARU_ES_Distance) {
     int cruise_throttle = (GET_BYTES(to_send, 2, 2) & 0xFFFU);
     bool cruise_cancel = GET_BIT(to_send, 56U) != 0U;
-    
+
     if (subaru_longitudinal) {
       violation |= longitudinal_gas_checks(cruise_throttle, SUBARU_LONG_LIMITS);
     } else {
@@ -256,7 +256,7 @@ static int subaru_tx_hook(CANPacket_t *to_send) {
     // reading ES button data by identifier (b'\x03\x22\x11\x30\x00\x00\x00\x00') is also allowed (DID 0x1130)
     bool is_button_rdbi = (GET_BYTES(to_send, 0, 4) == 0x30112203U) && (GET_BYTES(to_send, 4, 4) == 0x0U);
 
-    violation |= !(is_tester_present || is_button_rdbi);
+    violation |= !(is_tester_present || is_button_rdbi) || !subaru_longitudinal;
   }
 
   if (violation){


### PR DESCRIPTION
We only send tester present on ECU disable when openpilot longitudinal control is enabled. This PR enforces that tester present TX is only allowed when the openpilot longitudinal control flag is set.
- Honda Bosch
- Hyundai CAN
- Hyundai CAN-FD
- Subaru (Global)