### PR TITLE
Sort output of can_bit_transition script numerically

### DIFF
--- a/examples/can_bit_transition.py
+++ b/examples/can_bit_transition.py
@@ -97,7 +97,7 @@ def PrintUnique(log_file, low_range, high_range):
   high.load(log_file, start, end)
   # print messages that go from low to high
   found = False
-  for message_id in sorted(high.messages):
+  for message_id in sorted(high.messages, key=lambda x: int(x.split(':')[1], 16)):
     if message_id in low.messages:
       high.messages[message_id].printBitDiff(low.messages[message_id])
       found = True


### PR DESCRIPTION
Sort signals numerically instead of lexicographically.

Example output before:
```
id 0:140 0 -> 1 at byte 0 bitmask 64
id 0:1e9 0 -> 1 at byte 0 bitmask 64
id 0:1fc 0 -> 1 at byte 4 bitmask 3
id 0:214 0 -> 1 at byte 1 bitmask 80
id 0:2f9 0 -> 1 at byte 5 bitmask 40
id 0:be 0 -> 1 at byte 1 bitmask 84
id 0:be 1 -> 0 at byte 1 bitmask 2
id 0:be 1 -> 0 at byte 5 bitmask 80
id 0:c9 0 -> 1 at byte 5 bitmask 1
id 0:d1 0 -> 1 at byte 0 bitmask 3
id 0:d1 0 -> 1 at byte 4 bitmask 66
id 0:f1 0 -> 1 at byte 0 bitmask 66
id 0:f1 0 -> 1 at byte 1 bitmask 88
id 0:f1 1 -> 0 at byte 4 bitmask 176
id 2:170 0 -> 1 at byte 2 bitmask 88
id 2:1e9 0 -> 1 at byte 0 bitmask 16
id 2:212 0 -> 1 at byte 0 bitmask 32
id 2:212 0 -> 1 at byte 1 bitmask 80
id 2:212 0 -> 1 at byte 4 bitmask 88
id 2:214 0 -> 1 at byte 0 bitmask 2
id 2:214 0 -> 1 at byte 1 bitmask 152
id 2:214 1 -> 0 at byte 1 bitmask 64
id 2:214 0 -> 1 at byte 2 bitmask 8
id 2:214 0 -> 1 at byte 5 bitmask 128
id 2:214 1 -> 0 at byte 5 bitmask 64
id 2:219 0 -> 1 at byte 0 bitmask 1
id 2:21b 0 -> 1 at byte 1 bitmask 64
id 2:21b 0 -> 1 at byte 2 bitmask 32
id 2:21b 1 -> 0 at byte 2 bitmask 8
id 2:21b 1 -> 0 at byte 7 bitmask 16
id 2:21e 0 -> 1 at byte 5 bitmask 32
id 2:235 0 -> 1 at byte 1 bitmask 40
id 2:340 0 -> 1 at byte 0 bitmask 2
```

After:
```
id 0:be 0 -> 1 at byte 1 bitmask 84
id 0:be 1 -> 0 at byte 1 bitmask 2
id 0:be 1 -> 0 at byte 5 bitmask 80
id 0:c9 0 -> 1 at byte 5 bitmask 1
id 0:d1 0 -> 1 at byte 0 bitmask 3
id 0:d1 0 -> 1 at byte 4 bitmask 66
id 0:f1 0 -> 1 at byte 0 bitmask 66
id 0:f1 0 -> 1 at byte 1 bitmask 88
id 0:f1 1 -> 0 at byte 4 bitmask 176
id 0:140 0 -> 1 at byte 0 bitmask 64
id 2:170 0 -> 1 at byte 2 bitmask 88
id 0:1e9 0 -> 1 at byte 0 bitmask 64
id 2:1e9 0 -> 1 at byte 0 bitmask 16
id 0:1fc 0 -> 1 at byte 4 bitmask 3
id 2:212 0 -> 1 at byte 0 bitmask 32
id 2:212 0 -> 1 at byte 1 bitmask 80
id 2:212 0 -> 1 at byte 4 bitmask 88
id 2:214 0 -> 1 at byte 0 bitmask 2
id 2:214 0 -> 1 at byte 1 bitmask 152
id 2:214 1 -> 0 at byte 1 bitmask 64
id 2:214 0 -> 1 at byte 2 bitmask 8
id 2:214 0 -> 1 at byte 5 bitmask 128
id 2:214 1 -> 0 at byte 5 bitmask 64
id 0:214 0 -> 1 at byte 1 bitmask 80
id 2:219 0 -> 1 at byte 0 bitmask 1
id 2:21b 0 -> 1 at byte 1 bitmask 64
id 2:21b 0 -> 1 at byte 2 bitmask 32
id 2:21b 1 -> 0 at byte 2 bitmask 8
id 2:21b 1 -> 0 at byte 7 bitmask 16
id 2:21e 0 -> 1 at byte 5 bitmask 32
id 2:235 0 -> 1 at byte 1 bitmask 40
id 0:2f9 0 -> 1 at byte 5 bitmask 40
id 2:340 0 -> 1 at byte 0 bitmask 2
```