### PR TITLE
USB-C cable orientation clarification

### DIFF
--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -95,6 +95,7 @@ uint8_t harness_detect_orientation(void) {
         ret = HARNESS_STATUS_FLIPPED;
       } else {
         // orientation normal (PANDA_SBU2->HARNESS_SBU1(relay), PANDA_SBU1->HARNESS_SBU2(ign))
+        // (SBU1->SBU2 is the normal orientation connection per USB-C cable spec)
         ret = HARNESS_STATUS_NORMAL;
       }
     } else {


### PR DESCRIPTION
USB-C internally routes sbu1 to sbu2 in the default orientation.  This single comment should reduce the confusion about meaning of flipped/normal OBD-C . 


Background:
I was designing OBD2 adapter for OBD-C and needed to understand exactly relationship between OpenPilot buses, STM32 peripherals, and harness buses.
![image](https://github.com/commaai/panda/assets/841061/b78c84d4-3cd9-4716-8436-33f6e41397bf)
Unfortunately there was [conflicting](https://github.com/lukasloetkolben/OpenpilotHardware/pull/1) information from the community. Ultimately, [finding out](https://github.com/commaai/panda/pull/435#issuecomment-1928036952) how USB-C cables are built was the key to understanding. Also I can confirm accuracy of the comma [documentation](https://github.com/commaai/neo/blob/master/car_harness/OBD-C.sch.pdf). 