### PR TITLE
ELM safety: allow GM diagnostic camera address (0x24B)

### DIFF
--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -20,7 +20,7 @@ static bool elm327_tx_hook(const CANPacket_t *to_send) {
 
   // GM camera uses non-standard diagnostic address, this has no control message address collisions
   if ((addr == GM_CAMERA_DIAG_ADDR) && (len == 8)) {
-    // Only allow known frame types for ISO 15765-4
+    // Only allow known frame types for ISO 15765-2
     if ((GET_BYTE(to_send, 0) & 0xF0) > 0x30) {
       tx = false;
     }

--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -21,7 +21,7 @@ static bool elm327_tx_hook(const CANPacket_t *to_send) {
   // GM camera uses non-standard diagnostic address, this has no control message address collisions
   if ((addr == GM_CAMERA_DIAG_ADDR) && (len == 8)) {
     // Only allow known frame types for ISO 15765-2
-    if ((GET_BYTE(to_send, 0) & 0xF0U) > 0x30) {
+    if ((GET_BYTE(to_send, 0) & 0xF0U) > 0x30U) {
       tx = false;
     }
   }

--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -11,7 +11,7 @@ static bool elm327_tx_hook(const CANPacket_t *to_send) {
   // Check valid 29 bit send addresses for ISO 15765-4
   // Check valid 11 bit send addresses for ISO 15765-4
   if ((addr != 0x18DB33F1) && ((addr & 0x1FFF00FF) != 0x18DA00F1) &&
-      ((addr & 0x1FFFFF00) != 0x600) && ((addr & 0x1FFFFF00) != 0x700)) {
+      ((addr & 0x1FFFFF00) != 0x200) && ((addr & 0x1FFFFF00) != 0x600) && ((addr & 0x1FFFFF00) != 0x700)) {
     tx = false;
   }
   return tx;

--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -21,7 +21,7 @@ static bool elm327_tx_hook(const CANPacket_t *to_send) {
   // GM camera uses non-standard diagnostic address, this has no control message address collisions
   if ((addr == GM_CAMERA_DIAG_ADDR) && (len == 8)) {
     // Only allow known frame types for ISO 15765-2
-    if ((GET_BYTE(to_send, 0) & 0xF0) > 0x30) {
+    if ((GET_BYTE(to_send, 0) & 0xF0U) > 0x30) {
       tx = false;
     }
   }

--- a/board/safety/safety_elm327.h
+++ b/board/safety/safety_elm327.h
@@ -1,3 +1,5 @@
+const int GM_CAMERA_DIAG_ADDR = 0x24B;
+
 static bool elm327_tx_hook(const CANPacket_t *to_send) {
   bool tx = true;
   int addr = GET_ADDR(to_send);
@@ -11,8 +13,17 @@ static bool elm327_tx_hook(const CANPacket_t *to_send) {
   // Check valid 29 bit send addresses for ISO 15765-4
   // Check valid 11 bit send addresses for ISO 15765-4
   if ((addr != 0x18DB33F1) && ((addr & 0x1FFF00FF) != 0x18DA00F1) &&
-      ((addr & 0x1FFFFF00) != 0x200) && ((addr & 0x1FFFFF00) != 0x600) && ((addr & 0x1FFFFF00) != 0x700)) {
+      ((addr & 0x1FFFFF00) != 0x600) && ((addr & 0x1FFFFF00) != 0x700) &&
+      (addr != GM_CAMERA_DIAG_ADDR)) {
     tx = false;
+  }
+
+  // GM camera uses non-standard diagnostic address, this has no control message address collisions
+  if ((addr == GM_CAMERA_DIAG_ADDR) && (len == 8)) {
+    // Only allow known frame types for ISO 15765-4
+    if ((GET_BYTE(to_send, 0) & 0xF0) > 0x30) {
+      tx = false;
+    }
   }
   return tx;
 }

--- a/tests/misra/coverage_table
+++ b/tests/misra/coverage_table
@@ -1,11 +1,11 @@
 1.1     
-1.2     
+1.2     X (Addon)
 1.3     X (Cppcheck)
 2.1     X (Cppcheck)
-2.2     X (Cppcheck)
-2.3     
-2.4     
-2.5     
+2.2     X (Addon)
+2.3     X (Addon)
+2.4     X (Addon)
+2.5     X (Addon)
 2.6     X (Cppcheck)
 2.7     X (Addon)
 3.1     X (Addon)
@@ -17,45 +17,45 @@
 5.3     X (Cppcheck)
 5.4     X (Addon)
 5.5     X (Addon)
-5.6     
-5.7     
-5.8     
-5.9     
+5.6     X (Addon)
+5.7     X (Addon)
+5.8     X (Addon)
+5.9     X (Addon)
 6.1     X (Addon)
 6.2     X (Addon)
 7.1     X (Addon)
 7.2     X (Addon)
 7.3     X (Addon)
 7.4     X (Addon)
-8.1     
+8.1     X (Addon)
 8.2     X (Addon)
 8.3     X (Cppcheck)
-8.4     
-8.5     
-8.6     
-8.7     
-8.8     
-8.9     
-8.10    
+8.4     X (Addon)
+8.5     X (Addon)
+8.6     X (Addon)
+8.7     X (Addon)
+8.8     X (Addon)
+8.9     X (Addon)
+8.10    X (Addon)
 8.11    X (Addon)
 8.12    X (Addon)
-8.13    
+8.13    X (Cppcheck)
 8.14    X (Addon)
-9.1     
+9.1     X (Cppcheck)
 9.2     X (Addon)
 9.3     X (Addon)
 9.4     X (Addon)
 9.5     X (Addon)
 10.1    X (Addon)
 10.2    X (Addon)
-10.3    
+10.3    X (Addon)
 10.4    X (Addon)
-10.5    
+10.5    X (Addon)
 10.6    X (Addon)
-10.7    
+10.7    X (Addon)
 10.8    X (Addon)
-11.1    
-11.2    
+11.1    X (Addon)
+11.2    X (Addon)
 11.3    X (Addon)
 11.4    X (Addon)
 11.5    X (Addon)
@@ -66,7 +66,7 @@
 12.1    X (Addon)
 12.2    X (Addon)
 12.3    X (Addon)
-12.4    
+12.4    X (Addon)
 13.1    X (Addon)
 13.2    X (Cppcheck)
 13.3    X (Addon)
@@ -75,7 +75,7 @@
 13.6    X (Addon)
 14.1    X (Addon)
 14.2    X (Addon)
-14.3    
+14.3    X (Cppcheck)
 14.4    X (Addon)
 15.1    X (Addon)
 15.2    X (Addon)
@@ -84,7 +84,7 @@
 15.5    X (Addon)
 15.6    X (Addon)
 15.7    X (Addon)
-16.1    
+16.1    X (Addon)
 16.2    X (Addon)
 16.3    X (Addon)
 16.4    X (Addon)
@@ -93,8 +93,8 @@
 16.7    X (Addon)
 17.1    X (Addon)
 17.2    X (Addon)
-17.3    
-17.4    
+17.3    X (Addon)
+17.4    X (Cppcheck)
 17.5    X (Cppcheck)
 17.6    X (Addon)
 17.7    X (Addon)
@@ -107,7 +107,7 @@
 18.6    X (Cppcheck)
 18.7    X (Addon)
 18.8    X (Addon)
-19.1    
+19.1    X (Cppcheck)
 19.2    X (Addon)
 20.1    X (Addon)
 20.2    X (Addon)
@@ -116,15 +116,15 @@
 20.5    X (Addon)
 20.6    X (Cppcheck)
 20.7    X (Addon)
-20.8    
-20.9    
+20.8    X (Addon)
+20.9    X (Addon)
 20.10   X (Addon)
-20.11   
-20.12   
+20.11   X (Addon)
+20.12   X (Addon)
 20.13   X (Addon)
 20.14   X (Addon)
 21.1    X (Addon)
-21.2    
+21.2    X (Addon)
 21.3    X (Addon)
 21.4    X (Addon)
 21.5    X (Addon)
@@ -135,9 +135,22 @@
 21.10   X (Addon)
 21.11   X (Addon)
 21.12   X (Addon)
+21.13   X (Cppcheck)
+21.14   X (Addon)
+21.15   X (Addon)
+21.16   X (Addon)
+21.17   X (Cppcheck)
+21.18   X (Cppcheck)
+21.19   X (Addon)
+21.20   X (Addon)
+21.21   X (Addon)
 22.1    X (Cppcheck)
 22.2    X (Cppcheck)
-22.3    
+22.3    X (Cppcheck)
 22.4    X (Cppcheck)
-22.5    
+22.5    X (Addon)
 22.6    X (Cppcheck)
+22.7    X (Addon)
+22.8    X (Addon)
+22.9    X (Addon)
+22.10   X (Addon)

--- a/tests/misra/coverage_table
+++ b/tests/misra/coverage_table
@@ -1,11 +1,11 @@
 1.1     
-1.2     X (Addon)
+1.2     
 1.3     X (Cppcheck)
 2.1     X (Cppcheck)
-2.2     X (Addon)
-2.3     X (Addon)
-2.4     X (Addon)
-2.5     X (Addon)
+2.2     X (Cppcheck)
+2.3     
+2.4     
+2.5     
 2.6     X (Cppcheck)
 2.7     X (Addon)
 3.1     X (Addon)
@@ -17,45 +17,45 @@
 5.3     X (Cppcheck)
 5.4     X (Addon)
 5.5     X (Addon)
-5.6     X (Addon)
-5.7     X (Addon)
-5.8     X (Addon)
-5.9     X (Addon)
+5.6     
+5.7     
+5.8     
+5.9     
 6.1     X (Addon)
 6.2     X (Addon)
 7.1     X (Addon)
 7.2     X (Addon)
 7.3     X (Addon)
 7.4     X (Addon)
-8.1     X (Addon)
+8.1     
 8.2     X (Addon)
 8.3     X (Cppcheck)
-8.4     X (Addon)
-8.5     X (Addon)
-8.6     X (Addon)
-8.7     X (Addon)
-8.8     X (Addon)
-8.9     X (Addon)
-8.10    X (Addon)
+8.4     
+8.5     
+8.6     
+8.7     
+8.8     
+8.9     
+8.10    
 8.11    X (Addon)
 8.12    X (Addon)
-8.13    X (Cppcheck)
+8.13    
 8.14    X (Addon)
-9.1     X (Cppcheck)
+9.1     
 9.2     X (Addon)
 9.3     X (Addon)
 9.4     X (Addon)
 9.5     X (Addon)
 10.1    X (Addon)
 10.2    X (Addon)
-10.3    X (Addon)
+10.3    
 10.4    X (Addon)
-10.5    X (Addon)
+10.5    
 10.6    X (Addon)
-10.7    X (Addon)
+10.7    
 10.8    X (Addon)
-11.1    X (Addon)
-11.2    X (Addon)
+11.1    
+11.2    
 11.3    X (Addon)
 11.4    X (Addon)
 11.5    X (Addon)
@@ -66,7 +66,7 @@
 12.1    X (Addon)
 12.2    X (Addon)
 12.3    X (Addon)
-12.4    X (Addon)
+12.4    
 13.1    X (Addon)
 13.2    X (Cppcheck)
 13.3    X (Addon)
@@ -75,7 +75,7 @@
 13.6    X (Addon)
 14.1    X (Addon)
 14.2    X (Addon)
-14.3    X (Cppcheck)
+14.3    
 14.4    X (Addon)
 15.1    X (Addon)
 15.2    X (Addon)
@@ -84,7 +84,7 @@
 15.5    X (Addon)
 15.6    X (Addon)
 15.7    X (Addon)
-16.1    X (Addon)
+16.1    
 16.2    X (Addon)
 16.3    X (Addon)
 16.4    X (Addon)
@@ -93,8 +93,8 @@
 16.7    X (Addon)
 17.1    X (Addon)
 17.2    X (Addon)
-17.3    X (Addon)
-17.4    X (Cppcheck)
+17.3    
+17.4    
 17.5    X (Cppcheck)
 17.6    X (Addon)
 17.7    X (Addon)
@@ -107,7 +107,7 @@
 18.6    X (Cppcheck)
 18.7    X (Addon)
 18.8    X (Addon)
-19.1    X (Cppcheck)
+19.1    
 19.2    X (Addon)
 20.1    X (Addon)
 20.2    X (Addon)
@@ -116,15 +116,15 @@
 20.5    X (Addon)
 20.6    X (Cppcheck)
 20.7    X (Addon)
-20.8    X (Addon)
-20.9    X (Addon)
+20.8    
+20.9    
 20.10   X (Addon)
-20.11   X (Addon)
-20.12   X (Addon)
+20.11   
+20.12   
 20.13   X (Addon)
 20.14   X (Addon)
 21.1    X (Addon)
-21.2    X (Addon)
+21.2    
 21.3    X (Addon)
 21.4    X (Addon)
 21.5    X (Addon)
@@ -135,22 +135,9 @@
 21.10   X (Addon)
 21.11   X (Addon)
 21.12   X (Addon)
-21.13   X (Cppcheck)
-21.14   X (Addon)
-21.15   X (Addon)
-21.16   X (Addon)
-21.17   X (Cppcheck)
-21.18   X (Cppcheck)
-21.19   X (Addon)
-21.20   X (Addon)
-21.21   X (Addon)
 22.1    X (Cppcheck)
 22.2    X (Cppcheck)
-22.3    X (Cppcheck)
+22.3    
 22.4    X (Cppcheck)
-22.5    X (Addon)
+22.5    
 22.6    X (Cppcheck)
-22.7    X (Addon)
-22.8    X (Addon)
-22.9    X (Addon)
-22.10   X (Addon)

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -7,7 +7,7 @@ from panda import DLC_TO_LEN, Panda
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.test_defaults import TestDefaultRxHookBase
 
-GM_CAMERA_DIAG_ADDR = 0x24B
+GM_CAMERA_DIAG_ADDR = 0x24B  # frontview camera
 
 
 class TestElm327(TestDefaultRxHookBase):

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -11,7 +11,7 @@ GM_CAMERA_DIAG_ADDR = 0x24B
 
 
 class TestElm327(TestDefaultRxHookBase):
-  TX_MSGS = [[addr, bus] for addr in [0x24B, *range(0x600, 0x800),
+  TX_MSGS = [[addr, bus] for addr in [GM_CAMERA_DIAG_ADDR, *range(0x600, 0x800),
                                       *range(0x18DA00F1, 0x18DB00F1, 0x100),  # 29-bit UDS physical addressing
                                       *[0x18DB33F1],  # 29-bit UDS functional address
                                       ] for bus in range(4)]

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -9,7 +9,7 @@ from panda.tests.safety.test_defaults import TestDefaultRxHookBase
 
 
 class TestElm327(TestDefaultRxHookBase):
-  TX_MSGS = [[addr, bus] for addr in [*range(0x600, 0x800),
+  TX_MSGS = [[addr, bus] for addr in [*range(0x200, 0x300), *range(0x600, 0x800),
                                       *range(0x18DA00F1, 0x18DB00F1, 0x100),  # 29-bit UDS physical addressing
                                       *[0x18DB33F1],  # 29-bit UDS functional address
                                       ] for bus in range(4)]

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -33,16 +33,15 @@ class TestElm327(TestDefaultRxHookBase):
       should_tx = msg_len == 8
       self.assertEqual(should_tx, self._tx(common.make_msg(0, 0x700, msg_len)))
 
+    # TODO: perform this check for all addresses
+    # 4 to 15 are reserved ISO-TP frame types (https://en.wikipedia.org/wiki/ISO_15765-2)
+    for byte in range(0xff):
+      should_tx = (byte >> 4) <= 3
+      self.assertEqual(should_tx, self._tx(common.make_msg(0, GM_CAMERA_DIAG_ADDR, dat=bytes([byte] * 8))))
+
   def test_tx_hook_on_wrong_safety_mode(self):
     # No point, since we allow many diagnostic addresses
     pass
-
-  def test_gm_diagnostic_msg(self):
-    # TODO: perform this check for all addresses
-    for byte in range(0xff):
-      # 4 to 15 are reserved ISO-TP frame types (https://en.wikipedia.org/wiki/ISO_15765-2)
-      should_tx = (byte >> 4) <= 3
-      self.assertEqual(should_tx, self._tx(common.make_msg(0, GM_CAMERA_DIAG_ADDR, dat=bytes([byte] * 8))))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -7,7 +7,7 @@ from panda import DLC_TO_LEN, Panda
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.test_defaults import TestDefaultRxHookBase
 
-GM_CAMERA_DIAG_ADDR = 0x24B  # frontview camera
+GM_CAMERA_DIAG_ADDR = 0x24B
 
 
 class TestElm327(TestDefaultRxHookBase):

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -7,6 +7,8 @@ from panda import DLC_TO_LEN, Panda
 from panda.tests.libpanda import libpanda_py
 from panda.tests.safety.test_defaults import TestDefaultRxHookBase
 
+GM_CAMERA_DIAG_ADDR = 0x24B
+
 
 class TestElm327(TestDefaultRxHookBase):
   TX_MSGS = [[addr, bus] for addr in [0x24B, *range(0x600, 0x800),
@@ -24,7 +26,7 @@ class TestElm327(TestDefaultRxHookBase):
     for bus in range(4):
       for addr in self.SCANNED_ADDRS:
         should_tx = [addr, bus] in self.TX_MSGS
-        self.assertEqual(should_tx, self._tx(common.make_msg(bus, addr, 8)), (bus, addr))
+        self.assertEqual(should_tx, self._tx(common.make_msg(bus, addr, 8)))
 
     # ELM only allows 8 byte UDS/KWP messages under ISO 15765-4
     for msg_len in DLC_TO_LEN:
@@ -34,6 +36,13 @@ class TestElm327(TestDefaultRxHookBase):
   def test_tx_hook_on_wrong_safety_mode(self):
     # No point, since we allow many diagnostic addresses
     pass
+
+  def test_gm_diagnostic_msg(self):
+    # TODO: perform this check for all addresses
+    for byte in range(0xff):
+      # 4 to 15 are reserved ISO-TP frame types (https://en.wikipedia.org/wiki/ISO_15765-2)
+      should_tx = (byte >> 4) <= 3
+      self.assertEqual(should_tx, self._tx(common.make_msg(0, GM_CAMERA_DIAG_ADDR, dat=bytes([byte] * 8))))
 
 
 if __name__ == "__main__":

--- a/tests/safety/test_elm327.py
+++ b/tests/safety/test_elm327.py
@@ -9,7 +9,7 @@ from panda.tests.safety.test_defaults import TestDefaultRxHookBase
 
 
 class TestElm327(TestDefaultRxHookBase):
-  TX_MSGS = [[addr, bus] for addr in [*range(0x200, 0x300), *range(0x600, 0x800),
+  TX_MSGS = [[addr, bus] for addr in [0x24B, *range(0x600, 0x800),
                                       *range(0x18DA00F1, 0x18DB00F1, 0x100),  # 29-bit UDS physical addressing
                                       *[0x18DB33F1],  # 29-bit UDS functional address
                                       ] for bus in range(4)]
@@ -24,7 +24,7 @@ class TestElm327(TestDefaultRxHookBase):
     for bus in range(4):
       for addr in self.SCANNED_ADDRS:
         should_tx = [addr, bus] in self.TX_MSGS
-        self.assertEqual(should_tx, self._tx(common.make_msg(bus, addr, 8)))
+        self.assertEqual(should_tx, self._tx(common.make_msg(bus, addr, 8)), (bus, addr))
 
     # ELM only allows 8 byte UDS/KWP messages under ISO 15765-4
     for msg_len in DLC_TO_LEN:


### PR DESCRIPTION
Behind the OBD gateway, at the camera, 0x24b -> 0x64b is the only ECU that responds to tester present (camera). You can also see this range in GM's version of ISO-TP/UDS docs.