### PR TITLE
enable misra-c2012-8.2

### DIFF
--- a/board/safety.h
+++ b/board/safety.h
@@ -60,9 +60,7 @@ safety_config current_safety_config;
 bool safety_rx_hook(const CANPacket_t *to_push) {
   bool controls_allowed_prev = controls_allowed;
 
-  bool valid = rx_msg_safety_check(to_push, &current_safety_config, current_hooks->get_checksum,
-                                 current_hooks->compute_checksum, current_hooks->get_counter,
-                                 current_hooks->get_quality_flag_valid);
+  bool valid = rx_msg_safety_check(to_push, &current_safety_config, current_hooks);
   if (valid) {
     current_hooks->rx(to_push);
   }
@@ -223,36 +221,33 @@ void update_addr_timestamp(RxCheck addr_list[], int index) {
 }
 
 bool rx_msg_safety_check(const CANPacket_t *to_push,
-                       const safety_config *cfg,
-                       const get_checksum_t get_checksum,
-                       const compute_checksum_t compute_checksum,
-                       const get_counter_t get_counter,
-                       const get_quality_flag_valid_t get_quality_flag_valid) {
+                         const safety_config *cfg,
+                         const safety_hooks *safety_hooks) {
 
   int index = get_addr_check_index(to_push, cfg->rx_checks, cfg->rx_checks_len);
   update_addr_timestamp(cfg->rx_checks, index);
 
   if (index != -1) {
     // checksum check
-    if ((get_checksum != NULL) && (compute_checksum != NULL) && cfg->rx_checks[index].msg[cfg->rx_checks[index].status.index].check_checksum) {
-      uint32_t checksum = get_checksum(to_push);
-      uint32_t checksum_comp = compute_checksum(to_push);
+    if ((safety_hooks->get_checksum != NULL) && (safety_hooks->compute_checksum != NULL) && cfg->rx_checks[index].msg[cfg->rx_checks[index].status.index].check_checksum) {
+      uint32_t checksum = safety_hooks->get_checksum(to_push);
+      uint32_t checksum_comp = safety_hooks->compute_checksum(to_push);
       cfg->rx_checks[index].status.valid_checksum = checksum_comp == checksum;
     } else {
       cfg->rx_checks[index].status.valid_checksum = true;
     }
 
     // counter check (max_counter == 0 means skip check)
-    if ((get_counter != NULL) && (cfg->rx_checks[index].msg[cfg->rx_checks[index].status.index].max_counter > 0U)) {
-      uint8_t counter = get_counter(to_push);
+    if ((safety_hooks->get_counter != NULL) && (cfg->rx_checks[index].msg[cfg->rx_checks[index].status.index].max_counter > 0U)) {
+      uint8_t counter = safety_hooks->get_counter(to_push);
       update_counter(cfg->rx_checks, index, counter);
     } else {
       cfg->rx_checks[index].status.wrong_counters = 0U;
     }
 
     // quality flag check
-    if ((get_quality_flag_valid != NULL) && cfg->rx_checks[index].msg[cfg->rx_checks[index].status.index].quality_flag) {
-      cfg->rx_checks[index].status.valid_quality_flag = get_quality_flag_valid(to_push);
+    if ((safety_hooks->get_quality_flag_valid != NULL) && cfg->rx_checks[index].msg[cfg->rx_checks[index].status.index].quality_flag) {
+      cfg->rx_checks[index].status.valid_quality_flag = safety_hooks->get_quality_flag_valid(to_push);
     } else {
       cfg->rx_checks[index].status.valid_quality_flag = true;
     }

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -149,6 +149,22 @@ typedef uint32_t (*compute_checksum_t)(const CANPacket_t *to_push);
 typedef uint8_t (*get_counter_t)(const CANPacket_t *to_push);
 typedef bool (*get_quality_flag_valid_t)(const CANPacket_t *to_push);
 
+typedef safety_config (*safety_hook_init)(uint16_t param);
+typedef void (*rx_hook)(const CANPacket_t *to_push);
+typedef bool (*tx_hook)(const CANPacket_t *to_send);
+typedef int (*fwd_hook)(int bus_num, int addr);
+
+typedef struct {
+  safety_hook_init init;
+  rx_hook rx;
+  tx_hook tx;
+  fwd_hook fwd;
+  get_checksum_t get_checksum;
+  compute_checksum_t compute_checksum;
+  get_counter_t get_counter;
+  get_quality_flag_valid_t get_quality_flag_valid;
+} safety_hooks;
+
 bool safety_rx_hook(const CANPacket_t *to_push);
 bool safety_tx_hook(CANPacket_t *to_send);
 uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last);
@@ -175,11 +191,8 @@ void update_counter(RxCheck addr_list[], int index, uint8_t counter);
 void update_addr_timestamp(RxCheck addr_list[], int index);
 bool is_msg_valid(RxCheck addr_list[], int index);
 bool rx_msg_safety_check(const CANPacket_t *to_push,
-                         const safety_config *rx_checks,
-                         const get_checksum_t get_checksum,
-                         const compute_checksum_t compute_checksum,
-                         const get_counter_t get_counter,
-                         const get_quality_flag_valid_t get_quality_flag);
+                         const safety_config *cfg,
+                         const safety_hooks *safety_hooks);
 void generic_rx_checks(bool stock_ecu_detected);
 void relay_malfunction_set(void);
 void relay_malfunction_reset(void);
@@ -192,22 +205,6 @@ bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const Lo
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits);
 bool longitudinal_interceptor_checks(const CANPacket_t *to_send);
 void pcm_cruise_check(bool cruise_engaged);
-
-typedef safety_config (*safety_hook_init)(uint16_t param);
-typedef void (*rx_hook)(const CANPacket_t *to_push);
-typedef bool (*tx_hook)(const CANPacket_t *to_send);
-typedef int (*fwd_hook)(int bus_num, int addr);
-
-typedef struct {
-  safety_hook_init init;
-  rx_hook rx;
-  tx_hook tx;
-  fwd_hook fwd;
-  get_checksum_t get_checksum;
-  compute_checksum_t compute_checksum;
-  get_counter_t get_counter;
-  get_quality_flag_valid_t get_quality_flag_valid;
-} safety_hooks;
 
 void safety_tick(const safety_config *safety_config);
 

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -22,7 +22,6 @@ misra-config
 misra-c2012-1.2  # this is from the extensions (e.g. __typeof__) used in the MIN, MAX, ABS, and CLAMP macros
 misra-c2012-2.5
 misra-c2012-8.7
-misra-c2012-8.2
 misra-c2012-8.4
 misra-c2012-10.6
 misra-c2012-10.3


### PR DESCRIPTION
This is a bit of a workaround for what seems like a bug with cppcheck dumps dropping rx_msg_safety_check def arguments  after the first const function pointer type.
