### PR TITLE
Hyundai CAN: fix driver torque safety scaling

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -75,7 +75,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 
     if (addr == 0x184) {
       int torque_driver_new = ((GET_BYTE(to_push, 6) & 0x7U) << 8) | GET_BYTE(to_push, 7);
-      torque_driver_new = to_signed(torque_driver_new, 11);
+      torque_driver_new = to_signed(torque_driver_new, 11) * 0.79;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -75,7 +75,7 @@ static int gm_rx_hook(CANPacket_t *to_push) {
 
     if (addr == 0x184) {
       int torque_driver_new = ((GET_BYTE(to_push, 6) & 0x7U) << 8) | GET_BYTE(to_push, 7);
-      torque_driver_new = to_signed(torque_driver_new, 11) * 0.79;
+      torque_driver_new = to_signed(torque_driver_new, 11);
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,7 +178,8 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
+      int torque_driver_new = ((GET_BYTES(to_push, 0, 2) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
+//      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,8 +178,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = ((GET_BYTES(to_push, 0, 2) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
-//      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
+      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,8 +178,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-//      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
-      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
+      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,7 +178,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
+      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,7 +178,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024;
+      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,7 +178,8 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
+//      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
+      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -540,15 +540,21 @@ class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   def test_non_realtime_limit_down(self):
     self.safety.set_controls_allowed(True)
 
-    torque_meas = self.MAX_TORQUE - self.MAX_TORQUE_ERROR - 50
+    torque_meas = self.MAX_TORQUE - self.MAX_TORQUE_ERROR
+
+    # TODO: right now, only thing that catches `torque_meas_new = to_signed(torque_meas_new, 16) * 0.79;` for toyota
+    # is the measurement test. we should also test:
+    # test right at threshold, no need to wind down
+    # test winddown
+    # test slightly above windown limit
 
     self.safety.set_rt_torque_last(self.MAX_TORQUE)
     self.safety.set_torque_meas(torque_meas, torque_meas)
     self.safety.set_desired_torque_last(self.MAX_TORQUE)
-    self.assertTrue(self._tx(self._torque_cmd_msg(self.MAX_TORQUE - self.MAX_RATE_DOWN)))
+    self.assertTrue(self._tx(self._torque_cmd_msg(self.MAX_TORQUE)))
 
     self.safety.set_rt_torque_last(self.MAX_TORQUE)
-    self.safety.set_torque_meas(torque_meas, torque_meas)
+    self.safety.set_torque_meas(torque_meas - 50, torque_meas - 50)
     self.safety.set_desired_torque_last(self.MAX_TORQUE)
     self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_TORQUE - self.MAX_RATE_DOWN + 1)))
 
@@ -587,6 +593,7 @@ class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
   def test_torque_measurements(self):
+    return
     trq = 50
     for t in [trq, -trq, 0, 0, 0, 0]:
       self._rx(self._torque_meas_msg(t))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -556,21 +556,15 @@ class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   def test_non_realtime_limit_down(self):
     self.safety.set_controls_allowed(True)
 
-    torque_meas = self.MAX_TORQUE - self.MAX_TORQUE_ERROR
-
-    # TODO: right now, only thing that catches `torque_meas_new = to_signed(torque_meas_new, 16) * 0.79;` for toyota
-    # is the measurement test. we should also test:
-    # test right at threshold, no need to wind down
-    # test winddown
-    # test slightly above windown limit
+    torque_meas = self.MAX_TORQUE - self.MAX_TORQUE_ERROR - 50
 
     self.safety.set_rt_torque_last(self.MAX_TORQUE)
     self.safety.set_torque_meas(torque_meas, torque_meas)
     self.safety.set_desired_torque_last(self.MAX_TORQUE)
-    self.assertTrue(self._tx(self._torque_cmd_msg(self.MAX_TORQUE)))
+    self.assertTrue(self._tx(self._torque_cmd_msg(self.MAX_TORQUE - self.MAX_RATE_DOWN)))
 
     self.safety.set_rt_torque_last(self.MAX_TORQUE)
-    self.safety.set_torque_meas(torque_meas - 50, torque_meas - 50)
+    self.safety.set_torque_meas(torque_meas, torque_meas)
     self.safety.set_desired_torque_last(self.MAX_TORQUE)
     self.assertFalse(self._tx(self._torque_cmd_msg(self.MAX_TORQUE - self.MAX_RATE_DOWN + 1)))
 
@@ -609,7 +603,6 @@ class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
   def test_torque_measurements(self):
-    return
     trq = 50
     for t in [trq, -trq, 0, 0, 0, 0]:
       self._rx(self._torque_meas_msg(t))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -513,7 +513,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
   def test_driver_torque_measurements(self):
-    # Ensure driver torque is parsed properly
+    # Ensure driver torque is parsed properly and that sample_t is reset on safety mode init
     self._common_measurement_test(self._torque_driver_msg, -self.MAX_TORQUE, self.MAX_TORQUE, 1,
                                   self.safety.get_torque_driver_min, self.safety.get_torque_driver_max,
                                   increment=1)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -463,13 +463,12 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     # Tests down limits and driver torque blending
     self.safety.set_controls_allowed(True)
 
+    # Must wind down if above DRIVER_TORQUE_ALLOWANCE
     for sign in [-1, 1]:
-      for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
-        t *= -sign
-        self.safety.set_torque_driver(t, t)
-        # self._reset_torque_driver_measurement(t)
+      for driver_torque in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
+        self._reset_torque_driver_measurement(-driver_torque * sign)
         self._set_prev_torque(self.MAX_TORQUE * sign)
-        should_tx = abs(t) <= self.DRIVER_TORQUE_ALLOWANCE
+        should_tx = abs(driver_torque) <= self.DRIVER_TORQUE_ALLOWANCE
         self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))
 
     # arbitrary high driver torque to ensure max steer torque is allowed
@@ -477,29 +476,26 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
 
     # spot check some individual cases
     for sign in [-1, 1]:
+      # Ensure we wind down factor units for every unit above allowance
       driver_torque = (self.DRIVER_TORQUE_ALLOWANCE + 10) * sign
       torque_desired = (self.MAX_TORQUE - 10 * self.DRIVER_TORQUE_FACTOR) * sign
       delta = 1 * sign
       self._set_prev_torque(torque_desired)
-      self.safety.set_torque_driver(-driver_torque, -driver_torque)
-      # self._reset_torque_driver_measurement(-driver_torque)
+      self._reset_torque_driver_measurement(-driver_torque)
       self.assertTrue(self._tx(self._torque_cmd_msg(torque_desired)))
       self._set_prev_torque(torque_desired + delta)
-      self.safety.set_torque_driver(-driver_torque, -driver_torque)
-      # self._reset_torque_driver_measurement(-driver_torque)
+      self._reset_torque_driver_measurement(-driver_torque)
       self.assertFalse(self._tx(self._torque_cmd_msg(torque_desired + delta)))
 
+      # If we're well past the allowance, minimum wind down is MAX_RATE_DOWN
       self._set_prev_torque(self.MAX_TORQUE * sign)
-      self.safety.set_torque_driver(-max_driver_torque * sign, -max_driver_torque * sign)
-      # self._reset_torque_driver_measurement(-max_driver_torque * sign)
+      self._reset_torque_driver_measurement(-max_driver_torque * sign)
       self.assertTrue(self._tx(self._torque_cmd_msg((self.MAX_TORQUE - self.MAX_RATE_DOWN) * sign)))
       self._set_prev_torque(self.MAX_TORQUE * sign)
-      self.safety.set_torque_driver(-max_driver_torque * sign, -max_driver_torque * sign)
-      # self._reset_torque_driver_measurement(-max_driver_torque * sign)
+      self._reset_torque_driver_measurement(-max_driver_torque * sign)
       self.assertTrue(self._tx(self._torque_cmd_msg(0)))
       self._set_prev_torque(self.MAX_TORQUE * sign)
-      self.safety.set_torque_driver(-max_driver_torque * sign, -max_driver_torque * sign)
-      # self._reset_torque_driver_measurement(-max_driver_torque * sign)
+      self._reset_torque_driver_measurement(-max_driver_torque * sign)
       self.assertFalse(self._tx(self._torque_cmd_msg((self.MAX_TORQUE - self.MAX_RATE_DOWN + 1) * sign)))
 
   def test_realtime_limits(self):

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -429,6 +429,29 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_torque_driver(0, 0)
     super().test_non_realtime_limit_up()
 
+  def test_non_realtime_limit_down(self):
+    self.safety.set_controls_allowed(True)
+
+    torque_driver = self.DRIVER_TORQUE_ALLOWANCE# * self.DRIVER_TORQUE_FACTOR
+    torque_driver_above_limit = self.MAX_TORQUE - self.DRIVER_TORQUE_ALLOWANCE * self.DRIVER_TORQUE_FACTOR * 2
+
+    cases = (
+      (True, 0, self.MAX_TORQUE),
+      (True, -torque_driver, self.MAX_TORQUE),
+      (False, -(torque_driver + 1), self.MAX_TORQUE),
+      # (False, torque_driver_above_limit, self.MAX_TORQUE - self.MAX_RATE_DOWN + 1),
+    )
+
+    for should_tx, torque_driver, torque_desired in cases:
+      with self.subTest(should_tx=should_tx, torque_driver=torque_driver, torque_desired=torque_desired):
+        self.safety.set_controls_allowed(True)
+        self._set_prev_torque(self.MAX_TORQUE)
+        for _ in range(MAX_SAMPLE_VALS):
+          self._rx(self._torque_driver_msg(torque_driver))
+        # self.safety.set_torque_driver(torque_driver, torque_driver)
+        self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(torque_desired)))
+
+
   def test_against_torque_driver(self):
     # Tests down limits and driver torque blending
     self.safety.set_controls_allowed(True)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -108,12 +108,8 @@ class PandaSafetyTestBase(unittest.TestCase):
     incremented_val = increment * (MAX_SAMPLE_VALS - 1)
 
     for val in np.arange(min_value, max_value, incremented_val):
-      print(val)
       for i in range(MAX_SAMPLE_VALS):
-        print('rx', val + i * increment)
         self.assertTrue(self._rx(msg_func(val + i * increment)))
-      print(meas_min_func(), meas_max_func())
-      print()
 
       # assert close by one decimal place if float
       self.assertAlmostEqual(meas_min_func() / factor, val, delta=0.1)
@@ -455,22 +451,6 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_torque_driver(0, 0)
     super().test_non_realtime_limit_up()
 
-  # def test_driver_torque_measurements(self):
-  #   trq = 50
-  #   for t in [trq, -trq, 0, 0, 0, 0]:
-  #     self._rx(self._torque_driver_msg(t / self.DRIVER_TORQUE_TO_CAN))
-  #
-  #   self.assertEqual(self.safety.get_torque_driver_min(), -trq)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), trq)
-  #
-  #   self._rx(self._torque_driver_msg(0))
-  #   self.assertEqual(self.safety.get_torque_driver_min(), -trq)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
-  #
-  #   self._rx(self._torque_driver_msg(0))
-  #   self.assertEqual(self.safety.get_torque_driver_min(), 0)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
-
   def test_against_torque_driver(self):
     # Tests down limits and driver torque blending
     self.safety.set_controls_allowed(True)
@@ -532,24 +512,11 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA - 1))))
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
-  def test_reset_driver_torque_measurements2(self):
+  def test_driver_torque_measurements(self):
     # Ensure driver torque is parsed properly
-    self._common_measurement_test(self._torque_driver_msg, -self.MAX_TORQUE, self.MAX_TORQUE,
-                                  1,#self.DRIVER_TORQUE_TO_CAN,
+    self._common_measurement_test(self._torque_driver_msg, -self.MAX_TORQUE, self.MAX_TORQUE, 1,
                                   self.safety.get_torque_driver_min, self.safety.get_torque_driver_max,
                                   increment=1)
-
-  # def test_reset_driver_torque_measurements(self):
-  #   # Tests that the driver torque measurement sample_t is reset on safety mode init
-  #   for t in np.linspace(-self.MAX_TORQUE, self.MAX_TORQUE, MAX_SAMPLE_VALS):
-  #     self.assertTrue(self._rx(self._torque_driver_msg(t)))
-  #
-  #   self.assertNotEqual(self.safety.get_torque_driver_min(), 0)
-  #   self.assertNotEqual(self.safety.get_torque_driver_max(), 0)
-  #
-  #   self._reset_safety_hooks()
-  #   self.assertEqual(self.safety.get_torque_driver_min(), 0)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
 
 
 class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -453,7 +453,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     # Tests down limits and driver torque blending
     self.safety.set_controls_allowed(True)
 
-    # Must wind down if above DRIVER_TORQUE_ALLOWANCE
+    # Cannot stay at MAX_TORQUE if above DRIVER_TORQUE_ALLOWANCE
     for sign in [-1, 1]:
       for driver_torque in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
         self._reset_torque_driver_measurement(-driver_torque * sign)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -446,7 +446,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self._rx(self._torque_driver_msg(torque))
 
   def test_non_realtime_limit_up(self):
-    self.safety.set_torque_driver(0, 0)
+    self._reset_torque_driver_measurement(0)
     super().test_non_realtime_limit_up()
 
   def test_against_torque_driver(self):
@@ -494,7 +494,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     for sign in [-1, 1]:
       self.safety.init_tests()
       self._set_prev_torque(0)
-      self.safety.set_torque_driver(0, 0)
+      self._reset_torque_driver_measurement(0)
       for t in np.arange(0, self.MAX_RT_DELTA, 1):
         t *= sign
         self.assertTrue(self._tx(self._torque_cmd_msg(t)))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -451,21 +451,21 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_torque_driver(0, 0)
     super().test_non_realtime_limit_up()
 
-  def test_driver_torque_measurements(self):
-    trq = 50
-    for t in [trq, -trq, 0, 0, 0, 0]:
-      self._rx(self._torque_driver_msg(t / self.DRIVER_TORQUE_TO_CAN))
-
-    self.assertEqual(self.safety.get_torque_driver_min(), -trq)
-    self.assertEqual(self.safety.get_torque_driver_max(), trq)
-
-    self._rx(self._torque_driver_msg(0))
-    self.assertEqual(self.safety.get_torque_driver_min(), -trq)
-    self.assertEqual(self.safety.get_torque_driver_max(), 0)
-
-    self._rx(self._torque_driver_msg(0))
-    self.assertEqual(self.safety.get_torque_driver_min(), 0)
-    self.assertEqual(self.safety.get_torque_driver_max(), 0)
+  # def test_driver_torque_measurements(self):
+  #   trq = 50
+  #   for t in [trq, -trq, 0, 0, 0, 0]:
+  #     self._rx(self._torque_driver_msg(t / self.DRIVER_TORQUE_TO_CAN))
+  #
+  #   self.assertEqual(self.safety.get_torque_driver_min(), -trq)
+  #   self.assertEqual(self.safety.get_torque_driver_max(), trq)
+  #
+  #   self._rx(self._torque_driver_msg(0))
+  #   self.assertEqual(self.safety.get_torque_driver_min(), -trq)
+  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
+  #
+  #   self._rx(self._torque_driver_msg(0))
+  #   self.assertEqual(self.safety.get_torque_driver_min(), 0)
+  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
 
   def test_against_torque_driver(self):
     # Tests down limits and driver torque blending
@@ -528,17 +528,23 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA - 1))))
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
-  def test_reset_driver_torque_measurements(self):
-    # Tests that the driver torque measurement sample_t is reset on safety mode init
-    for t in np.linspace(-self.MAX_TORQUE, self.MAX_TORQUE, MAX_SAMPLE_VALS):
-      self.assertTrue(self._rx(self._torque_driver_msg(t)))
+  def test_reset_driver_torque_measurements2(self):
+    # Ensure driver torque is parsed properly
+    self._common_measurement_test(self._torque_driver_msg, -self.MAX_TORQUE / 100, self.MAX_TORQUE / 100, 1,
+                                  self.safety.get_torque_driver_min, self.safety.get_torque_driver_max,
+                                  increment=1)
 
-    self.assertNotEqual(self.safety.get_torque_driver_min(), 0)
-    self.assertNotEqual(self.safety.get_torque_driver_max(), 0)
-
-    self._reset_safety_hooks()
-    self.assertEqual(self.safety.get_torque_driver_min(), 0)
-    self.assertEqual(self.safety.get_torque_driver_max(), 0)
+  # def test_reset_driver_torque_measurements(self):
+  #   # Tests that the driver torque measurement sample_t is reset on safety mode init
+  #   for t in np.linspace(-self.MAX_TORQUE, self.MAX_TORQUE, MAX_SAMPLE_VALS):
+  #     self.assertTrue(self._rx(self._torque_driver_msg(t)))
+  #
+  #   self.assertNotEqual(self.safety.get_torque_driver_min(), 0)
+  #   self.assertNotEqual(self.safety.get_torque_driver_max(), 0)
+  #
+  #   self._reset_safety_hooks()
+  #   self.assertEqual(self.safety.get_torque_driver_min(), 0)
+  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
 
 
 class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -102,8 +102,6 @@ class PandaSafetyTestBase(unittest.TestCase):
   def _common_measurement_test(self, msg_func: Callable, min_value: float, max_value: float, factor: int,
                                meas_min_func: Callable[[], int], meas_max_func: Callable[[], int]):
     """Tests accurate measurement parsing, and that the struct is reset on safety mode init"""
-
-    # Support testing float and int measurement structs using increment argument
     for val in np.arange(min_value, max_value, 0.5):
       for i in range(MAX_SAMPLE_VALS):
         self.assertTrue(self._rx(msg_func(val + i * 0.1)))
@@ -681,12 +679,10 @@ class AngleSteeringSafetyTest(PandaSafetyTestBase):
       self._rx(self._speed_msg(speed))
 
   def test_vehicle_speed_measurements(self):
-    self._common_measurement_test(self._speed_msg, 0, 80, VEHICLE_SPEED_FACTOR,
-                                  self.safety.get_vehicle_speed_min, self.safety.get_vehicle_speed_max, increment=0.1)
+    self._common_measurement_test(self._speed_msg, 0, 80, VEHICLE_SPEED_FACTOR, self.safety.get_vehicle_speed_min, self.safety.get_vehicle_speed_max)
 
   def test_steering_angle_measurements(self):
-    self._common_measurement_test(self._angle_meas_msg, -180, 180, self.DEG_TO_CAN,
-                                  self.safety.get_angle_meas_min, self.safety.get_angle_meas_max, increment=0.1)
+    self._common_measurement_test(self._angle_meas_msg, -180, 180, self.DEG_TO_CAN, self.safety.get_angle_meas_min, self.safety.get_angle_meas_max)
 
   def test_angle_cmd_when_enabled(self):
     # when controls are allowed, angle cmd rate limit is enforced

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -414,6 +414,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
 
   DRIVER_TORQUE_ALLOWANCE = 0
   DRIVER_TORQUE_FACTOR = 0
+  DRIVER_TORQUE_TO_CAN = 1
 
   @classmethod
   def setUpClass(cls):
@@ -432,7 +433,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   def test_driver_torque_measurements(self):
     trq = 50
     for t in [trq, -trq, 0, 0, 0, 0]:
-      self._rx(self._torque_driver_msg(t))
+      self._rx(self._torque_driver_msg(t / self.DRIVER_TORQUE_TO_CAN))
 
     self.assertEqual(self.safety.get_torque_driver_min(), -trq)
     self.assertEqual(self.safety.get_torque_driver_max(), trq)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -99,7 +99,7 @@ class PandaSafetyTestBase(unittest.TestCase):
         should_tx = (should_tx or v == inactive_value) and msg_allowed
         self.assertEqual(self._tx(msg_function(v)), should_tx, (controls_allowed, should_tx, v))
 
-  def _common_measurement_test(self, msg_func: Callable[[int | float], ...], min_value: float, max_value: float,
+  def _common_measurement_test(self, msg_func: MessageFunction, min_value: float, max_value: float,
                                factor: int, meas_min_func: Callable[[], int], meas_max_func: Callable[[], int],
                                increment: float = 1):
     """Tests accurate measurement parsing, and that the struct is reset on safety mode init"""

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -451,21 +451,21 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_torque_driver(0, 0)
     super().test_non_realtime_limit_up()
 
-  # def test_driver_torque_measurements(self):
-  #   trq = 50
-  #   for t in [trq, -trq, 0, 0, 0, 0]:
-  #     self._rx(self._torque_driver_msg(t / self.DRIVER_TORQUE_TO_CAN))
-  #
-  #   self.assertEqual(self.safety.get_torque_driver_min(), -trq)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), trq)
-  #
-  #   self._rx(self._torque_driver_msg(0))
-  #   self.assertEqual(self.safety.get_torque_driver_min(), -trq)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
-  #
-  #   self._rx(self._torque_driver_msg(0))
-  #   self.assertEqual(self.safety.get_torque_driver_min(), 0)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
+  def test_driver_torque_measurements(self):
+    trq = 50
+    for t in [trq, -trq, 0, 0, 0, 0]:
+      self._rx(self._torque_driver_msg(t / self.DRIVER_TORQUE_TO_CAN))
+
+    self.assertEqual(self.safety.get_torque_driver_min(), -trq)
+    self.assertEqual(self.safety.get_torque_driver_max(), trq)
+
+    self._rx(self._torque_driver_msg(0))
+    self.assertEqual(self.safety.get_torque_driver_min(), -trq)
+    self.assertEqual(self.safety.get_torque_driver_max(), 0)
+
+    self._rx(self._torque_driver_msg(0))
+    self.assertEqual(self.safety.get_torque_driver_min(), 0)
+    self.assertEqual(self.safety.get_torque_driver_max(), 0)
 
   def test_against_torque_driver(self):
     # Tests down limits and driver torque blending
@@ -528,23 +528,17 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA - 1))))
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
-  def test_reset_driver_torque_measurements2(self):
-    # Ensure driver torque is parsed properly
-    self._common_measurement_test(self._torque_driver_msg, -self.MAX_TORQUE / 100, self.MAX_TORQUE / 100, 1,
-                                  self.safety.get_torque_driver_min, self.safety.get_torque_driver_max,
-                                  increment=1)
+  def test_reset_driver_torque_measurements(self):
+    # Tests that the driver torque measurement sample_t is reset on safety mode init
+    for t in np.linspace(-self.MAX_TORQUE, self.MAX_TORQUE, MAX_SAMPLE_VALS):
+      self.assertTrue(self._rx(self._torque_driver_msg(t)))
 
-  # def test_reset_driver_torque_measurements(self):
-  #   # Tests that the driver torque measurement sample_t is reset on safety mode init
-  #   for t in np.linspace(-self.MAX_TORQUE, self.MAX_TORQUE, MAX_SAMPLE_VALS):
-  #     self.assertTrue(self._rx(self._torque_driver_msg(t)))
-  #
-  #   self.assertNotEqual(self.safety.get_torque_driver_min(), 0)
-  #   self.assertNotEqual(self.safety.get_torque_driver_max(), 0)
-  #
-  #   self._reset_safety_hooks()
-  #   self.assertEqual(self.safety.get_torque_driver_min(), 0)
-  #   self.assertEqual(self.safety.get_torque_driver_max(), 0)
+    self.assertNotEqual(self.safety.get_torque_driver_min(), 0)
+    self.assertNotEqual(self.safety.get_torque_driver_max(), 0)
+
+    self._reset_safety_hooks()
+    self.assertEqual(self.safety.get_torque_driver_min(), 0)
+    self.assertEqual(self.safety.get_torque_driver_max(), 0)
 
 
 class MotorTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -82,6 +82,7 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
   RT_INTERVAL = 250000
   DRIVER_TORQUE_ALLOWANCE = 65
   DRIVER_TORQUE_FACTOR = 4
+  DRIVER_TORQUE_TO_CAN = 100
 
   PCM_CRUISE = True  # openpilot is tied to the PCM state if not longitudinal
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -128,7 +128,8 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
     return self.packer.make_can_msg_panda("AcceleratorPedal2", 0, values)
 
   def _torque_driver_msg(self, torque):
-    values = {"LKADriverAppldTrq": torque}
+    # Safety assumes driver torque is an int
+    values = {"LKADriverAppldTrq": torque / self.DRIVER_TORQUE_TO_CAN}
     return self.packer.make_can_msg_panda("PSCMStatus", 0, values)
 
   def _torque_cmd_msg(self, torque, steer_req=1):

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -82,7 +82,6 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
   RT_INTERVAL = 250000
   DRIVER_TORQUE_ALLOWANCE = 65
   DRIVER_TORQUE_FACTOR = 4
-  DRIVER_TORQUE_TO_CAN = 100
 
   PCM_CRUISE = True  # openpilot is tied to the PCM state if not longitudinal
 
@@ -128,8 +127,8 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
     return self.packer.make_can_msg_panda("AcceleratorPedal2", 0, values)
 
   def _torque_driver_msg(self, torque):
-    # Safety assumes driver torque is an int
-    values = {"LKADriverAppldTrq": torque / self.DRIVER_TORQUE_TO_CAN}
+    # Safety assumes driver torque is an int, use DBC factor
+    values = {"LKADriverAppldTrq": torque * 0.01}
     return self.packer.make_can_msg_panda("PSCMStatus", 0, values)
 
   def _torque_cmd_msg(self, torque, steer_req=1):

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -127,7 +127,7 @@ class TestGmSafetyBase(common.PandaSafetyTest, common.DriverTorqueSteeringSafety
     return self.packer.make_can_msg_panda("AcceleratorPedal2", 0, values)
 
   def _torque_driver_msg(self, torque):
-    # Safety assumes driver torque is an int, use DBC factor
+    # Safety tests assume driver torque is an int, use DBC factor
     values = {"LKADriverAppldTrq": torque * 0.01}
     return self.packer.make_can_msg_panda("PSCMStatus", 0, values)
 

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -103,7 +103,6 @@ class TestHyundaiSafety(HyundaiButtonBase, common.PandaSafetyTest, common.Driver
     self.__class__.cnt_cruise += 1
     return self.packer.make_can_msg_panda("SCC12", self.SCC_BUS, values, fix_checksum=checksum)
 
-  # TODO: this is unused
   def _torque_driver_msg(self, torque):
     values = {"CR_Mdps_StrColTq": torque}
     return self.packer.make_can_msg_panda("MDPS12", 0, values)


### PR DESCRIPTION
Changed in https://github.com/commaai/panda/pull/503 without changing any of the tests or OP. Panda safety was allowing 1.26x more driver torque than desired before it asserted winddown.

A bug like this is caught with meas/EPS torque safety because of the measurement test we have, we just didn't have one for driver torque safety.

---

Now we RX real driver torque messages and run the existing override tests on that, which is a more complete end to end test to catch this (similar to angle test with current angle and vehicle speed)