### PR TITLE
Fix CAN comment

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -136,7 +136,7 @@ void black_init(void) {
   // Set normal CAN mode
   black_set_can_mode(CAN_MODE_NORMAL);
 
-  // flip CAN0 and CAN2 if we are flipped
+  // change CAN mapping when flipped
   if (harness.status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
   }

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -168,7 +168,7 @@ void dos_init(void) {
   // Set normal CAN mode
   dos_set_can_mode(CAN_MODE_NORMAL);
 
-  // flip CAN0 and CAN2 if we are flipped
+  // change CAN mapping when flipped
   if (harness.status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
   }

--- a/board/boards/red.h
+++ b/board/boards/red.h
@@ -150,7 +150,7 @@ void red_init(void) {
   // Set normal CAN mode
   red_set_can_mode(CAN_MODE_NORMAL);
 
-  // flip CAN0 and CAN2 if we are flipped
+  // change CAN mapping when flipped
   if (harness.status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
   }

--- a/board/boards/red_chiplet.h
+++ b/board/boards/red_chiplet.h
@@ -133,7 +133,7 @@ void red_chiplet_init(void) {
   // Set normal CAN mode
   red_chiplet_set_can_mode(CAN_MODE_NORMAL);
 
-  // flip CAN0 and CAN2 if we are flipped
+  // change CAN mapping when flipped
   if (harness.status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
   }

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -161,7 +161,7 @@ void uno_init(void) {
   // Set normal CAN mode
   uno_set_can_mode(CAN_MODE_NORMAL);
 
-  // flip CAN0 and CAN2 if we are flipped
+  // change CAN mapping when flipped
   if (harness.status == HARNESS_STATUS_FLIPPED) {
     can_flip_buses(0, 2);
   }


### PR DESCRIPTION
In the rest of the codebase `CAN1`, `CAN2 `, `CAN3 `refer to stm32 peripheral only.
Don't use harness CAN bus labeling to avoid confusion with panda peripheral. 

