### PR TITLE
Reset baudrate when connecting from Python

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -28,7 +28,6 @@ logging.basicConfig(level=LOGLEVEL, format='%(message)s')
 CANPACKET_HEAD_SIZE = 0x6
 DLC_TO_LEN = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]
 LEN_TO_DLC = {length: dlc for (dlc, length) in enumerate(DLC_TO_LEN)}
-PANDA_CAN_CNT = 3
 PANDA_BUS_CNT = 4
 
 


### PR DESCRIPTION
When a script changes the baudrate of the panda this becomes a persistent change until the panda is power cycled. This can cause other scripts to not work. This wasted me quite a bit of time debugging.

Moved the call to `can_reset_communications` to the connect function to make behavior consistent between creating a new panda object and calling `reset()`.

Feel free to close if you think this is intended behavior. This can also be solved by improving user feedback (e.g. printing a warning on connect).