### PR TITLE
safety: macro to update vehicle speed

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -214,7 +214,7 @@ static void ford_rx_hook(CANPacket_t *to_push) {
     // Update vehicle speed
     if (addr == FORD_BrakeSysFeatures) {
       // Signal: Veh_V_ActlBrk
-      update_sample(&vehicle_speed, ROUND(((GET_BYTE(to_push, 0) << 8) | GET_BYTE(to_push, 1)) * 0.01 / 3.6 * VEHICLE_SPEED_FACTOR));
+      UPDATE_VEHICLE_SPEED(((GET_BYTE(to_push, 0) << 8) | GET_BYTE(to_push, 1)) * 0.01 / 3.6);
     }
 
     // Check vehicle speed against a second source

--- a/board/safety/safety_nissan.h
+++ b/board/safety/safety_nissan.h
@@ -61,7 +61,7 @@ static void nissan_rx_hook(CANPacket_t *to_push) {
       uint16_t right_rear = (GET_BYTE(to_push, 0) << 8) | (GET_BYTE(to_push, 1));
       uint16_t left_rear = (GET_BYTE(to_push, 2) << 8) | (GET_BYTE(to_push, 3));
       vehicle_moving = (right_rear | left_rear) != 0U;
-      update_sample(&vehicle_speed, ROUND((right_rear + left_rear) / 2.0 * 0.005 / 3.6 * VEHICLE_SPEED_FACTOR));
+      UPDATE_VEHICLE_SPEED((right_rear + left_rear) / 2.0 * 0.005 / 3.6);
     }
 
     // X-Trail 0x15c, Leaf 0x239

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -165,8 +165,7 @@ static void subaru_rx_hook(CANPacket_t *to_push) {
 
     vehicle_moving = (fr > 0U) || (rr > 0U) || (rl > 0U) || (fl > 0U);
 
-    float speed = (fr + rr + rl + fl) / 4U * 0.057;
-    update_sample(&vehicle_speed, ROUND(speed * VEHICLE_SPEED_FACTOR));
+    UPDATE_VEHICLE_SPEED((fr + rr + rl + fl) / 4U * 0.057);
   }
 
   if ((addr == MSG_SUBARU_Brake_Status) && (bus == alt_main_bus)) {

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -72,7 +72,7 @@ static void tesla_rx_hook(CANPacket_t *to_push) {
       // Vehicle speed: ((0.05 * val) - 25) * MPH_TO_MPS
       float speed = (((((GET_BYTE(to_push, 3) & 0x0FU) << 8) | (GET_BYTE(to_push, 2))) * 0.05) - 25) * 0.447;
       vehicle_moving = ABS(speed) > 0.1;
-      update_sample(&vehicle_speed, ROUND(speed * VEHICLE_SPEED_FACTOR));
+      UPDATE_VEHICLE_SPEED(speed);
     }
 
     if(addr == (tesla_powertrain ? 0x106 : 0x108)) {

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -10,6 +10,7 @@
                                    (config).rx_checks_len = sizeof((rx)) / sizeof((rx)[0]))
 #define SET_TX_MSGS(tx, config) ((config).tx_msgs = (tx), \
                                  (config).tx_msgs_len = sizeof((tx)) / sizeof((tx)[0]))
+#define UPDATE_VEHICLE_SPEED(val_ms) (update_sample(&vehicle_speed, ROUND((val_ms) * VEHICLE_SPEED_FACTOR)))
 
 uint32_t GET_BYTES(const CANPacket_t *msg, int start, int len) {
   uint32_t ret = 0U;


### PR DESCRIPTION
sample_t supports int, so we needed a way to store float, hence rounding and vehicle speed factor. Put this duplicate math in a macro