### PR TITLE
CI: Enable MISRA tests caching

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,6 +104,7 @@ jobs:
                           cd panda/tests/safety && \
                           ./test_coverage.sh"
 
+
   misra:
     name: MISRA C:2012
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: tests
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 concurrency:
@@ -103,7 +105,6 @@ jobs:
                           scons -j$(nproc) opendbc/ cereal/ && \
                           cd panda/tests/safety && \
                           ./test_coverage.sh"
-
 
   misra:
     name: MISRA C:2012

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup ci cache
-        if: setup-ci-cache
+        id: setup-ci-cache
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/ci_cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,6 @@ name: tests
 
 on:
   push:
-    branches:
-      - master
   pull_request:
 
 concurrency:
@@ -11,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  RUN: docker run -v ${{ github.workspace }}:/tmp/openpilot/panda -w /tmp/openpilot/panda --rm panda /bin/bash -c
+  RUN: docker run -v ${{ github.workspace }}:/tmp/openpilot/panda -w /tmp/openpilot/panda -v ${{ github.workspace }}/ci_cache/scons_cache:/tmp/scons_cache -v ${{ github.workspace }}/ci_cache/cppcheck_build:/tmp/cppcheck_build -e CI=1 --rm panda /bin/bash -c
   BUILD: |
       export DOCKER_BUILDKIT=1
       docker build --pull --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from ghcr.io/commaai/panda:latest -t panda -f Dockerfile .
@@ -112,6 +110,16 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
+      - name: Setup ci cache
+        if: setup-ci-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/ci_cache
+          key: ci_cache-${{ runner.os }}-${{ hashFiles('**/test_misra.sh') }}-${{ hashFiles('**/test_mutation.py') }}
+      - if: steps.setup-ci-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ${{ github.workspace }}/ci_cache/scons_cache
+          mkdir -p ${{ github.workspace }}/ci_cache/cppcheck_build
       - name: Build Docker image
         run: eval "$BUILD"
       - name: Build FW

--- a/SConscript
+++ b/SConscript
@@ -27,7 +27,7 @@ def objcopy(source, target, env, for_signature):
 
 def get_version(builder, build_type):
   try:
-    git = subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"], encoding='utf8').strip()
+    git = subprocess.check_output(["git", "rev-parse", "--short=8", "HEAD"], encoding='utf8').strip() if not os.getenv("CI") else ""
   except subprocess.CalledProcessError:
     git = "unknown"
   return f"{builder}-{git}-{build_type}"

--- a/SConstruct
+++ b/SConstruct
@@ -12,5 +12,9 @@ AddOption('--coverage',
           action='store_true',
           help='build with test coverage options')
 
+cache_dir = "/tmp/scons_cache"
+CacheDir(cache_dir)
+Clean(["."], cache_dir)
+
 # panda fw & test files
 SConscript('SConscript')


### PR DESCRIPTION
Enable caching both the scons build and the MISRA test (test_misra.sh and test_mutation.py), reducing the MISRA CI test from ~2m20 normally to [~40s](https://github.com/bongbui321/panda/actions/runs/7551529023/job/20558894429). This should be a good speedup for MISRA mutation test cases