### PR TITLE
invoke system browser for coverage reports

### DIFF
--- a/tests/safety/test_coverage.sh
+++ b/tests/safety/test_coverage.sh
@@ -12,7 +12,7 @@ scons -j$(nproc) -D --coverage
 if [ "$1" == "--report" ]; then
   geninfo ../libpanda/ -o coverage.info
   genhtml coverage.info -o coverage-out
-  browse coverage-out/index.html
+  sensible-browser coverage-out/index.html
 fi
 
 # test coverage


### PR DESCRIPTION
Invokes the native browser for baremetal/virtual Ubuntu, and the Windows browser for WSL users.