### PR TITLE
safety tests: clean up state reset

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -377,7 +377,6 @@ static int honda_tx_hook(CANPacket_t *to_send) {
 }
 
 static const addr_checks* honda_nidec_init(uint16_t param) {
-  gas_interceptor_detected = 0;
   honda_hw = HONDA_NIDEC;
   honda_alt_brake_msg = false;
   honda_bosch_long = false;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -378,6 +378,8 @@ static int honda_tx_hook(CANPacket_t *to_send) {
 
 static const addr_checks* honda_nidec_init(uint16_t param) {
   honda_hw = HONDA_NIDEC;
+  honda_brake = 0;
+  honda_fwd_brake = false;
   honda_alt_brake_msg = false;
   honda_bosch_long = false;
   honda_bosch_radarless = false;

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -226,6 +226,8 @@ static const addr_checks* tesla_init(uint16_t param) {
   tesla_powertrain = GET_FLAG(param, TESLA_FLAG_POWERTRAIN);
   tesla_longitudinal = GET_FLAG(param, TESLA_FLAG_LONGITUDINAL_CONTROL);
 
+  tesla_stock_aeb = false;
+
   return tesla_powertrain ? (&tesla_pt_rx_checks) : (&tesla_rx_checks);
 }
 

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -222,7 +222,6 @@ static int toyota_tx_hook(CANPacket_t *to_send) {
 }
 
 static const addr_checks* toyota_init(uint16_t param) {
-  gas_interceptor_detected = 0;
   toyota_alt_brake = GET_FLAG(param, TOYOTA_PARAM_ALT_BRAKE);
   toyota_stock_longitudinal = GET_FLAG(param, TOYOTA_PARAM_STOCK_LONGITUDINAL);
   toyota_dbc_eps_torque_factor = param & TOYOTA_EPS_FACTOR;

--- a/tests/libpanda/safety_helpers.h
+++ b/tests/libpanda/safety_helpers.h
@@ -187,10 +187,6 @@ void init_tests(void){
   ts_steer_req_mismatch_last = 0;
   valid_steer_req_count = 0;
   invalid_steer_req_count = 0;
-
-  // car-specific stuff
-  honda_fwd_brake = false;
-  tesla_stock_aeb = false;
 }
 
 void set_gmlan_digital_output(int to_set){


### PR DESCRIPTION
`gas_interceptor_detected` is already cleaned up by the main safety hook init function

Honda had its own safety test init function which was refactored out, leaving just this behind: https://github.com/commaai/panda/commit/d68356b9246f37a73c91a1b1216c3f4f4ac49896#diff-a8952cdeddfbad7fb89cc950ad6bc4fba0a01dd1609e78d75a576a8c9a1da12c

Tesla added here: https://github.com/commaai/panda/pull/1340