### PR TITLE
safety test: fix incorrect error message

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -1007,7 +1007,7 @@ class PandaSafetyTest(PandaSafetyTestBase):
             if attr.startswith('TestHonda'):
               # exceptions for common msgs across different hondas
               tx = list(filter(lambda m: m[0] not in [0x1FA, 0x30C, 0x33D], tx))
-            all_tx.append([m[0], m[1], attr] for m in tx)
+            all_tx.append([[m[0], m[1], attr] for m in tx])
 
     # make sure we got all the msgs
     self.assertTrue(len(all_tx) >= len(test_files)-1)


### PR DESCRIPTION
Fix regression from https://github.com/commaai/panda/pull/1579

Attr is always the last attr we loop through, which happens to be `unittest` due to adding generators and not evaluating the values.

Example:

```python
AssertionError: 1 is not false : transmit of addr=0x2e6 bus=0 from unittest during TestToyotaStockLongitudinalTorque was allowed
```

Fixed:

```python
AssertionError: 1 is not false : transmit of addr=0x2e6 bus=0 from TestToyotaAltBrakeSafety during TestToyotaStockLongitudinalTorque was allowed
```