### PR TITLE
Honda: reset prev brake switch

### DIFF
--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -375,6 +375,7 @@ static bool honda_tx_hook(CANPacket_t *to_send) {
 static safety_config honda_nidec_init(uint16_t param) {
   honda_hw = HONDA_NIDEC;
   honda_brake = 0;
+  honda_brake_switch_prev = false;
   honda_fwd_brake = false;
   honda_alt_brake_msg = false;
   honda_bosch_long = false;
@@ -400,6 +401,7 @@ static safety_config honda_nidec_init(uint16_t param) {
 
 static safety_config honda_bosch_init(uint16_t param) {
   honda_hw = HONDA_BOSCH;
+  honda_brake_switch_prev = false;
   honda_bosch_radarless = GET_FLAG(param, HONDA_PARAM_RADARLESS);
   // Checking for alternate brake override from safety parameter
   honda_alt_brake_msg = GET_FLAG(param, HONDA_PARAM_ALT_BRAKE);


### PR DESCRIPTION
I recall fixing this on a branch, but not sure where it got lost. This fixes a mismatch in https://github.com/commaai/openpilot/pull/30443 when running on randomly-ordered tests since the previous value is sticking around