### PR TITLE
safety tests: fix driver torque override test

### DIFF
--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,8 +178,7 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
-//      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
+      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/board/safety/safety_hyundai.h
+++ b/board/safety/safety_hyundai.h
@@ -178,7 +178,8 @@ static int hyundai_rx_hook(CANPacket_t *to_push) {
 
   if (valid && (bus == 0)) {
     if (addr == 0x251) {
-      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
+      int torque_driver_new = (GET_BYTES(to_push, 0, 2) & 0x7ffU) - 1024U;
+//      int torque_driver_new = ((GET_BYTES(to_push, 0, 4) & 0x7ffU) * 0.79) - 808; // scale down new driver torque signal to match previous one
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
     }

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -441,6 +441,10 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   def _torque_driver_msg(self, torque):
     pass
 
+  def _reset_torque_driver_measurement(self, torque):
+    for _ in range(MAX_SAMPLE_VALS):
+      self._rx(self._torque_driver_msg(torque))
+
   def test_non_realtime_limit_up(self):
     self.safety.set_torque_driver(0, 0)
     super().test_non_realtime_limit_up()
@@ -452,7 +456,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     for sign in [-1, 1]:
       for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
         t *= -sign
-        self.safety.set_torque_driver(t, t)
+        self._reset_torque_driver_measurement(t)
         self._set_prev_torque(self.MAX_TORQUE * sign)
         should_tx = abs(t) <= self.DRIVER_TORQUE_ALLOWANCE
         self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -441,10 +441,6 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
   def _torque_driver_msg(self, torque):
     pass
 
-  def _reset_torque_driver_measurement(self, torque):
-    for _ in range(MAX_SAMPLE_VALS):
-      self._rx(self._torque_driver_msg(torque))
-
   def test_non_realtime_limit_up(self):
     self.safety.set_torque_driver(0, 0)
     super().test_non_realtime_limit_up()
@@ -456,7 +452,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     for sign in [-1, 1]:
       for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
         t *= -sign
-        self._reset_torque_driver_measurement(t)
+        self.safety.set_torque_driver(t, t)
         self._set_prev_torque(self.MAX_TORQUE * sign)
         should_tx = abs(t) <= self.DRIVER_TORQUE_ALLOWANCE
         self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -450,14 +450,12 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_controls_allowed(True)
 
     for sign in [-1, 1]:
-      for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE + 1, 1):
+      for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
         t *= -sign
         self.safety.set_torque_driver(t, t)
         self._set_prev_torque(self.MAX_TORQUE * sign)
-        self.assertTrue(self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))
-
-      self.safety.set_torque_driver(self.DRIVER_TORQUE_ALLOWANCE + 1, self.DRIVER_TORQUE_ALLOWANCE + 1)
-      self.assertFalse(self._tx(self._torque_cmd_msg(-self.MAX_TORQUE)))
+        should_tx = abs(t) <= self.DRIVER_TORQUE_ALLOWANCE
+        self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))
 
     # arbitrary high driver torque to ensure max steer torque is allowed
     max_driver_torque = int(self.MAX_TORQUE / self.DRIVER_TORQUE_FACTOR + self.DRIVER_TORQUE_ALLOWANCE + 1)

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -450,11 +450,11 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_controls_allowed(True)
 
     for sign in [-1, 1]:
-      for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
-        t *= -sign
-        self.safety.set_torque_driver(t, t)
+      for driver_torque in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
+        driver_torque *= -sign
+        self.safety.set_torque_driver(driver_torque * sign, driver_torque * sign)
         self._set_prev_torque(self.MAX_TORQUE * sign)
-        should_tx = abs(t) <= self.DRIVER_TORQUE_ALLOWANCE
+        should_tx = abs(driver_torque) <= self.DRIVER_TORQUE_ALLOWANCE
         self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))
 
     # arbitrary high driver torque to ensure max steer torque is allowed

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -450,11 +450,11 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
     self.safety.set_controls_allowed(True)
 
     for sign in [-1, 1]:
-      for driver_torque in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
-        driver_torque *= -sign
-        self.safety.set_torque_driver(driver_torque * sign, driver_torque * sign)
+      for t in np.arange(0, self.DRIVER_TORQUE_ALLOWANCE * 2, 1):
+        t *= -sign
+        self.safety.set_torque_driver(t, t)
         self._set_prev_torque(self.MAX_TORQUE * sign)
-        should_tx = abs(driver_torque) <= self.DRIVER_TORQUE_ALLOWANCE
+        should_tx = abs(t) <= self.DRIVER_TORQUE_ALLOWANCE
         self.assertEqual(should_tx, self._tx(self._torque_cmd_msg(self.MAX_TORQUE * sign)))
 
     # arbitrary high driver torque to ensure max steer torque is allowed


### PR DESCRIPTION
Noticed in https://github.com/commaai/panda/pull/1695

This asserts that above the driver torque allowance, torque command messages are blocked. However here, they were blocked due to the sign of the torque command flipping when `sign` is `1` (when `sign` is `-1`, everything was tested properly), since `self.assertFalse(self._tx(self._torque_cmd_msg(-self.MAX_TORQUE)))` doesn't multiply by `sign`

Now we test 2x the range