### PR TITLE
fix pytest loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,7 @@ ignore = ["W292", "E741", "E402", "C408", "ISC003"]
 line-length = 160
 target-version="py311"
 flake8-implicit-str-concat.allow-multiline=false
+
+[tool.pytest.ini_options]
+# FIXME: pytest 8.0.0 now collects all files, stop pytest-cpp from running these
+addopts = "--ignore=test.sh --ignore=test_coverage.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,4 @@ flake8-implicit-str-concat.allow-multiline=false
 
 [tool.pytest.ini_options]
 # FIXME: pytest 8.0.0 now collects all files, stop pytest-cpp from running these
-addopts = "--ignore=test.sh --ignore=test_coverage.sh"
+addopts = "--ignore=test.sh --ignore=test_coverage.sh -n auto -k 'not Base'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,4 @@ flake8-implicit-str-concat.allow-multiline=false
 
 [tool.pytest.ini_options]
 # FIXME: pytest 8.0.0 now collects all files, stop pytest-cpp from running these
-addopts = "--ignore=test.sh --ignore=test_coverage.sh -n auto -k 'not Base'"
+addopts = "--ignore=test.sh --ignore=test_coverage.sh"


### PR DESCRIPTION
In pytest 8.0.0, it collects all files, even if you only specify one file to run. Then pytest-cpp will execute these two files since they are executable (an issue if you have openpilot's environment)

[Relevant issue](https://github.com/pytest-dev/pytest/issues/11974)