### PR TITLE
Hardware pin names refactor

### DIFF
--- a/board/boards/black.h
+++ b/board/boards/black.h
@@ -107,8 +107,8 @@ void black_init(void) {
   set_gpio_output(GPIOC, 5, 0);
   set_gpio_output(GPIOC, 12, 0);
 
-  // C10: OBD_SBU1_RELAY (harness relay driving output)
-  // C11: OBD_SBU2_RELAY (harness relay driving output)
+  // C10: OBD_SBU1_SWITCH (switch driving harness relay)
+  // C11: OBD_SBU2_SWITCH (switch driving harness relay)
   set_gpio_mode(GPIOC, 10, MODE_OUTPUT);
   set_gpio_mode(GPIOC, 11, MODE_OUTPUT);
   set_gpio_output_type(GPIOC, 10, OUTPUT_TYPE_OPEN_DRAIN);
@@ -152,12 +152,12 @@ const harness_configuration black_harness_config = {
   .has_harness = true,
   .GPIO_SBU1 = GPIOC,
   .GPIO_SBU2 = GPIOC,
-  .GPIO_relay_SBU1 = GPIOC,
-  .GPIO_relay_SBU2 = GPIOC,
+  .GPIO_switch_SBU1 = GPIOC,
+  .GPIO_switch_SBU2 = GPIOC,
   .pin_SBU1 = 0,
   .pin_SBU2 = 3,
-  .pin_relay_SBU1 = 10,
-  .pin_relay_SBU2 = 11,
+  .pin_switch_SBU1 = 10,
+  .pin_switch_SBU2 = 11,
   .adc_channel_SBU1 = 10,
   .adc_channel_SBU2 = 13
 };

--- a/board/boards/dos.h
+++ b/board/boards/dos.h
@@ -122,8 +122,8 @@ void dos_init(void) {
   set_gpio_mode(GPIOC, 0, MODE_ANALOG);
   set_gpio_mode(GPIOC, 3, MODE_ANALOG);
 
-  // C10: OBD_SBU1_RELAY (harness relay driving output)
-  // C11: OBD_SBU2_RELAY (harness relay driving output)
+  // C10: OBD_SBU1_SWITCH (switch driving harness relay)
+  // C11: OBD_SBU2_SWITCH (switch driving harness relay)
   set_gpio_mode(GPIOC, 10, MODE_OUTPUT);
   set_gpio_mode(GPIOC, 11, MODE_OUTPUT);
   set_gpio_output_type(GPIOC, 10, OUTPUT_TYPE_OPEN_DRAIN);
@@ -181,12 +181,12 @@ const harness_configuration dos_harness_config = {
   .has_harness = true,
   .GPIO_SBU1 = GPIOC,
   .GPIO_SBU2 = GPIOC,
-  .GPIO_relay_SBU1 = GPIOC,
-  .GPIO_relay_SBU2 = GPIOC,
+  .GPIO_switch_SBU1 = GPIOC,
+  .GPIO_switch_SBU2 = GPIOC,
   .pin_SBU1 = 0,
   .pin_SBU2 = 3,
-  .pin_relay_SBU1 = 10,
-  .pin_relay_SBU2 = 11,
+  .pin_switch_SBU1 = 10,
+  .pin_switch_SBU2 = 11,
   .adc_channel_SBU1 = 10,
   .adc_channel_SBU2 = 13
 };

--- a/board/boards/red.h
+++ b/board/boards/red.h
@@ -99,7 +99,7 @@ bool red_check_ignition(void) {
 void red_init(void) {
   common_init_gpio();
 
-  //C10,C11 : OBD_SBU1_RELAY, OBD_SBU2_RELAY
+  //C10,C11 : OBD_SBU1_SWITCH, OBD_SBU2_SWITCH
   set_gpio_output_type(GPIOC, 10, OUTPUT_TYPE_OPEN_DRAIN);
   set_gpio_pullup(GPIOC, 10, PULL_NONE);
   set_gpio_mode(GPIOC, 10, MODE_OUTPUT);
@@ -160,12 +160,12 @@ const harness_configuration red_harness_config = {
   .has_harness = true,
   .GPIO_SBU1 = GPIOC,
   .GPIO_SBU2 = GPIOA,
-  .GPIO_relay_SBU1 = GPIOC,
-  .GPIO_relay_SBU2 = GPIOC,
+  .GPIO_switch_SBU1 = GPIOC,
+  .GPIO_switch_SBU2 = GPIOC,
   .pin_SBU1 = 4,
   .pin_SBU2 = 1,
-  .pin_relay_SBU1 = 10,
-  .pin_relay_SBU2 = 11,
+  .pin_switch_SBU1 = 10,
+  .pin_switch_SBU2 = 11,
   .adc_channel_SBU1 = 4, //ADC12_INP4
   .adc_channel_SBU2 = 17 //ADC1_INP17
 };

--- a/board/boards/red_chiplet.h
+++ b/board/boards/red_chiplet.h
@@ -84,7 +84,7 @@ void red_chiplet_set_fan_or_usb_load_switch(bool enabled) {
 void red_chiplet_init(void) {
   common_init_gpio();
 
-  // A8, A3: OBD_SBU1_RELAY, OBD_SBU2_RELAY
+  // A8, A3: OBD_SBU1_SWITCH, OBD_SBU2_SWITCH
   set_gpio_output_type(GPIOA, 8, OUTPUT_TYPE_OPEN_DRAIN);
   set_gpio_pullup(GPIOA, 8, PULL_NONE);
   set_gpio_output(GPIOA, 8, 1);
@@ -143,12 +143,12 @@ const harness_configuration red_chiplet_harness_config = {
   .has_harness = true,
   .GPIO_SBU1 = GPIOC,
   .GPIO_SBU2 = GPIOA,
-  .GPIO_relay_SBU1 = GPIOA,
-  .GPIO_relay_SBU2 = GPIOA,
+  .GPIO_switch_SBU1 = GPIOA,
+  .GPIO_switch_SBU2 = GPIOA,
   .pin_SBU1 = 4,
   .pin_SBU2 = 1,
-  .pin_relay_SBU1 = 8,
-  .pin_relay_SBU2 = 3,
+  .pin_switch_SBU1 = 8,
+  .pin_switch_SBU2 = 3,
   .adc_channel_SBU1 = 4, // ADC12_INP4
   .adc_channel_SBU2 = 17 // ADC1_INP17
 };

--- a/board/boards/uno.h
+++ b/board/boards/uno.h
@@ -124,8 +124,8 @@ void uno_init(void) {
   set_gpio_output(GPIOC, 5, 0);
   set_gpio_output(GPIOC, 12, 0);
 
-  // C10: OBD_SBU1_RELAY (harness relay driving output)
-  // C11: OBD_SBU2_RELAY (harness relay driving output)
+  // C10: OBD_SBU1_SWITCH (switch driving harness relay)
+  // C11: OBD_SBU2_SWITCH (switch driving harness relay)
   set_gpio_mode(GPIOC, 10, MODE_OUTPUT);
   set_gpio_mode(GPIOC, 11, MODE_OUTPUT);
   set_gpio_output_type(GPIOC, 10, OUTPUT_TYPE_OPEN_DRAIN);
@@ -188,12 +188,12 @@ const harness_configuration uno_harness_config = {
   .has_harness = true,
   .GPIO_SBU1 = GPIOC,
   .GPIO_SBU2 = GPIOC,
-  .GPIO_relay_SBU1 = GPIOC,
-  .GPIO_relay_SBU2 = GPIOC,
+  .GPIO_switch_SBU1 = GPIOC,
+  .GPIO_switch_SBU2 = GPIOC,
   .pin_SBU1 = 0,
   .pin_SBU2 = 3,
-  .pin_relay_SBU1 = 10,
-  .pin_relay_SBU2 = 11,
+  .pin_switch_SBU1 = 10,
+  .pin_switch_SBU2 = 11,
   .adc_channel_SBU1 = 10,
   .adc_channel_SBU2 = 13
 };

--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -25,8 +25,9 @@ struct harness_configuration {
   uint8_t adc_channel_SBU2;
 };
 
-// The ignition relay is only used for testing purposes
-void set_intercept_relay(bool intercept, bool ignition_relay) {
+// Intercept - drives a relay that severs CAN0 and CAN2 and puts Panda in the middle
+// Ignition test probe - only for debugging
+void set_intercept_relay(bool intercept, bool ignition_testprobe) {
   if (current_board->harness_config->has_harness) {
     bool drive_relay = intercept;
     if (harness.status == HARNESS_STATUS_NC) {
@@ -34,7 +35,7 @@ void set_intercept_relay(bool intercept, bool ignition_relay) {
       drive_relay = false;
     }
 
-    if (drive_relay || ignition_relay) {
+    if (drive_relay || ignition_testprobe) {
       harness.relay_driven = true;
     }
 
@@ -42,14 +43,14 @@ void set_intercept_relay(bool intercept, bool ignition_relay) {
     while (harness.sbu_adc_lock) {}
 
     if (harness.status == HARNESS_STATUS_NORMAL) {
-      set_gpio_output(current_board->harness_config->GPIO_switch_SBU1, current_board->harness_config->pin_switch_SBU1, !ignition_relay);
+      set_gpio_output(current_board->harness_config->GPIO_switch_SBU1, current_board->harness_config->pin_switch_SBU1, !ignition_testprobe);
       set_gpio_output(current_board->harness_config->GPIO_switch_SBU2, current_board->harness_config->pin_switch_SBU2, !drive_relay);
     } else {
       set_gpio_output(current_board->harness_config->GPIO_switch_SBU1, current_board->harness_config->pin_switch_SBU1, !drive_relay);
-      set_gpio_output(current_board->harness_config->GPIO_switch_SBU2, current_board->harness_config->pin_switch_SBU2, !ignition_relay);
+      set_gpio_output(current_board->harness_config->GPIO_switch_SBU2, current_board->harness_config->pin_switch_SBU2, !ignition_testprobe);
     }
 
-    if (!(drive_relay || ignition_relay)) {
+    if (!(drive_relay || ignition_testprobe)) {
       harness.relay_driven = false;
     }
   }

--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -15,12 +15,12 @@ struct harness_configuration {
   const bool has_harness;
   GPIO_TypeDef *GPIO_SBU1;
   GPIO_TypeDef *GPIO_SBU2;
-  GPIO_TypeDef *GPIO_relay_SBU1;
-  GPIO_TypeDef *GPIO_relay_SBU2;
+  GPIO_TypeDef *GPIO_switch_SBU1;
+  GPIO_TypeDef *GPIO_switch_SBU2;
   uint8_t pin_SBU1;
   uint8_t pin_SBU2;
-  uint8_t pin_relay_SBU1;
-  uint8_t pin_relay_SBU2;
+  uint8_t pin_switch_SBU1;
+  uint8_t pin_switch_SBU2;
   uint8_t adc_channel_SBU1;
   uint8_t adc_channel_SBU2;
 };
@@ -42,11 +42,11 @@ void set_intercept_relay(bool intercept, bool ignition_relay) {
     while (harness.sbu_adc_lock) {}
 
     if (harness.status == HARNESS_STATUS_NORMAL) {
-      set_gpio_output(current_board->harness_config->GPIO_relay_SBU1, current_board->harness_config->pin_relay_SBU1, !ignition_relay);
-      set_gpio_output(current_board->harness_config->GPIO_relay_SBU2, current_board->harness_config->pin_relay_SBU2, !drive_relay);
+      set_gpio_output(current_board->harness_config->GPIO_switch_SBU1, current_board->harness_config->pin_switch_SBU1, !ignition_relay);
+      set_gpio_output(current_board->harness_config->GPIO_switch_SBU2, current_board->harness_config->pin_switch_SBU2, !drive_relay);
     } else {
-      set_gpio_output(current_board->harness_config->GPIO_relay_SBU1, current_board->harness_config->pin_relay_SBU1, !drive_relay);
-      set_gpio_output(current_board->harness_config->GPIO_relay_SBU2, current_board->harness_config->pin_relay_SBU2, !ignition_relay);
+      set_gpio_output(current_board->harness_config->GPIO_switch_SBU1, current_board->harness_config->pin_switch_SBU1, !drive_relay);
+      set_gpio_output(current_board->harness_config->GPIO_switch_SBU2, current_board->harness_config->pin_switch_SBU2, !ignition_relay);
     }
 
     if (!(drive_relay || ignition_relay)) {

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -941,8 +941,8 @@ class Panda:
   def set_clock_source_period(self, period):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xe6, period, 0, b'')
 
-  def force_relay_drive(self, intercept_relay_drive, ignition_relay_drive):
-    self._handle.controlWrite(Panda.REQUEST_OUT, 0xc5, (int(intercept_relay_drive) | int(ignition_relay_drive) << 1), 0, b'')
+  def force_relay_drive(self, intercept_relay_drive, ignition_testprobe):
+    self._handle.controlWrite(Panda.REQUEST_OUT, 0xc5, (int(intercept_relay_drive) | int(ignition_testprobe) << 1), 0, b'')
 
   def read_som_gpio(self) -> bool:
     r = self._handle.controlRead(Panda.REQUEST_IN, 0xc6, 0, 0, 1)


### PR DESCRIPTION
1. Why I changed "sbu relay" to "switch"? 
SBUs lines are driving the relay, yes, but it is more logical to use "switch" since each SBU has its own transistor activated depending on cable rotation. Yes, transistor can be called relay, but it's better to say "switch" which separates it from the mechanical relay in the harness.

3. Why I changed "Ignition relay" to "Ignition test probe"?
Because by the same logic as with "harness relay", this implied there was a second relay (or a transistor) that can be driven. But there isn't anything that can be switched.  All this does, is pulls harness sbu2 line voltage higher.  

