### PR TITLE
STM32f4 CAN initialization cleanup

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -94,6 +94,10 @@ bool black_check_ignition(void){
 void black_init(void) {
   common_init_gpio();
 
+  // B8,B9: normal CAN 1
+  set_gpio_alternate(GPIOB, 8, GPIO_AF8_CAN1);
+  set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
+
   // A8,A15: normal CAN3 mode
   set_gpio_alternate(GPIOA, 8, GPIO_AF11_CAN3);
   set_gpio_alternate(GPIOA, 15, GPIO_AF11_CAN3);

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -113,6 +113,10 @@ bool dos_read_som_gpio (void){
 void dos_init(void) {
   common_init_gpio();
 
+  // B8,B9: normal CAN 1
+  set_gpio_alternate(GPIOB, 8, GPIO_AF8_CAN1);
+  set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
+
   // A8,A15: normal CAN3 mode
   set_gpio_alternate(GPIOA, 8, GPIO_AF11_CAN3);
   set_gpio_alternate(GPIOA, 15, GPIO_AF11_CAN3);

--- a/board/boards/pedal.h
+++ b/board/boards/pedal.h
@@ -48,6 +48,10 @@ bool pedal_check_ignition(void){
 void pedal_init(void) {
   common_init_gpio();
 
+  // B8,B9: normal CAN 1
+  set_gpio_alternate(GPIOB, 8, GPIO_AF9_CAN1);
+  set_gpio_alternate(GPIOB, 9, GPIO_AF9_CAN1);
+
   // C0, C1: Throttle inputs
   set_gpio_mode(GPIOC, 0, MODE_ANALOG);
   set_gpio_mode(GPIOC, 1, MODE_ANALOG);

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -110,6 +110,10 @@ void uno_set_fan_enabled(bool enabled){
 void uno_init(void) {
   common_init_gpio();
 
+  // B8,B9: normal CAN 1
+  set_gpio_alternate(GPIOB, 8, GPIO_AF8_CAN1);
+  set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
+
   // A8,A15: normal CAN3 mode
   set_gpio_alternate(GPIOA, 8, GPIO_AF11_CAN3);
   set_gpio_alternate(GPIOA, 15, GPIO_AF11_CAN3);

--- a/board/boards/white.h
+++ b/board/boards/white.h
@@ -136,6 +136,10 @@ bool white_check_ignition(void){
 void white_grey_init(void) {
   common_init_gpio();
 
+  // B8,B9: normal CAN 1
+  set_gpio_alternate(GPIOB, 8, GPIO_AF8_CAN1);
+  set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
+
   // C3: current sense
   set_gpio_mode(GPIOC, 3, MODE_ANALOG);
 

--- a/board/jungle/boards/board_v1.h
+++ b/board/jungle/boards/board_v1.h
@@ -126,6 +126,10 @@ uint16_t board_v1_get_sbu_mV(uint8_t channel, uint8_t sbu) {
 void board_v1_init(void) {
   common_init_gpio();
 
+  // B8,B9: normal CAN 1
+  set_gpio_alternate(GPIOB, 8, GPIO_AF8_CAN1);
+  set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
+
   // A8,A15: normal CAN3 mode
   set_gpio_alternate(GPIOA, 8, GPIO_AF11_CAN3);
   set_gpio_alternate(GPIOA, 15, GPIO_AF11_CAN3);

--- a/board/stm32fx/peripherals.h
+++ b/board/stm32fx/peripherals.h
@@ -35,15 +35,6 @@ void common_init_gpio(void) {
   set_gpio_mode(GPIOC, 2, MODE_ANALOG);
 
   gpio_usb_init();
-
-   // B8,B9: CAN 1
-  #ifdef STM32F4
-    set_gpio_alternate(GPIOB, 8, GPIO_AF8_CAN1);
-    set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
-  #else
-    set_gpio_alternate(GPIOB, 8, GPIO_AF9_CAN1);
-    set_gpio_alternate(GPIOB, 9, GPIO_AF9_CAN1);
-  #endif
 }
 
 void flasher_peripherals_init(void) {


### PR DESCRIPTION
It's a small attempt to make those calls a little less spread out and keep CAN1,2,3 initializations in a single file.  It was easier to analyze for me.
Also removes `#ifdef STM32F4` which was only necessary for the pedal which uses `GPIO_AF9_CAN1`. 

See if you like, no big deal if closed.