### PR TITLE
Ford: check predicted gas

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -157,7 +157,7 @@ const LongitudinalLimits FORD_LONG_LIMITS = {
   .inactive_accel = 5128,  // -0.0008 m/s^2
 
   // gas cmd limits
-  // Signal: AccPrpl_A_Rq
+  // Signal: AccPrpl_A_Rq & AccPrpl_A_Pred
   .max_gas = 700,          //  2.0 m/s^2
   .min_gas = 450,          // -0.5 m/s^2
   .inactive_gas = 0,       // -5.0 m/s^2
@@ -274,6 +274,8 @@ static bool ford_tx_hook(CANPacket_t *to_send) {
   if (addr == FORD_ACCDATA) {
     // Signal: AccPrpl_A_Rq
     int gas = ((GET_BYTE(to_send, 6) & 0x3U) << 8) | GET_BYTE(to_send, 7);
+    // Signal: AccPrpl_A_Pred
+    int gas_pred = ((GET_BYTE(to_send, 2) & 0x3U) << 8) | GET_BYTE(to_send, 3);
     // Signal: AccBrkTot_A_Rq
     int accel = ((GET_BYTE(to_send, 0) & 0x1FU) << 8) | GET_BYTE(to_send, 1);
     // Signal: CmbbDeny_B_Actl
@@ -282,6 +284,7 @@ static bool ford_tx_hook(CANPacket_t *to_send) {
     bool violation = false;
     violation |= longitudinal_accel_checks(accel, FORD_LONG_LIMITS);
     violation |= longitudinal_gas_checks(gas, FORD_LONG_LIMITS);
+    violation |= longitudinal_gas_checks(gas_pred, FORD_LONG_LIMITS);
 
     // Safety check for stock AEB
     violation |= cmbb_deny != 0; // do not prevent stock AEB actuation

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -409,6 +409,7 @@ class TestFordLongitudinalSafetyBase(TestFordSafetyBase):
   def _acc_command_msg(self, gas: float, brake: float, cmbb_deny: bool = False):
     values = {
       "AccPrpl_A_Rq": gas,                       # [-5|5.23] m/s^2
+      "AccPrpl_A_Pred": gas,                     # [-5|5.23] m/s^2
       "AccBrkTot_A_Rq": brake,                   # [-20|11.9449] m/s^2
       "CmbbDeny_B_Actl": 1 if cmbb_deny else 0,  # [0|1] deny AEB actuation
     }


### PR DESCRIPTION
Unknown what effect this signal has if set while other signal is inactive, so it's best to assert safety on this. We do this for other safety modes too: https://github.com/commaai/panda/blob/bb75afc84e4d33af1554ada81851547db648e33e/board/safety/safety_hyundai.h#L242-L243 and https://github.com/commaai/panda/blob/bb75afc84e4d33af1554ada81851547db648e33e/board/safety/safety_hyundai_canfd.h#L272-L273

It just happened that a byte value of 0 is the actual inactive value (-5 m/s^2), and that it actuates gas.