### PR TITLE
Ford: fix possible standstill mismatch

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -216,7 +216,7 @@ static int ford_rx_hook(CANPacket_t *to_push) {
     // Update in motion state from standstill signal
     if (addr == FORD_DesiredTorqBrk) {
       // Signal: VehStop_D_Stat
-      vehicle_moving = ((GET_BYTE(to_push, 3) >> 3) & 0x3U) == 0U;
+      vehicle_moving = ((GET_BYTE(to_push, 3) >> 3) & 0x3U) != 1U;
     }
 
     // Update vehicle speed

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import numpy as np
+import random
 import unittest
 
 import panda.tests.safety.common as common
@@ -134,7 +135,7 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
 
   # Standstill state
   def _vehicle_moving_msg(self, speed: float):
-    values = {"VehStop_D_Stat": 1 if speed <= self.STANDSTILL_THRESHOLD else 0}
+    values = {"VehStop_D_Stat": 1 if speed <= self.STANDSTILL_THRESHOLD else random.choice((0, 2, 3))}
     return self.packer.make_can_msg_panda("DesiredTorqBrk", 0, values)
 
   # Current curvature


### PR DESCRIPTION
Split from https://github.com/commaai/panda/pull/1718, caught in https://github.com/commaai/openpilot/pull/30443. Similar bug to: https://github.com/commaai/panda/pull/1724

openpilot checks that this value == 1 to be in standstill, but panda was checking it to be 0, when it's a 2 bit signal (can be 2=NoDataExists, 3=Faulty).