### PR TITLE
safety: test with default pytest dist (load)

### DIFF
--- a/tests/safety/test.sh
+++ b/tests/safety/test.sh
@@ -7,5 +7,5 @@ cd $DIR
 HW_TYPES=( 6 9 )
 for hw_type in "${HW_TYPES[@]}"; do
   echo "Testing HW_TYPE: $hw_type"
-  HW_TYPE=$hw_type pytest -n auto --dist loadfile test_*.py -k 'not Base'
+  HW_TYPE=$hw_type pytest -n auto test_*.py -k 'not Base'
 done

--- a/tests/safety/test.sh
+++ b/tests/safety/test.sh
@@ -7,5 +7,5 @@ cd $DIR
 HW_TYPES=( 6 9 )
 for hw_type in "${HW_TYPES[@]}"; do
   echo "Testing HW_TYPE: $hw_type"
-  HW_TYPE=$hw_type pytest -n auto test_*.py -k 'not Base'
+  HW_TYPE=$hw_type pytest -n logical test_*.py -k 'not Base'
 done

--- a/tests/safety/test.sh
+++ b/tests/safety/test.sh
@@ -7,5 +7,5 @@ cd $DIR
 HW_TYPES=( 6 9 )
 for hw_type in "${HW_TYPES[@]}"; do
   echo "Testing HW_TYPE: $hw_type"
-  HW_TYPE=$hw_type pytest -n logical test_*.py -k 'not Base'
+  HW_TYPE=$hw_type pytest -n auto test_*.py -k 'not Base'
 done


### PR DESCRIPTION
distribute per test not per file

no faster in CI, but about 4 seconds faster per hw type locally with 16 procs (-n auto)