### PR TITLE
Enable caching in test_misra

### DIFF
--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -27,7 +27,8 @@ cd $PANDA_DIR
 scons -j8
 
 cppcheck() {
-  build_dir=/tmp/cppcheck_build_$7
+  hashed_args=$(echo -n "$@" | sha256sum | awk '{print $1}')
+  build_dir=/tmp/cppcheck_build/$hashed_args
   if [ -d $build_dir ]; then
     build_dir_exists=true
   else
@@ -60,12 +61,12 @@ cppcheck() {
 }
 
 printf "\n${GREEN}** PANDA F4 CODE **${NC}\n"
-cppcheck -DCAN3 -DPANDA -DSTM32F4 -UPEDAL -DUID_BASE board/main.c f4
+cppcheck -DCAN3 -DPANDA -DSTM32F4 -UPEDAL -DUID_BASE board/main.c
 
 printf "\n${GREEN}** PANDA H7 CODE **${NC}\n"
-cppcheck -DCAN3 -DPANDA -DSTM32H7 -UPEDAL -DUID_BASE board/main.c h7
+cppcheck -DCAN3 -DPANDA -DSTM32H7 -UPEDAL -DUID_BASE board/main.c
 
 printf "\n${GREEN}** PEDAL CODE **${NC}\n"
-cppcheck -UCAN3 -UPANDA -DSTM32F2 -DPEDAL -UUID_BASE board/pedal/main.c pedal
+cppcheck -UCAN3 -UPANDA -DSTM32F2 -DPEDAL -UUID_BASE board/pedal/main.c
 
 printf "\n${GREEN}Success!${NC} took $SECONDS seconds\n"

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -29,12 +29,7 @@ scons -j8
 cppcheck() {
   hashed_args=$(echo -n "$@" | md5sum | awk '{print $1}')
   build_dir=/tmp/cppcheck_build/$hashed_args
-  if [ -d $build_dir ]; then
-    build_dir_exists=true
-  else
-    build_dir_exists=false
-    mkdir -p $build_dir
-  fi
+  mkdir -p $build_dir
 
   $CPPCHECK_DIR/cppcheck --enable=all --force --inline-suppr -I $PANDA_DIR/board/ \
           -I $gcc_inc "$(arm-none-eabi-gcc -print-file-name=include)" \


### PR DESCRIPTION
Before it was not caching into `--cppcheck-build-dir` because each folder can only used for one file and we have 3 files to check. After caching if there is no change in compilation then it would take ~1s, and only recache specifically changed files. I disabled the sanity check to only check if the folder doesn't already exists because checkers are not called if the files are cached.
```
** PANDA F4 CODE **
Checking board/main.c ...
nofile:0:0: information: Active checkers: 177/792 (use --checkers-report=<filename> to see details) [checkersReport]

** PANDA H7 CODE **
Checking board/main.c ...
nofile:0:0: information: Active checkers: 177/792 (use --checkers-report=<filename> to see details) [checkersReport]

** PEDAL CODE **
Checking board/pedal/main.c ...
nofile:0:0: information: Active checkers: 177/792 (use --checkers-report=<filename> to see details) [checkersReport]

Success! took 1 seconds
```
If this PR is merge, we put this cache into GHA similar to scons_cache