### PR TITLE
safety tests: common interceptor msg

### DIFF
--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -126,9 +126,6 @@ class InterceptorSafetyTest(PandaSafetyTestBase):
 
   INTERCEPTOR_THRESHOLD = 0
 
-  cnt_gas_cmd = 0
-  cnt_user_gas = 0
-
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "InterceptorSafetyTest":
@@ -136,17 +133,14 @@ class InterceptorSafetyTest(PandaSafetyTestBase):
       raise unittest.SkipTest
 
   def _interceptor_gas_cmd(self, gas):
-    values = {"COUNTER_PEDAL": self.__class__.cnt_gas_cmd & 0xF}
+    values = {}
     if gas > 0:
       values["GAS_COMMAND"] = gas * 255.
       values["GAS_COMMAND2"] = gas * 255.
-    self.__class__.cnt_gas_cmd += 1
     return self.packer.make_can_msg_panda("GAS_COMMAND", 0, values)
 
   def _interceptor_user_gas(self, gas):
-    values = {"INTERCEPTOR_GAS": gas, "INTERCEPTOR_GAS2": gas,
-              "COUNTER_PEDAL": self.__class__.cnt_user_gas}
-    self.__class__.cnt_user_gas += 1
+    values = {"INTERCEPTOR_GAS": gas, "INTERCEPTOR_GAS2": gas}
     return self.packer.make_can_msg_panda("GAS_SENSOR", 0, values)
 
   def test_prev_gas_interceptor(self):

--- a/tests/safety/common.py
+++ b/tests/safety/common.py
@@ -126,19 +126,28 @@ class InterceptorSafetyTest(PandaSafetyTestBase):
 
   INTERCEPTOR_THRESHOLD = 0
 
+  cnt_gas_cmd = 0
+  cnt_user_gas = 0
+
   @classmethod
   def setUpClass(cls):
     if cls.__name__ == "InterceptorSafetyTest":
       cls.safety = None
       raise unittest.SkipTest
 
-  @abc.abstractmethod
   def _interceptor_gas_cmd(self, gas):
-    pass
+    values = {"COUNTER_PEDAL": self.__class__.cnt_gas_cmd & 0xF}
+    if gas > 0:
+      values["GAS_COMMAND"] = gas * 255.
+      values["GAS_COMMAND2"] = gas * 255.
+    self.__class__.cnt_gas_cmd += 1
+    return self.packer.make_can_msg_panda("GAS_COMMAND", 0, values)
 
-  @abc.abstractmethod
   def _interceptor_user_gas(self, gas):
-    pass
+    values = {"INTERCEPTOR_GAS": gas, "INTERCEPTOR_GAS2": gas,
+              "COUNTER_PEDAL": self.__class__.cnt_user_gas}
+    self.__class__.cnt_user_gas += 1
+    return self.packer.make_can_msg_panda("GAS_SENSOR", 0, values)
 
   def test_prev_gas_interceptor(self):
     self._rx(self._interceptor_user_gas(0x0))

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -6,7 +6,7 @@ from typing import Optional
 from panda import Panda
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, make_msg, MAX_WRONG_COUNTERS
+from panda.tests.safety.common import CANPackerPanda, MAX_WRONG_COUNTERS
 
 class Btn:
   NONE = 0
@@ -17,15 +17,6 @@ class Btn:
 
 HONDA_NIDEC = 0
 HONDA_BOSCH = 1
-
-
-def interceptor_msg(gas, addr):
-  to_send = make_msg(0, addr, 6)
-  to_send[0].data[0] = (gas & 0xFF00) >> 8
-  to_send[0].data[1] = gas & 0xFF
-  to_send[0].data[2] = (gas & 0xFF00) >> 8
-  to_send[0].data[3] = gas & 0xFF
-  return to_send
 
 
 # Honda safety has several different configurations tested here:
@@ -280,12 +271,6 @@ class TestHondaNidecSafetyBase(HondaBase):
     self.safety = libpanda_py.libpanda
     self.safety.set_safety_hooks(Panda.SAFETY_HONDA_NIDEC, 0)
     self.safety.init_tests()
-
-  def _interceptor_gas_cmd(self, gas):
-    return interceptor_msg(gas, 0x200)
-
-  def _interceptor_user_gas(self, gas):
-    return interceptor_msg(gas, 0x201)
 
   def _send_brake_msg(self, brake, aeb_req=0, bus=0):
     values = {"COMPUTER_BRAKE": brake, "AEB_REQ_1": aeb_req}

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -7,16 +7,7 @@ import itertools
 from panda import Panda
 from panda.tests.libpanda import libpanda_py
 import panda.tests.safety.common as common
-from panda.tests.safety.common import CANPackerPanda, make_msg
-
-
-def interceptor_msg(gas, addr):
-  to_send = make_msg(0, addr, 6)
-  to_send[0].data[0] = (gas & 0xFF00) >> 8
-  to_send[0].data[1] = gas & 0xFF
-  to_send[0].data[2] = (gas & 0xFF00) >> 8
-  to_send[0].data[3] = gas & 0xFF
-  return to_send
+from panda.tests.safety.common import CANPackerPanda
 
 
 class TestToyotaSafetyBase(common.PandaCarSafetyTest, common.InterceptorSafetyTest,
@@ -73,12 +64,6 @@ class TestToyotaSafetyBase(common.PandaCarSafetyTest, common.InterceptorSafetyTe
   def _pcm_status_msg(self, enable):
     values = {"CRUISE_ACTIVE": enable}
     return self.packer.make_can_msg_panda("PCM_CRUISE", 0, values)
-
-  def _interceptor_gas_cmd(self, gas):
-    return interceptor_msg(gas, 0x200)
-
-  def _interceptor_user_gas(self, gas):
-    return interceptor_msg(gas, 0x201)
 
   def test_block_aeb(self):
     for controls_allowed in (True, False):


### PR DESCRIPTION
Split from https://github.com/commaai/panda/pull/1735

All safety modes that inherit from the interceptor test so far use the same DBC msg structure, only thing that is different is scaling. This matches openpilot's message creation which is also generic.