### PR TITLE
GM: Car Port for XT4 2023

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -197,9 +197,10 @@ void can_set_forwarding(uint8_t from, uint8_t to) {
 
 void ignition_can_hook(CANPacket_t *to_push) {
   int bus = GET_BUS(to_push);
+  int addr = GET_ADDR(to_push);
+  int len = GET_LEN(to_push);
+  
   if (bus == 0) {
-    int addr = GET_ADDR(to_push);
-    int len = GET_LEN(to_push);
     
     // GM exception
     if ((addr == 0x1F1) && (len == 8)) {
@@ -221,6 +222,14 @@ void ignition_can_hook(CANPacket_t *to_push) {
       ignition_can_cnt = 0U;
     }
 
+  } else if (bus == 2) {
+    // GM exception, SDGM cars have this message on bus 2
+    if ((addr == 0x1F1) && (len == 8)) {
+      // SystemPowerMode (2=Run, 3=Crank Request)
+      ignition_can = (GET_BYTE(to_push, 0) & 0x2U) != 0U;
+      ignition_can_cnt = 0U;
+    }
+  } else {
   }
 }
 

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -41,7 +41,8 @@ const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4}, {0x315, 0, 5}, {0x2CB, 0, 8
 RxCheck gm_rx_checks[] = {
   {.msg = {{0x184, 0, 8, .frequency = 10U}, { 0 }, { 0 }}},
   {.msg = {{0x34A, 0, 5, .frequency = 10U}, { 0 }, { 0 }}},
-  {.msg = {{0x1E1, 0, 7, .frequency = 10U}, { 0 }, { 0 }}},
+  {.msg = {{0x1E1, 0, 7, .frequency = 10U},   // Non-SDGM Car
+           {0x1E1, 2, 7, .frequency = 10U}, { 0 }}}, // SDGM Car
   {.msg = {{0xBE, 0, 6, .frequency = 10U},    // Volt, Silverado, Acadia Denali
            {0xBE, 0, 7, .frequency = 10U},    // Bolt EUV
            {0xBE, 0, 8, .frequency = 10U}}},  // Escalade


### PR DESCRIPTION
Add support for GM vehicles with ASCMs intercepted at the Serial Data Gateway Module.

Prerequisite of
commaai/openpilot#30420