### PR TITLE
safety tests: support multiple relay malfunction addresses

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -274,7 +274,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
     if (ford_longitudinal) {
       stock_ecu_detected = stock_ecu_detected || (addr == FORD_ACCDATA);
     }
-    generic_rx_checks(ford_lkas_msg_check(addr));
+    generic_rx_checks(stock_ecu_detected);
   }
 
   return valid;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -270,6 +270,10 @@ static int ford_rx_hook(CANPacket_t *to_push) {
 
     // If steering controls messages are received on the destination bus, it's an indication
     // that the relay might be malfunctioning.
+    bool stock_ecu_detected = ford_lkas_msg_check(addr);
+    if (ford_longitudinal) {
+      stock_ecu_detected = stock_ecu_detected || (addr == FORD_ACCDATA);
+    }
     generic_rx_checks(ford_lkas_msg_check(addr));
   }
 

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -918,8 +918,6 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # each car has an addr that is used to detect relay malfunction
     # if that addr is seen on specified bus, triggers the relay malfunction
     # protection logic: both tx_hook and fwd_hook are expected to return failure
-
-    # test relay malfunction addresses match between tests and safety
     self.assertFalse(self.safety.get_relay_malfunction())
     for bus in range(3):
       for addr in self.SCANNED_ADDRS:

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -918,18 +918,29 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # each car has an addr that is used to detect relay malfunction
     # if that addr is seen on specified bus, triggers the relay malfunction
     # protection logic: both tx_hook and fwd_hook are expected to return failure
-    if self.RELAY_MALFUNCTION_ADDRS is not None:
+
+    # self.safety.set_relay_malfunction(True)
+    # for bus in range(3):
+    #   for addr in self.SCANNED_ADDRS:
+    #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
+    #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+
+    if self.RELAY_MALFUNCTION_ADDRS is not None or True:
       print(self.__class__.__name__)
-      for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-        for relay_malfunction_addr in relay_malfunction_addrs:
-          self.assertFalse(self.safety.get_relay_malfunction())
-          self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-          self.assertTrue(self.safety.get_relay_malfunction())
-          for bus in range(3):
-            for addr in self.SCANNED_ADDRS:
-              self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-              self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
-          self.safety.set_relay_malfunction(False)
+      # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
+      #   for relay_malfunction_addr in relay_malfunction_addrs:
+      # self.assertFalse(self.safety.get_relay_malfunction())
+      # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
+      # self.assertTrue(self.safety.get_relay_malfunction())
+      for bus in range(3):
+        for addr in self.SCANNED_ADDRS:
+          with self.subTest(bus=bus, addr=addr):
+            self.safety.set_relay_malfunction(False)
+            self._rx(make_msg(bus, addr, 8))
+            should_relay_malfunction = bus in self.RELAY_MALFUNCTION_ADDRS and addr in self.RELAY_MALFUNCTION_ADDRS[bus]
+            self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction())
+            # self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+            # self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
 
     # self.assertFalse(self.safety.get_relay_malfunction())
     # self._rx(make_msg(self.RELAY_MALFUNCTION_BUS, self.RELAY_MALFUNCTION_ADDR, 8))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -922,14 +922,14 @@ class PandaCarSafetyTest(PandaSafetyTest):
         self.safety.set_relay_malfunction(False)
         self._rx(make_msg(bus, addr, 8))
         should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
-        self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction())
+        self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction(), (bus, addr))
 
     # test relay malfunction protection logic
     self.safety.set_relay_malfunction(True)
     for bus in range(3):
       for addr in self.SCANNED_ADDRS:
         self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
-        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr), (bus, addr))
 
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -879,8 +879,6 @@ class PandaSafetyTest(PandaSafetyTestBase):
 class PandaCarSafetyTest(PandaSafetyTest):
   STANDSTILL_THRESHOLD: Optional[float] = None
   GAS_PRESSED_THRESHOLD = 0
-  # RELAY_MALFUNCTION_ADDR: Optional[int] = None
-  # RELAY_MALFUNCTION_BUS: Optional[int] = None
   RELAY_MALFUNCTION_ADDRS: Optional[Dict[int, Tuple[int, ...]]] = None
 
   @classmethod

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -916,20 +916,16 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # each car has an addr that is used to detect relay malfunction
     # if that addr is seen on specified bus, triggers the relay malfunction
     # protection logic: both tx_hook and fwd_hook are expected to return failure
-    self.assertFalse(self.safety.get_relay_malfunction())
-    for bus in range(3):
-      for addr in self.SCANNED_ADDRS:
+    for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
+      for relay_malfunction_addr in relay_malfunction_addrs:
+        self.assertFalse(self.safety.get_relay_malfunction())
+        self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
+        self.assertTrue(self.safety.get_relay_malfunction())
+        for bus in range(3):
+          for addr in self.SCANNED_ADDRS:
+            self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+            self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
         self.safety.set_relay_malfunction(False)
-        self._rx(make_msg(bus, addr, 8))
-        should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
-        self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction(), (bus, addr))
-
-    # test relay malfunction protection logic
-    self.safety.set_relay_malfunction(True)
-    for bus in range(3):
-      for addr in self.SCANNED_ADDRS:
-        self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
-        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr), (bus, addr))
 
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -928,8 +928,8 @@ class PandaCarSafetyTest(PandaSafetyTest):
     self.safety.set_relay_malfunction(True)
     for bus in range(3):
       for addr in self.SCANNED_ADDRS:
-        self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
-        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr), (bus, addr))
+        self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
 
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -916,16 +916,20 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # each car has an addr that is used to detect relay malfunction
     # if that addr is seen on specified bus, triggers the relay malfunction
     # protection logic: both tx_hook and fwd_hook are expected to return failure
-    for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-      for relay_malfunction_addr in relay_malfunction_addrs:
-        self.assertFalse(self.safety.get_relay_malfunction())
-        self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-        self.assertTrue(self.safety.get_relay_malfunction())
-        for bus in range(3):
-          for addr in self.SCANNED_ADDRS:
-            self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-            self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+    self.assertFalse(self.safety.get_relay_malfunction())
+    for bus in range(3):
+      for addr in self.SCANNED_ADDRS:
         self.safety.set_relay_malfunction(False)
+        self._rx(make_msg(bus, addr, 8))
+        should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
+        self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction(), (bus, addr))
+
+    # test relay malfunction protection logic
+    self.safety.set_relay_malfunction(True)
+    for bus in range(3):
+      for addr in self.SCANNED_ADDRS:
+        self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
+        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr), (bus, addr))
 
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -919,34 +919,13 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # if that addr is seen on specified bus, triggers the relay malfunction
     # protection logic: both tx_hook and fwd_hook are expected to return failure
 
-    #
-    # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-    #   for relay_malfunction_addr in relay_malfunction_addrs:
-    #     # self.assertFalse(self.safety.get_relay_malfunction())
-    #     self.safety.set_relay_malfunction(False)
-    #     self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-    #     self.assertTrue(self.safety.get_relay_malfunction())
-    #     for bus in range(3):
-    #       for addr in self.SCANNED_ADDRS:
-    #         self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-    #         self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
-
-    # test relay malfunction addresses are expected
-    print(self.__class__.__name__)
-    # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-    #   for relay_malfunction_addr in relay_malfunction_addrs:
-    # self.assertFalse(self.safety.get_relay_malfunction())
-    # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-    # self.assertTrue(self.safety.get_relay_malfunction())
+    # test relay malfunction addresses match between tests and safety
     for bus in range(3):
       for addr in self.SCANNED_ADDRS:
-        # with self.subTest(bus=bus, addr=addr):
         self.safety.set_relay_malfunction(False)
         self._rx(make_msg(bus, addr, 8))
         should_relay_malfunction = bus in self.RELAY_MALFUNCTION_ADDRS and addr in self.RELAY_MALFUNCTION_ADDRS[bus]
         self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction())
-        # self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-        # self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
 
     # test relay malfunction protection logic
     self.safety.set_relay_malfunction(True)
@@ -954,14 +933,6 @@ class PandaCarSafetyTest(PandaSafetyTest):
       for addr in self.SCANNED_ADDRS:
         self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
         self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
-
-    # # self.assertFalse(self.safety.get_relay_malfunction())
-    # # self._rx(make_msg(self.RELAY_MALFUNCTION_BUS, self.RELAY_MALFUNCTION_ADDR, 8))
-    # # self.assertTrue(self.safety.get_relay_malfunction())
-    # # for bus in range(3):
-    # #   for addr in self.SCANNED_ADDRS:
-    # #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-    # #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
 
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -919,36 +919,49 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # if that addr is seen on specified bus, triggers the relay malfunction
     # protection logic: both tx_hook and fwd_hook are expected to return failure
 
-    # self.safety.set_relay_malfunction(True)
-    # for bus in range(3):
-    #   for addr in self.SCANNED_ADDRS:
-    #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
-    #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+    #
+    # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
+    #   for relay_malfunction_addr in relay_malfunction_addrs:
+    #     # self.assertFalse(self.safety.get_relay_malfunction())
+    #     self.safety.set_relay_malfunction(False)
+    #     self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
+    #     self.assertTrue(self.safety.get_relay_malfunction())
+    #     for bus in range(3):
+    #       for addr in self.SCANNED_ADDRS:
+    #         self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+    #         self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
 
-    if self.RELAY_MALFUNCTION_ADDRS is not None or True:
-      print(self.__class__.__name__)
-      # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-      #   for relay_malfunction_addr in relay_malfunction_addrs:
-      # self.assertFalse(self.safety.get_relay_malfunction())
-      # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-      # self.assertTrue(self.safety.get_relay_malfunction())
-      for bus in range(3):
-        for addr in self.SCANNED_ADDRS:
-          with self.subTest(bus=bus, addr=addr):
-            self.safety.set_relay_malfunction(False)
-            self._rx(make_msg(bus, addr, 8))
-            should_relay_malfunction = bus in self.RELAY_MALFUNCTION_ADDRS and addr in self.RELAY_MALFUNCTION_ADDRS[bus]
-            self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction())
-            # self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-            # self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
-
+    # test relay malfunction addresses are expected
+    print(self.__class__.__name__)
+    # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
+    #   for relay_malfunction_addr in relay_malfunction_addrs:
     # self.assertFalse(self.safety.get_relay_malfunction())
-    # self._rx(make_msg(self.RELAY_MALFUNCTION_BUS, self.RELAY_MALFUNCTION_ADDR, 8))
+    # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
     # self.assertTrue(self.safety.get_relay_malfunction())
-    # for bus in range(3):
-    #   for addr in self.SCANNED_ADDRS:
-    #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-    #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+    for bus in range(3):
+      for addr in self.SCANNED_ADDRS:
+        # with self.subTest(bus=bus, addr=addr):
+        self.safety.set_relay_malfunction(False)
+        self._rx(make_msg(bus, addr, 8))
+        should_relay_malfunction = bus in self.RELAY_MALFUNCTION_ADDRS and addr in self.RELAY_MALFUNCTION_ADDRS[bus]
+        self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction())
+        # self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+        # self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+
+    # test relay malfunction protection logic
+    self.safety.set_relay_malfunction(True)
+    for bus in range(3):
+      for addr in self.SCANNED_ADDRS:
+        self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)), (bus, addr))
+        self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+
+    # # self.assertFalse(self.safety.get_relay_malfunction())
+    # # self._rx(make_msg(self.RELAY_MALFUNCTION_BUS, self.RELAY_MALFUNCTION_ADDR, 8))
+    # # self.assertTrue(self.safety.get_relay_malfunction())
+    # # for bus in range(3):
+    # #   for addr in self.SCANNED_ADDRS:
+    # #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+    # #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
 
   def test_prev_gas(self):
     self.assertFalse(self.safety.get_gas_pressed_prev())

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -920,11 +920,12 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # protection logic: both tx_hook and fwd_hook are expected to return failure
 
     # test relay malfunction addresses match between tests and safety
+    self.assertFalse(self.safety.get_relay_malfunction())
     for bus in range(3):
       for addr in self.SCANNED_ADDRS:
         self.safety.set_relay_malfunction(False)
         self._rx(make_msg(bus, addr, 8))
-        should_relay_malfunction = bus in self.RELAY_MALFUNCTION_ADDRS and addr in self.RELAY_MALFUNCTION_ADDRS[bus]
+        should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
         self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction())
 
     # test relay malfunction protection logic

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -879,9 +879,9 @@ class PandaSafetyTest(PandaSafetyTestBase):
 class PandaCarSafetyTest(PandaSafetyTest):
   STANDSTILL_THRESHOLD: Optional[float] = None
   GAS_PRESSED_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDR: Optional[int] = None
+  # RELAY_MALFUNCTION_ADDR: Optional[int] = None
+  # RELAY_MALFUNCTION_BUS: Optional[int] = None
   RELAY_MALFUNCTION_ADDRS: Optional[Dict[int, Tuple[int, ...]]] = None
-  RELAY_MALFUNCTION_BUS: Optional[int] = None
 
   @classmethod
   def setUpClass(cls):

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -920,38 +920,16 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # protection logic: both tx_hook and fwd_hook are expected to return failure
     if self.RELAY_MALFUNCTION_ADDRS is not None:
       print(self.__class__.__name__)
-      # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-      #   for relay_malfunction_addr in relay_malfunction_addrs:
-      self.assertFalse(self.safety.get_relay_malfunction())
-
-
-      # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-      # self.assertTrue(self.safety.get_relay_malfunction())
-      should_relay_malfunction = False
-      for bus in range(3):
-        for addr in self.SCANNED_ADDRS:
-          print(bus, addr)
-          self._rx(make_msg(bus, addr, 8))
-          # if addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ()):
-          #   should_relay_malfunction = True
-          should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
-          # should_relay_malfunction = bus == relay_malfunction_bus and addr == relay_malfunction_addr
-          self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction(), (bus, addr))
+      for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
+        for relay_malfunction_addr in relay_malfunction_addrs:
+          self.assertFalse(self.safety.get_relay_malfunction())
+          self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
+          self.assertTrue(self.safety.get_relay_malfunction())
+          for bus in range(3):
+            for addr in self.SCANNED_ADDRS:
+              self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+              self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
           self.safety.set_relay_malfunction(False)
-          # if should_relay_malfunction:
-          #   self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-          #   self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
-
-
-          # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-          # self.assertTrue(self.safety.get_relay_malfunction())
-          # for bus in range(3):
-          #   for addr in self.SCANNED_ADDRS:
-          #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-          #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
-
-
-      self.safety.set_relay_malfunction(False)
 
     # self.assertFalse(self.safety.get_relay_malfunction())
     # self._rx(make_msg(self.RELAY_MALFUNCTION_BUS, self.RELAY_MALFUNCTION_ADDR, 8))

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -920,16 +920,38 @@ class PandaCarSafetyTest(PandaSafetyTest):
     # protection logic: both tx_hook and fwd_hook are expected to return failure
     if self.RELAY_MALFUNCTION_ADDRS is not None:
       print(self.__class__.__name__)
-      for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
-        for relay_malfunction_addr in relay_malfunction_addrs:
-          self.assertFalse(self.safety.get_relay_malfunction())
-          self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
-          self.assertTrue(self.safety.get_relay_malfunction())
-          for bus in range(3):
-            for addr in self.SCANNED_ADDRS:
-              self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
-              self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+      # for relay_malfunction_bus, relay_malfunction_addrs in self.RELAY_MALFUNCTION_ADDRS.items():
+      #   for relay_malfunction_addr in relay_malfunction_addrs:
+      self.assertFalse(self.safety.get_relay_malfunction())
+
+
+      # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
+      # self.assertTrue(self.safety.get_relay_malfunction())
+      should_relay_malfunction = False
+      for bus in range(3):
+        for addr in self.SCANNED_ADDRS:
+          print(bus, addr)
+          self._rx(make_msg(bus, addr, 8))
+          # if addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ()):
+          #   should_relay_malfunction = True
+          should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
+          # should_relay_malfunction = bus == relay_malfunction_bus and addr == relay_malfunction_addr
+          self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction(), (bus, addr))
           self.safety.set_relay_malfunction(False)
+          # if should_relay_malfunction:
+          #   self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+          #   self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+
+
+          # self._rx(make_msg(relay_malfunction_bus, relay_malfunction_addr, 8))
+          # self.assertTrue(self.safety.get_relay_malfunction())
+          # for bus in range(3):
+          #   for addr in self.SCANNED_ADDRS:
+          #     self.assertEqual(-1, self._tx(make_msg(bus, addr, 8)))
+          #     self.assertEqual(-1, self.safety.safety_fwd_hook(bus, addr))
+
+
+      self.safety.set_relay_malfunction(False)
 
     # self.assertFalse(self.safety.get_relay_malfunction())
     # self._rx(make_msg(self.RELAY_MALFUNCTION_BUS, self.RELAY_MALFUNCTION_ADDR, 8))

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -9,8 +9,7 @@ from panda.tests.safety.common import CANPackerPanda
 class TestChryslerSafety(common.PandaCarSafetyTest, common.MotorTorqueSteeringSafetyTest):
   TX_MSGS = [[0x23B, 0], [0x292, 0], [0x2A6, 0]]
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDR = 0x292
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x292,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x292, 0x2A6]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -75,7 +75,7 @@ class TestChryslerSafety(common.PandaCarSafetyTest, common.MotorTorqueSteeringSa
 
 class TestChryslerRamDTSafety(TestChryslerSafety):
   TX_MSGS = [[0xB1, 2], [0xA6, 0], [0xFA, 0]]
-  RELAY_MALFUNCTION_ADDR = 0xA6
+  RELAY_MALFUNCTION_ADDRS = {0: (0xA6,)}
   FWD_BLACKLISTED_ADDRS = {2: [0xA6, 0xFA]}
 
   MAX_RATE_UP = 6
@@ -98,7 +98,7 @@ class TestChryslerRamDTSafety(TestChryslerSafety):
 
 class TestChryslerRamHDSafety(TestChryslerSafety):
   TX_MSGS = [[0x275, 0], [0x276, 0], [0x23A, 2]]
-  RELAY_MALFUNCTION_ADDR = 0x276
+  RELAY_MALFUNCTION_ADDRS = {0: (0x276,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x275, 0x276]}
 
   MAX_TORQUE = 361

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -66,8 +66,8 @@ class Buttons:
 
 class TestFordSafetyBase(common.PandaCarSafetyTest):
   STANDSTILL_THRESHOLD = 1
-  RELAY_MALFUNCTION_ADDR = MSG_IPMA_Data
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (MSG_ACCDATA_3, MSG_Lane_Assist_Data1, MSG_LateralMotionControl,
+                                 MSG_LateralMotionControl2, MSG_IPMA_Data)}
 
   FWD_BLACKLISTED_ADDRS = {2: [MSG_ACCDATA_3, MSG_Lane_Assist_Data1, MSG_LateralMotionControl,
                                MSG_LateralMotionControl2, MSG_IPMA_Data]}
@@ -385,6 +385,9 @@ class TestFordCANFDStockSafety(TestFordSafetyBase):
 
 
 class TestFordLongitudinalSafetyBase(TestFordSafetyBase):
+  RELAY_MALFUNCTION_ADDRS = {0: (MSG_ACCDATA, MSG_ACCDATA_3, MSG_Lane_Assist_Data1, MSG_LateralMotionControl,
+                                 MSG_LateralMotionControl2, MSG_IPMA_Data)}
+
   FWD_BLACKLISTED_ADDRS = {2: [MSG_ACCDATA, MSG_ACCDATA_3, MSG_Lane_Assist_Data1, MSG_LateralMotionControl,
                                MSG_LateralMotionControl2, MSG_IPMA_Data]}
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -17,7 +17,7 @@ class Buttons:
 class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeSafetyTest):
   # pylint: disable=no-member,abstract-method
 
-  RELAY_MALFUNCTION_ADDRS = {0: (0x180, 0x2CB)}  # ASCMLKASteeringCmd,ASCMGasRegenCmd
+  RELAY_MALFUNCTION_ADDRS = {0: (0x180, 0x2CB)}  # ASCMLKASteeringCmd, ASCMGasRegenCmd
 
   MAX_POSSIBLE_BRAKE = 2 ** 12
   MAX_BRAKE = 400
@@ -72,8 +72,6 @@ class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeS
 
 class TestGmSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 10 * 0.0311
-  # RELAY_MALFUNCTION_ADDR = 0x180  # ASCMLKASteeringCmd
-  # RELAY_MALFUNCTION_BUS = 0
   RELAY_MALFUNCTION_ADDRS = {0: (0x180,)}  # ASCMLKASteeringCmd
   BUTTONS_BUS = 0  # rx or tx
   BRAKE_BUS = 0  # tx only

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -72,6 +72,7 @@ class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeS
 
 class TestGmSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 10 * 0.0311
+  # Ensures ASCM is off on ASCM cars, and relay is not malfunctioning for camera-ACC cars
   RELAY_MALFUNCTION_ADDRS = {0: (0x180,)}  # ASCMLKASteeringCmd
   BUTTONS_BUS = 0  # rx or tx
   BRAKE_BUS = 0  # tx only

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -209,7 +209,6 @@ class TestGmCameraSafety(TestGmCameraSafetyBase):
 class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase):
   TX_MSGS = [[0x180, 0], [0x315, 0], [0x2CB, 0], [0x370, 0],  # pt bus
              [0x184, 2]]  # camera bus
-  RELAY_MALFUNCTION_BUS = 0
   FWD_BLACKLISTED_ADDRS = {2: [0x180, 0x2CB, 0x370, 0x315], 0: [0x184]}  # block LKAS, ACC messages and PSCMStatus
   BUTTONS_BUS = 0  # rx only
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -17,6 +17,8 @@ class Buttons:
 class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeSafetyTest):
   # pylint: disable=no-member,abstract-method
 
+  RELAY_MALFUNCTION_ADDRS = {0: (0x180, 0x2CB)}  # ASCMLKASteeringCmd,ASCMGasRegenCmd
+
   MAX_POSSIBLE_BRAKE = 2 ** 12
   MAX_BRAKE = 400
 
@@ -70,8 +72,9 @@ class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeS
 
 class TestGmSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 10 * 0.0311
-  RELAY_MALFUNCTION_ADDR = 0x180  # ASCMLKASteeringCmd
-  RELAY_MALFUNCTION_BUS = 0
+  # RELAY_MALFUNCTION_ADDR = 0x180  # ASCMLKASteeringCmd
+  # RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x180,)}  # ASCMLKASteeringCmd
   BUTTONS_BUS = 0  # rx or tx
   BRAKE_BUS = 0  # tx only
 
@@ -149,8 +152,6 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
   FWD_BUS_LOOKUP: Dict[int, int] = {}
   BRAKE_BUS = 2
 
-  RELAY_MALFUNCTION_ADDRS = {0: (0x180, 0x2CB)}  # ASCMLKASteeringCmd
-
   MAX_GAS = 3072
   MIN_GAS = 1404 # maximum regen
   INACTIVE_GAS = 1404
@@ -210,7 +211,6 @@ class TestGmCameraSafety(TestGmCameraSafetyBase):
 class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase):
   TX_MSGS = [[0x180, 0], [0x315, 0], [0x2CB, 0], [0x370, 0],  # pt bus
              [0x184, 2]]  # camera bus
-  RELAY_MALFUNCTION_ADDR = 0x2CB  # ASCMGasRegenCmd
   RELAY_MALFUNCTION_BUS = 0
   FWD_BLACKLISTED_ADDRS = {2: [0x180, 0x2CB, 0x370, 0x315], 0: [0x184]}  # block LKAS, ACC messages and PSCMStatus
   BUTTONS_BUS = 0  # rx only

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -70,7 +70,7 @@ class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeS
 
 class TestGmSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 10 * 0.0311
-  RELAY_MALFUNCTION_ADDR = 0x180
+  RELAY_MALFUNCTION_ADDR = 0x180  # ASCMLKASteeringCmd
   RELAY_MALFUNCTION_BUS = 0
   BUTTONS_BUS = 0  # rx or tx
   BRAKE_BUS = 0  # tx only
@@ -208,6 +208,8 @@ class TestGmCameraSafety(TestGmCameraSafetyBase):
 class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase):
   TX_MSGS = [[0x180, 0], [0x315, 0], [0x2CB, 0], [0x370, 0],  # pt bus
              [0x184, 2]]  # camera bus
+  RELAY_MALFUNCTION_ADDR = 0x2CB  # ASCMGasRegenCmd
+  RELAY_MALFUNCTION_BUS = 0
   FWD_BLACKLISTED_ADDRS = {2: [0x180, 0x2CB, 0x370, 0x315], 0: [0x184]}  # block LKAS, ACC messages and PSCMStatus
   BUTTONS_BUS = 0  # rx only
 

--- a/tests/safety/test_gm.py
+++ b/tests/safety/test_gm.py
@@ -149,6 +149,8 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
   FWD_BUS_LOOKUP: Dict[int, int] = {}
   BRAKE_BUS = 2
 
+  RELAY_MALFUNCTION_ADDRS = {0: (0x180, 0x2CB)}  # ASCMLKASteeringCmd
+
   MAX_GAS = 3072
   MIN_GAS = 1404 # maximum regen
   INACTIVE_GAS = 1404

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -182,7 +182,7 @@ class HondaBase(common.PandaCarSafetyTest):
   BUTTONS_BUS: Optional[int] = None  # must be set when inherited, tx on this bus, rx on PT_BUS
 
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194)}  # ASCMLKASteeringCmd
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194)}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   cnt_speed = 0

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -493,6 +493,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   STEER_BUS = 1
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
+  # 0x1DF is to test that radar is disabled
   RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194), 1: (0x1DF,)}  # STEERING_CONTROL, ACC_CONTROL
 
   def setUp(self):
@@ -518,12 +519,6 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
 
     not_tester_present = libpanda_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\xAA\xAA\x00\x00\x00\x00\x00")
     self.assertFalse(self._tx(not_tester_present))
-
-  def test_radar_alive(self):  # TODO: remove me
-    # If the radar knockout failed, make sure the relay malfunction is shown
-    self.assertFalse(self.safety.get_relay_malfunction())
-    self._rx(make_msg(self.PT_BUS, 0x1DF, 8))
-    self.assertTrue(self.safety.get_relay_malfunction())
 
   def test_gas_safety_check(self):
     for controls_allowed in [True, False]:

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -182,7 +182,7 @@ class HondaBase(common.PandaCarSafetyTest):
   BUTTONS_BUS: Optional[int] = None  # must be set when inherited, tx on this bus, rx on PT_BUS
 
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194)}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194)}  # STEERING_CONTROL
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   cnt_speed = 0
@@ -493,7 +493,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   STEER_BUS = 1
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194), 1: (0x1DF,)}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194), 1: (0x1DF,)}  # STEERING_CONTROL, ACC_CONTROL
 
   def setUp(self):
     super().setUp()

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -182,8 +182,7 @@ class HondaBase(common.PandaCarSafetyTest):
   BUTTONS_BUS: Optional[int] = None  # must be set when inherited, tx on this bus, rx on PT_BUS
 
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDR = 0xE4
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194)}  # ASCMLKASteeringCmd
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   cnt_speed = 0
@@ -494,6 +493,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
   STEER_BUS = 1
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194), 1: (0x1DF,)}
 
   def setUp(self):
     super().setUp()

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -519,7 +519,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
     not_tester_present = libpanda_py.make_CANPacket(0x18DAB0F1, self.PT_BUS, b"\x03\xAA\xAA\x00\x00\x00\x00\x00")
     self.assertFalse(self._tx(not_tester_present))
 
-  def test_radar_alive(self):
+  def test_radar_alive(self):  # TODO: remove me
     # If the radar knockout failed, make sure the relay malfunction is shown
     self.assertFalse(self.safety.get_relay_malfunction())
     self._rx(make_msg(self.PT_BUS, 0x1DF, 8))

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -45,7 +45,7 @@ def checksum(msg):
 class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest, common.SteerRequestCutSafetyTest):
   TX_MSGS = [[0x340, 0], [0x4F1, 0], [0x485, 0]]
   STANDSTILL_THRESHOLD = 12  # 0.375 kph
-  RELAY_MALFUNCTION_ADDRS = {0: (0x340,)}
+  RELAY_MALFUNCTION_ADDRS = {0: (0x340,)}  # LKAS11
   FWD_BLACKLISTED_ADDRS = {2: [0x340, 0x485]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -168,7 +168,7 @@ class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
 class TestHyundaiLongitudinalSafety(HyundaiLongitudinalBase, TestHyundaiSafety):
   TX_MSGS = [[0x340, 0], [0x4F1, 0], [0x485, 0], [0x420, 0], [0x421, 0], [0x50A, 0], [0x389, 0], [0x4A2, 0], [0x38D, 0], [0x483, 0], [0x7D0, 0]]
 
-  RELAY_MALFUNCTION_ADDRS = {0: (0x340, 0x421)}
+  RELAY_MALFUNCTION_ADDRS = {0: (0x340, 0x421)}  # LKAS11, SCC12
 
   DISABLED_ECU_UDS_MSG = (0x7D0, 0)
   DISABLED_ECU_ACTUATION_MSG = (0x421, 0)

--- a/tests/safety/test_hyundai.py
+++ b/tests/safety/test_hyundai.py
@@ -45,8 +45,7 @@ def checksum(msg):
 class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest, common.SteerRequestCutSafetyTest):
   TX_MSGS = [[0x340, 0], [0x4F1, 0], [0x485, 0]]
   STANDSTILL_THRESHOLD = 12  # 0.375 kph
-  RELAY_MALFUNCTION_ADDR = 0x340
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x340,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x340, 0x485]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -168,6 +167,8 @@ class TestHyundaiLegacySafetyHEV(TestHyundaiSafety):
 
 class TestHyundaiLongitudinalSafety(HyundaiLongitudinalBase, TestHyundaiSafety):
   TX_MSGS = [[0x340, 0], [0x4F1, 0], [0x485, 0], [0x420, 0], [0x421, 0], [0x50A, 0], [0x389, 0], [0x4A2, 0], [0x38D, 0], [0x483, 0], [0x7D0, 0]]
+
+  RELAY_MALFUNCTION_ADDRS = {0: (0x340, 0x421)}
 
   DISABLED_ECU_UDS_MSG = (0x7D0, 0)
   DISABLED_ECU_ACTUATION_MSG = (0x421, 0)

--- a/tests/safety/test_hyundai_canfd.py
+++ b/tests/safety/test_hyundai_canfd.py
@@ -12,7 +12,6 @@ class TestHyundaiCanfdBase(HyundaiButtonBase, common.PandaCarSafetyTest, common.
 
   TX_MSGS = [[0x50, 0], [0x1CF, 1], [0x2A4, 0]]
   STANDSTILL_THRESHOLD = 12  # 0.375 kph
-  RELAY_MALFUNCTION_ADDRS = None
   FWD_BLACKLISTED_ADDRS = {2: [0x50, 0x2a4]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 

--- a/tests/safety/test_hyundai_canfd.py
+++ b/tests/safety/test_hyundai_canfd.py
@@ -8,13 +8,11 @@ from panda.tests.safety.common import CANPackerPanda
 from panda.tests.safety.hyundai_common import HyundaiButtonBase, HyundaiLongitudinalBase
 
 
-
 class TestHyundaiCanfdBase(HyundaiButtonBase, common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest, common.SteerRequestCutSafetyTest):
 
   TX_MSGS = [[0x50, 0], [0x1CF, 1], [0x2A4, 0]]
   STANDSTILL_THRESHOLD = 12  # 0.375 kph
-  RELAY_MALFUNCTION_ADDR = 0x50
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = None
   FWD_BLACKLISTED_ADDRS = {2: [0x50, 0x2a4]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -85,8 +83,7 @@ class TestHyundaiCanfdBase(HyundaiButtonBase, common.PandaCarSafetyTest, common.
 class TestHyundaiCanfdHDA1Base(TestHyundaiCanfdBase):
 
   TX_MSGS = [[0x12A, 0], [0x1A0, 1], [0x1CF, 0], [0x1E0, 0]]
-  RELAY_MALFUNCTION_ADDR = 0x12A
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x12A,)}  # LFA
   FWD_BLACKLISTED_ADDRS = {2: [0x12A, 0x1E0]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -163,8 +160,7 @@ class TestHyundaiCanfdHDA1AltButtons(TestHyundaiCanfdHDA1Base):
 class TestHyundaiCanfdHDA2EV(TestHyundaiCanfdBase):
 
   TX_MSGS = [[0x50, 0], [0x1CF, 1], [0x2A4, 0]]
-  RELAY_MALFUNCTION_ADDR = 0x50
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x50,)}  # LKAS
   FWD_BLACKLISTED_ADDRS = {2: [0x50, 0x2a4]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -184,8 +180,7 @@ class TestHyundaiCanfdHDA2EV(TestHyundaiCanfdBase):
 class TestHyundaiCanfdHDA2EVAltSteering(TestHyundaiCanfdBase):
 
   TX_MSGS = [[0x110, 0], [0x1CF, 1], [0x362, 0]]
-  RELAY_MALFUNCTION_ADDR = 0x110
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x110,)}  # LKAS_ALT
   FWD_BLACKLISTED_ADDRS = {2: [0x110, 0x362]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -207,13 +202,14 @@ class TestHyundaiCanfdHDA2LongEV(HyundaiLongitudinalBase, TestHyundaiCanfdHDA2EV
   TX_MSGS = [[0x50, 0], [0x1CF, 1], [0x2A4, 0], [0x51, 0], [0x730, 1], [0x12a, 1], [0x160, 1],
              [0x1e0, 1], [0x1a0, 1], [0x1ea, 1], [0x200, 1], [0x345, 1], [0x1da, 1]]
 
+  RELAY_MALFUNCTION_ADDRS = {0: (0x50,), 1: (0x1a0,)}  # LKAS, SCC_CONTROL
+
   DISABLED_ECU_UDS_MSG = (0x730, 1)
   DISABLED_ECU_ACTUATION_MSG = (0x1a0, 1)
 
   STEER_MSG = "LFA"
   GAS_MSG = ("ACCELERATOR", "ACCELERATOR_PEDAL")
   STEER_BUS = 1
-
 
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_canfd")
@@ -232,6 +228,8 @@ class TestHyundaiCanfdHDA2LongEV(HyundaiLongitudinalBase, TestHyundaiCanfdHDA2EV
 class TestHyundaiCanfdHDALongHybrid(HyundaiLongitudinalBase, TestHyundaiCanfdHDA1Base):
 
   FWD_BLACKLISTED_ADDRS = {2: [0x12a, 0x1e0, 0x1a0]}
+
+  RELAY_MALFUNCTION_ADDRS = {0: (0x12A, 0x1a0)}  # LFA, SCC_CONTROL
 
   DISABLED_ECU_UDS_MSG = (0x730, 1)
   DISABLED_ECU_ACTUATION_MSG = (0x1a0, 0)

--- a/tests/safety/test_mazda.py
+++ b/tests/safety/test_mazda.py
@@ -10,8 +10,7 @@ class TestMazdaSafety(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafe
 
   TX_MSGS = [[0x243, 0], [0x09d, 0], [0x440, 0]]
   STANDSTILL_THRESHOLD = .1
-  RELAY_MALFUNCTION_ADDR = 0x243
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x243,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x243, 0x440]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 

--- a/tests/safety/test_nissan.py
+++ b/tests/safety/test_nissan.py
@@ -11,8 +11,7 @@ class TestNissanSafety(common.PandaCarSafetyTest, common.AngleSteeringSafetyTest
   TX_MSGS = [[0x169, 0], [0x2b1, 0], [0x4cc, 0], [0x20b, 2], [0x280, 2]]
   STANDSTILL_THRESHOLD = 0
   GAS_PRESSED_THRESHOLD = 3
-  RELAY_MALFUNCTION_ADDR = 0x169
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x169,)}
   FWD_BLACKLISTED_ADDRS = {0: [0x280], 2: [0x169, 0x2b1, 0x4cc]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -55,8 +55,7 @@ def fwd_blacklisted_addr(lkas_msg=SubaruMsg.ES_LKAS):
 class TestSubaruSafetyBase(common.PandaCarSafetyTest):
   FLAGS = 0
   STANDSTILL_THRESHOLD = 0 # kph
-  RELAY_MALFUNCTION_ADDR = SubaruMsg.ES_LKAS
-  RELAY_MALFUNCTION_BUS = SUBARU_MAIN_BUS
+  RELAY_MALFUNCTION_ADDRS = {0: (SubaruMsg.ES_LKAS,)}
   FWD_BUS_LOOKUP = {SUBARU_MAIN_BUS: SUBARU_CAM_BUS, SUBARU_CAM_BUS: SUBARU_MAIN_BUS}
   FWD_BLACKLISTED_ADDRS = fwd_blacklisted_addr()
 

--- a/tests/safety/test_subaru.py
+++ b/tests/safety/test_subaru.py
@@ -55,7 +55,7 @@ def fwd_blacklisted_addr(lkas_msg=SubaruMsg.ES_LKAS):
 class TestSubaruSafetyBase(common.PandaCarSafetyTest):
   FLAGS = 0
   STANDSTILL_THRESHOLD = 0 # kph
-  RELAY_MALFUNCTION_ADDRS = {0: (SubaruMsg.ES_LKAS,)}
+  RELAY_MALFUNCTION_ADDRS = {SUBARU_MAIN_BUS: (SubaruMsg.ES_LKAS,)}
   FWD_BUS_LOOKUP = {SUBARU_MAIN_BUS: SUBARU_CAM_BUS, SUBARU_CAM_BUS: SUBARU_MAIN_BUS}
   FWD_BLACKLISTED_ADDRS = fwd_blacklisted_addr()
 

--- a/tests/safety/test_subaru_preglobal.py
+++ b/tests/safety/test_subaru_preglobal.py
@@ -9,8 +9,7 @@ from panda.tests.safety.common import CANPackerPanda
 class TestSubaruPreglobalSafety(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   TX_MSGS = [[0x161, 0], [0x164, 0]]
   STANDSTILL_THRESHOLD = 0  # kph
-  RELAY_MALFUNCTION_ADDR = 0x164
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x164,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x161, 0x164]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -23,7 +23,6 @@ class CONTROL_LEVER_STATE:
 class TestTeslaSafety(common.PandaCarSafetyTest):
   STANDSTILL_THRESHOLD = 0
   GAS_PRESSED_THRESHOLD = 3
-  RELAY_MALFUNCTION_BUS = 0
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   def setUp(self):
@@ -65,7 +64,7 @@ class TestTeslaSafety(common.PandaCarSafetyTest):
 
 class TestTeslaSteeringSafety(TestTeslaSafety, common.AngleSteeringSafetyTest):
   TX_MSGS = [[0x488, 0], [0x45, 0], [0x45, 2]]
-  RELAY_MALFUNCTION_ADDR = 0x488
+  RELAY_MALFUNCTION_ADDRS = {0: (0x488,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x488]}
 
   # Angle control limits
@@ -149,7 +148,7 @@ class TestTeslaLongitudinalSafety(TestTeslaSafety):
 
 class TestTeslaChassisLongitudinalSafety(TestTeslaLongitudinalSafety):
   TX_MSGS = [[0x488, 0], [0x45, 0], [0x45, 2], [0x2B9, 0]]
-  RELAY_MALFUNCTION_ADDR = 0x488
+  RELAY_MALFUNCTION_ADDRS = {0: (0x488,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x2B9, 0x488]}
 
   def setUp(self):
@@ -161,7 +160,7 @@ class TestTeslaChassisLongitudinalSafety(TestTeslaLongitudinalSafety):
 
 class TestTeslaPTLongitudinalSafety(TestTeslaLongitudinalSafety):
   TX_MSGS = [[0x2BF, 0]]
-  RELAY_MALFUNCTION_ADDR = 0x2BF
+  RELAY_MALFUNCTION_ADDRS = {0: (0x2BF,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x2BF]}
 
   def setUp(self):

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -27,8 +27,7 @@ class TestToyotaSafetyBase(common.PandaCarSafetyTest, common.InterceptorSafetyTe
              [0x2E4, 0], [0x191, 0], [0x411, 0], [0x412, 0], [0x343, 0], [0x1D2, 0],  # LKAS + ACC
              [0x200, 0], [0x750, 0]]  # interceptor + blindspot monitor
   STANDSTILL_THRESHOLD = 0  # kph
-  RELAY_MALFUNCTION_ADDR = 0x2E4
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (0x2E4,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x2E4, 0x412, 0x191, 0x343]}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
   INTERCEPTOR_THRESHOLD = 805

--- a/tests/safety/test_volkswagen_mqb.py
+++ b/tests/safety/test_volkswagen_mqb.py
@@ -24,8 +24,7 @@ MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
 class TestVolkswagenMqbSafety(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDR = MSG_HCA_01
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (MSG_HCA_01,)}
 
   MAX_RATE_UP = 4
   MAX_RATE_DOWN = 10

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -21,8 +21,7 @@ class TestVolkswagenPqSafety(common.PandaCarSafetyTest, common.DriverTorqueSteer
   cruise_engaged = False
 
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDR = MSG_HCA_1
-  RELAY_MALFUNCTION_BUS = 0
+  RELAY_MALFUNCTION_ADDRS = {0: (MSG_HCA_1,)}
 
   MAX_RATE_UP = 6
   MAX_RATE_DOWN = 10


### PR DESCRIPTION
Expands coverage for https://github.com/commaai/panda/pull/1699, also allows for safety tests to specify multiple relay malfunction addresses for full coverage. This prepares us for Toyota radar disable safety in the new RAV4s as well!

---

The new relay malfunction test keeps the same coverage while also asserting that the addresses that cause a relay malfunction match what is in the safety test; this catches some cases where safety was setting a relay malfunction and we weren't ensuring that: Hyundai CAN FD long, Ford Long, GM long, etc.

---

![image](https://github.com/commaai/panda/assets/25857203/70c11c87-3f19-4958-84f5-8f17026ae577)
