### PR TITLE
Adding compilation_db to panda builds

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -101,7 +101,8 @@ def build_project(project_name, project, extra_flags):
     ASCOM="$AS $ASFLAGS -o $TARGET -c $SOURCES",
     BUILDERS={
       'Objcopy': Builder(generator=objcopy, suffix='.bin', src_suffix='.elf')
-    }
+    },
+    tools=["default", "compilation_db"],
   )
 
   startup = env.Object(f"obj/startup_{project_name}", project["STARTUP_FILE"])

--- a/SConstruct
+++ b/SConstruct
@@ -12,5 +12,17 @@ AddOption('--coverage',
           action='store_true',
           help='build with test coverage options')
 
+AddOption('--compile_db',
+          action='store_true',
+          help='build clang compilation database')
+
+env = Environment(
+  COMPILATIONDB_USE_ABSPATH=True,
+  tools=["default", "compilation_db"],
+)
+  
+if GetOption('compile_db'):
+    env.CompilationDatabase("compile_commands.json")
+
 # panda fw & test files
 SConscript('SConscript')


### PR DESCRIPTION
This brings the compilation_db command to panda as well. We currently have it on opnepilot and it helps setup IDEs nicely.

_This was first introduced in openpilot on https://github.com/commaai/openpilot/pull/19533 by @adeebshihadeh_

This MR basically brings that to panda and it has two ways it can work. 
1. When building as standalone the panda project, you can provide `--compile-db` same as in openpilot.
  a. This will create a `compile_commands.json` on the `panda` folder with only panda stuff. 
3. As part of building the openpilot project and panda is a submodule. By adding the tools to the env on the `panda/SConscript` we basically signal `SConstruct` to generate the compilation db for our stuff as well. 
  a. This will add to the `compile_commands.json` that openpilot generates on the openpilot folder. 