### PR TITLE
safety replay: support Nissan

### DIFF
--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -24,7 +24,7 @@ def is_steering_msg(mode, param, addr):
   elif mode == Panda.SAFETY_FORD:
     ret = addr == 0x3d3
   elif mode == Panda.SAFETY_NISSAN:
-    ret = addr == 361
+    ret = addr == 0x169
   return ret
 
 def get_steer_value(mode, param, to_send):

--- a/tests/safety_replay/helpers.py
+++ b/tests/safety_replay/helpers.py
@@ -23,6 +23,8 @@ def is_steering_msg(mode, param, addr):
     ret = addr == 0x122
   elif mode == Panda.SAFETY_FORD:
     ret = addr == 0x3d3
+  elif mode == Panda.SAFETY_NISSAN:
+    ret = addr == 361
   return ret
 
 def get_steer_value(mode, param, to_send):
@@ -49,6 +51,9 @@ def get_steer_value(mode, param, to_send):
     torque = -to_signed(torque, 13)
   elif mode == Panda.SAFETY_FORD:
     angle = ((to_send.data[0] << 3) | (to_send.data[1] >> 5)) - 1000
+  elif mode == Panda.SAFETY_NISSAN:
+    angle = (to_send.data[0] << 10) | (to_send.data[1] << 2) | (to_send.data[2] >> 6)
+    angle = -angle + (1310 * 100)
   return torque, angle
 
 def package_can_msg(msg):


### PR DESCRIPTION
Wrote this to make sure that https://github.com/commaai/panda/pull/1752 wasn't only an issue for Toyota, might as well merge. Initializes safety properly with PR mentioned.

This supports running on segments already enabled.