### PR TITLE
Enable cache for MISRA mutation test

### DIFF
--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -27,7 +27,7 @@ cd $PANDA_DIR
 scons -j8
 
 cppcheck() {
-  hashed_args=$(echo -n "$@" | md5sum | awk '{print $1}')
+  hashed_args=$(echo -n "$@$DIR" | md5sum | awk '{print $1}')
   build_dir=/tmp/cppcheck_build/$hashed_args
   mkdir -p $build_dir
 

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -4,6 +4,7 @@ import pytest
 import shutil
 import subprocess
 import tempfile
+import hashlib
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 ROOT = os.path.join(HERE, "../../")
@@ -23,7 +24,7 @@ mutations = [
 
 @pytest.mark.parametrize("fn, patch, should_fail", mutations)
 def test_misra_mutation(fn, patch, should_fail):
-  temp_dir_name = f"misra_check_tmp_{os.path.basename(fn if fn is not None else 'main')}"
+  temp_dir_name = hashlib.md5((fn + patch if (fn is not None and patch is not None) else "main").encode()).hexdigest()
   tmp = os.path.join(tempfile.gettempdir(), temp_dir_name)
   shutil.copytree(ROOT, tmp, dirs_exist_ok=True)
 

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -21,16 +21,11 @@ mutations = [
   ("board/safety/safety_toyota.h", "s/is_lkas_msg =.*;/is_lkas_msg = addr == 1 || addr == 2;/g", True),
 ]
 
-def ignore_folder(dir, contents):
-  ignore_list = [".git"]
-  return [item for item in contents if item in ignore_list]
-
 @pytest.mark.parametrize("fn, patch, should_fail", mutations)
 def test_misra_mutation(fn, patch, should_fail):
-  tmp_path = "tmp/main.temp" if fn == None else fn
-  temp_dir_name = f"misra_check_tmp_{os.path.basename(tmp_path).split('.')[0]}"
+  temp_dir_name = f"misra_check_tmp_{os.path.basename(fn if fn is not None else 'main')}"
   tmp = os.path.join(tempfile.gettempdir(), temp_dir_name)
-  shutil.copytree(ROOT, tmp, dirs_exist_ok=True, ignore=ignore_folder)
+  shutil.copytree(ROOT, tmp, dirs_exist_ok=True)
 
   # apply patch
   if fn is not None:

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -24,9 +24,12 @@ mutations = [
 
 @pytest.mark.parametrize("fn, patch, should_fail", mutations)
 def test_misra_mutation(fn, patch, should_fail):
-  temp_dir_name = hashlib.md5((fn + patch if (fn is not None and patch is not None) else "main").encode()).hexdigest()
-  tmp = os.path.join(tempfile.gettempdir(), temp_dir_name)
-  shutil.copytree(ROOT, tmp, dirs_exist_ok=True)
+  key = hashlib.md5((str(fn) + str(patch)).encode()).hexdigest()
+  tmp = os.path.join(tempfile.gettempdir(), key)
+
+  if os.path.exists(tmp):
+    shutil.rmtree(tmp)
+  shutil.copytree(ROOT, tmp)
 
   # apply patch
   if fn is not None:
@@ -34,10 +37,10 @@ def test_misra_mutation(fn, patch, should_fail):
     assert r == 0
 
   # run test
-  r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True,
-                      stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+  r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
   failed = r.returncode != 0
   assert failed == should_fail
+
   shutil.rmtree(tmp)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now mutation test can cache from ~45s to ~10s, replace `tempDirectory()` so that we can name the directory ourselves

```
9.21s call     panda/tests/misra/test_mutation.py::test_misra_mutation[None-None-False]
8.92s call     panda/tests/misra/test_mutation.py::test_misra_mutation[board/stm32h7/llfdcan.h-s/return ret;/if (true) { return ret; } else { return false; }/g-True]
8.63s call     panda/tests/misra/test_mutation.py::test_misra_mutation[board/safety/safety_toyota.h-s/is_lkas_msg =.*;/is_lkas_msg = addr == 1 || addr == 2;/g-True]
8.48s call     panda/tests/misra/test_mutation.py::test_misra_mutation[board/stm32fx/llbxcan.h-s/1U/1/g-True]

(6 durations < 0.005s hidden.  Use -vv to show these durations.)
=================================================================== 4 passed in 9.97s ====================================================================
```