### PR TITLE
Make MISRA results consistent across cppcheck runs

### DIFF
--- a/board/can_comms.h
+++ b/board/can_comms.h
@@ -68,9 +68,8 @@ void comms_can_write(const uint8_t *data, uint32_t len) {
       can_write_buffer.ptr += can_write_buffer.tail_size;
       pos += can_write_buffer.tail_size;
 
-      void *addr= &to_push;
       // send out
-      (void)memcpy(addr, can_write_buffer.data, can_write_buffer.ptr);
+      (void)memcpy(&to_push, can_write_buffer.data, can_write_buffer.ptr);
       can_send(&to_push, to_push.bus, false);
 
       // reset overflow buffer

--- a/board/can_comms.h
+++ b/board/can_comms.h
@@ -68,8 +68,9 @@ void comms_can_write(const uint8_t *data, uint32_t len) {
       can_write_buffer.ptr += can_write_buffer.tail_size;
       pos += can_write_buffer.tail_size;
 
+      void *addr= &to_push;
       // send out
-      (void)memcpy(&to_push, can_write_buffer.data, can_write_buffer.ptr);
+      (void)memcpy(addr, can_write_buffer.data, can_write_buffer.ptr);
       can_send(&to_push, to_push.bus, false);
 
       // reset overflow buffer

--- a/tests/misra/.gitignore
+++ b/tests/misra/.gitignore
@@ -1,4 +1,5 @@
 *.pdf
 *.txt
+.output.log
 new_table
 cppcheck/

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -29,18 +29,18 @@ if [ -z "${SKIP_BUILD}" ]; then
 fi
 
 cppcheck() {
+  # note that cppcheck build cache results in inconsistent results as of v2.13.0
+  OUTPUT=$DIR/.output.log
   $CPPCHECK_DIR/cppcheck --enable=all --force --inline-suppr -I $PANDA_DIR/board/ \
           -I $gcc_inc "$(arm-none-eabi-gcc -print-file-name=include)" \
           --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
           --suppress=*:*include/* --error-exitcode=2 --addon=misra \
-          --check-level=exhaustive "$@" |& tee /tmp/output.log
-  
-  if grep "misra violation" /tmp/output.log > /dev/null
-  then
-    rm /tmp/output.log
+          --check-level=exhaustive "$@" |& tee $OUTPUT
+
+  # cppcheck bug: some MISRA errors won't result in the error exit code,
+  # so check the output (https://trac.cppcheck.net/ticket/12440#no1)
+  if grep "misra violation" $OUTPUT > /dev/null; then
     exit 1
-  else
-    rm /tmp/output.log
   fi
 }
 

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -37,10 +37,10 @@ cppcheck() {
   
   if grep "misra violation" /tmp/output.log > /dev/null
   then
-    rm -r /tmp/output.log
+    rm -f /tmp/output.log
     exit 1
   else
-    rm -r /tmp/output.log
+    rm -f /tmp/output.log
   fi
 }
 

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -32,7 +32,7 @@ cppcheck() {
   $CPPCHECK_DIR/cppcheck --enable=all --force --inline-suppr -I $PANDA_DIR/board/ \
           -I $gcc_inc "$(arm-none-eabi-gcc -print-file-name=include)" \
           --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
-          --suppress=*:*include/* --error-exitcode=2 --addon=misra.py \
+          --suppress=*:*include/* --error-exitcode=2 --addon=misra \
           --check-level=exhaustive "$@" |& tee /tmp/output.log
   
   if grep "misra violation" /tmp/output.log > /dev/null

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -37,10 +37,10 @@ cppcheck() {
   
   if grep "misra violation" /tmp/output.log > /dev/null
   then
-    rm -f /tmp/output.log
+    rm /tmp/output.log
     exit 1
   else
-    rm -f /tmp/output.log
+    rm /tmp/output.log
   fi
 }
 

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -48,9 +48,9 @@ printf "\n${GREEN}** PANDA F4 CODE **${NC}\n"
 cppcheck -DCAN3 -DPANDA -DSTM32F4 -UPEDAL -DUID_BASE $PANDA_DIR/board/main.c
 
 printf "\n${GREEN}** PANDA H7 CODE **${NC}\n"
-cppcheck -DCAN3 -DPANDA -DSTM32H7 -UPEDAL -DUID_BASE $PANDA_DIR/board/main.c  
+cppcheck -DCAN3 -DPANDA -DSTM32H7 -UPEDAL -DUID_BASE $PANDA_DIR/board/main.c
 
 printf "\n${GREEN}** PEDAL CODE **${NC}\n"
-cppcheck -UCAN3 -UPANDA -DSTM32F2 -DPEDAL -UUID_BASE $PANDA_DIR/board/pedal/main.c 
+cppcheck -UCAN3 -UPANDA -DSTM32F2 -DPEDAL -UUID_BASE $PANDA_DIR/board/pedal/main.c
 
 printf "\n${GREEN}Success!${NC} took $SECONDS seconds\n"

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -5,7 +5,6 @@ import pytest
 import shutil
 import subprocess
 import tempfile
-import hashlib
 import random
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -68,25 +67,19 @@ for p in patterns:
 
 @pytest.mark.parametrize("fn, patch, should_fail", mutations)
 def test_misra_mutation(fn, patch, should_fail):
-  key = hashlib.md5((str(fn) + str(patch)).encode()).hexdigest()
-  tmp = os.path.join(tempfile.gettempdir(), key)
+  with tempfile.TemporaryDirectory() as tmp:
+    shutil.copytree(ROOT, tmp, dirs_exist_ok=True)
 
-  if os.path.exists(tmp):
-    shutil.rmtree(tmp)
-  shutil.copytree(ROOT, tmp)
+    # apply patch
+    if fn is not None:
+      r = os.system(f"cd {tmp} && sed -i '{patch}' {fn}")
+      assert r == 0
 
-  # apply patch
-  if fn is not None:
-    r = os.system(f"cd {tmp} && sed -i '{patch}' {fn}")
-    assert r == 0
-
-  # run test
-  env = {'SKIP_BUILD': '1'} | os.environ.copy()
-  r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True, env=env)
-  failed = r.returncode != 0
-  assert failed == should_fail
-
-  shutil.rmtree(tmp)
+    # run test
+    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    failed = r.returncode != 0
+    assert failed == should_fail
 
 if __name__ == "__main__":
   pytest.main([__file__, "-n 8"])

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -82,4 +82,4 @@ def test_misra_mutation(fn, patch, should_fail):
     assert failed == should_fail
 
 if __name__ == "__main__":
-  pytest.main([__file__, "-n 4"])
+  pytest.main([__file__, "-n 8"])

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -76,8 +76,7 @@ def test_misra_mutation(fn, patch, should_fail):
       assert r == 0
 
     # run test
-    env = {'SKIP_BUILD': '1'} | os.environ.copy()
-    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True, env=env)
+    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
     failed = r.returncode != 0
     assert failed == should_fail
 

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -82,4 +82,4 @@ def test_misra_mutation(fn, patch, should_fail):
     assert failed == should_fail
 
 if __name__ == "__main__":
-  pytest.main([__file__, "-n 8"])
+  pytest.main([__file__, "-n 4"])

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -76,7 +76,8 @@ def test_misra_mutation(fn, patch, should_fail):
       assert r == 0
 
     # run test
-    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
+    env = {'SKIP_BUILD': '1'} | os.environ.copy()
+    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True, env=env)
     failed = r.returncode != 0
     assert failed == should_fail
 

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -76,8 +76,7 @@ def test_misra_mutation(fn, patch, should_fail):
       assert r == 0
 
     # run test
-    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True,
-                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
     failed = r.returncode != 0
     assert failed == should_fail
 


### PR DESCRIPTION
For #1847

Update on the [issue](https://trac.cppcheck.net/ticket/12440):
After some communication with the cppchecker team, it seems that specific misra violations return 0 with the both cases: 
- running the misra addon directly over the dump 
- running it with the `--addon` flag. 

Hence to exit when we find any misra violation, I have decided to grep the output log for `misra violation`