### PR TITLE
refactor GET_BIT to be MISRA friendly

### DIFF
--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -185,7 +185,7 @@ static void chrysler_rx_hook(const CANPacket_t *to_push) {
   // enter controls on rising edge of ACC, exit controls on ACC off
   const int das_3_bus = (chrysler_platform == CHRYSLER_PACIFICA) ? 0 : 2;
   if ((bus == das_3_bus) && (addr == chrysler_addrs->DAS_3)) {
-    bool cruise_engaged = GET_BIT(to_push, 21U) == 1U;
+    bool cruise_engaged = GET_BIT(to_push, 21U);
     pcm_cruise_check(cruise_engaged);
   }
 
@@ -226,7 +226,13 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
     const SteeringLimits limits = (chrysler_platform == CHRYSLER_PACIFICA) ? CHRYSLER_STEERING_LIMITS :
                                   (chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_STEERING_LIMITS : CHRYSLER_RAM_HD_STEERING_LIMITS;
 
-    bool steer_req = (chrysler_platform == CHRYSLER_PACIFICA) ? (GET_BIT(to_send, 4U) != 0U) : ((GET_BYTE(to_send, 3) & 0x7U) == 2U);
+    bool steer_req = false;
+    if (chrysler_platform == CHRYSLER_PACIFICA) {
+      steer_req = GET_BIT(to_send, 4U);
+    } else {
+      steer_req = (GET_BYTE(to_send, 3) & 0x7U) == 2U;
+    }
+
     if (steer_torque_cmd_checks(desired_torque, steer_req, limits)) {
       tx = false;
     }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -227,7 +227,6 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
                                   (chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_STEERING_LIMITS : CHRYSLER_RAM_HD_STEERING_LIMITS;
 
     bool steer_req = (chrysler_platform == CHRYSLER_PACIFICA) ? GET_BIT(to_send, 4U) : (GET_BYTE(to_send, 3) & 0x7U) == 2U;
-
     if (steer_torque_cmd_checks(desired_torque, steer_req, limits)) {
       tx = false;
     }

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -226,12 +226,7 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
     const SteeringLimits limits = (chrysler_platform == CHRYSLER_PACIFICA) ? CHRYSLER_STEERING_LIMITS :
                                   (chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_STEERING_LIMITS : CHRYSLER_RAM_HD_STEERING_LIMITS;
 
-    bool steer_req = false;
-    if (chrysler_platform == CHRYSLER_PACIFICA) {
-      steer_req = GET_BIT(to_send, 4U);
-    } else {
-      steer_req = (GET_BYTE(to_send, 3) & 0x7U) == 2U;
-    }
+    bool steer_req = (chrysler_platform == CHRYSLER_PACIFICA) ? GET_BIT(to_send, 4U) : (GET_BYTE(to_send, 3) & 0x7U) == 2U;
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, limits)) {
       tx = false;

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -280,7 +280,7 @@ static bool ford_tx_hook(const CANPacket_t *to_send) {
     // Signal: AccBrkTot_A_Rq
     int accel = ((GET_BYTE(to_send, 0) & 0x1FU) << 8) | GET_BYTE(to_send, 1);
     // Signal: CmbbDeny_B_Actl
-    int cmbb_deny = GET_BIT(to_send, 37U);
+    bool cmbb_deny = GET_BIT(to_send, 37U);
 
     bool violation = false;
     violation |= longitudinal_accel_checks(accel, FORD_LONG_LIMITS);
@@ -288,7 +288,7 @@ static bool ford_tx_hook(const CANPacket_t *to_send) {
     violation |= longitudinal_gas_checks(gas_pred, FORD_LONG_LIMITS);
 
     // Safety check for stock AEB
-    violation |= cmbb_deny != 0; // do not prevent stock AEB actuation
+    violation |= cmbb_deny; // do not prevent stock AEB actuation
 
     if (violation) {
       tx = false;
@@ -302,8 +302,8 @@ static bool ford_tx_hook(const CANPacket_t *to_send) {
     // Violation if resume button is pressed while controls not allowed, or
     // if cancel button is pressed when cruise isn't engaged.
     bool violation = false;
-    violation |= (GET_BIT(to_send, 8U) == 1U) && !cruise_engaged_prev;   // Signal: CcAslButtnCnclPress (cancel)
-    violation |= (GET_BIT(to_send, 25U) == 1U) && !controls_allowed;     // Signal: CcAsllButtnResPress (resume)
+    violation |= GET_BIT(to_send, 8U) && !cruise_engaged_prev;   // Signal: CcAslButtnCnclPress (cancel)
+    violation |= GET_BIT(to_send, 25U) && !controls_allowed;     // Signal: CcAsllButtnResPress (resume)
 
     if (violation) {
       tx = false;

--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -108,7 +108,7 @@ static void gm_rx_hook(const CANPacket_t *to_push) {
     }
 
     if ((addr == 0xC9) && (gm_hw == GM_CAM)) {
-      brake_pressed = GET_BIT(to_push, 40U) != 0U;
+      brake_pressed = GET_BIT(to_push, 40U);
     }
 
     if (addr == 0x1C4) {
@@ -153,7 +153,7 @@ static bool gm_tx_hook(const CANPacket_t *to_send) {
     int desired_torque = ((GET_BYTE(to_send, 0) & 0x7U) << 8) + GET_BYTE(to_send, 1);
     desired_torque = to_signed(desired_torque, 11);
 
-    bool steer_req = (GET_BIT(to_send, 3U) != 0U);
+    bool steer_req = GET_BIT(to_send, 3U);
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, GM_STEERING_LIMITS)) {
       tx = false;
@@ -162,7 +162,7 @@ static bool gm_tx_hook(const CANPacket_t *to_send) {
 
   // GAS/REGEN: safety check
   if (addr == 0x2CB) {
-    bool apply = GET_BIT(to_send, 0U) != 0U;
+    bool apply = GET_BIT(to_send, 0U);
     int gas_regen = ((GET_BYTE(to_send, 2) & 0x7FU) << 5) + ((GET_BYTE(to_send, 3) & 0xF8U) >> 3);
 
     bool violation = false;

--- a/board/safety/safety_honda.h
+++ b/board/safety/safety_honda.h
@@ -166,7 +166,7 @@ static void honda_rx_hook(const CANPacket_t *to_push) {
 
   // enter controls when PCM enters cruise state
   if (pcm_cruise && (addr == 0x17C)) {
-    const bool cruise_engaged = GET_BIT(to_push, 38U) != 0U;
+    const bool cruise_engaged = GET_BIT(to_push, 38U);
     // engage on rising edge
     if (cruise_engaged && !cruise_engaged_prev) {
       controls_allowed = true;
@@ -207,13 +207,13 @@ static void honda_rx_hook(const CANPacket_t *to_push) {
   // accord, crv: 0x1BE
   if (honda_alt_brake_msg) {
     if (addr == 0x1BE) {
-      brake_pressed = GET_BIT(to_push, 4U) != 0U;
+      brake_pressed = GET_BIT(to_push, 4U);
     }
   } else {
     if (addr == 0x17C) {
       // also if brake switch is 1 for two CAN frames, as brake pressed is delayed
-      const bool brake_switch = GET_BIT(to_push, 32U) != 0U;
-      brake_pressed = (GET_BIT(to_push, 53U) != 0U) || (brake_switch && honda_brake_switch_prev);
+      const bool brake_switch = GET_BIT(to_push, 32U);
+      brake_pressed = (GET_BIT(to_push, 53U)) || (brake_switch && honda_brake_switch_prev);
       honda_brake_switch_prev = brake_switch;
     }
   }
@@ -234,7 +234,7 @@ static void honda_rx_hook(const CANPacket_t *to_push) {
   // disable stock Honda AEB in alternative experience
   if (!(alternative_experience & ALT_EXP_DISABLE_STOCK_AEB)) {
     if ((bus == 2) && (addr == 0x1FA)) {
-      bool honda_stock_aeb = GET_BIT(to_push, 29U) != 0U;
+      bool honda_stock_aeb = GET_BIT(to_push, 29U);
       int honda_stock_brake = (GET_BYTE(to_push, 0) << 2) | (GET_BYTE(to_push, 1) >> 6);
 
       // Forward AEB when stock braking is higher than openpilot braking
@@ -383,7 +383,7 @@ static safety_config honda_nidec_init(uint16_t param) {
   enable_gas_interceptor = GET_FLAG(param, HONDA_PARAM_GAS_INTERCEPTOR);
 
   safety_config ret;
-  
+
   bool enable_nidec_alt = GET_FLAG(param, HONDA_PARAM_NIDEC_ALT);
   if (enable_nidec_alt) {
     enable_gas_interceptor ? SET_RX_CHECKS(honda_nidec_alt_interceptor_rx_checks, ret) : \

--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -186,15 +186,15 @@ static void hyundai_canfd_rx_hook(const CANPacket_t *to_push) {
     if ((addr == 0x35) && hyundai_ev_gas_signal) {
       gas_pressed = GET_BYTE(to_push, 5) != 0U;
     } else if ((addr == 0x105) && hyundai_hybrid_gas_signal) {
-      gas_pressed = (GET_BIT(to_push, 103U) != 0U) || (GET_BYTE(to_push, 13) != 0U) || (GET_BIT(to_push, 112U) != 0U);
+      gas_pressed = GET_BIT(to_push, 103U) || (GET_BYTE(to_push, 13) != 0U) || GET_BIT(to_push, 112U);
     } else if ((addr == 0x100) && !hyundai_ev_gas_signal && !hyundai_hybrid_gas_signal) {
-      gas_pressed = GET_BIT(to_push, 176U) != 0U;
+      gas_pressed = GET_BIT(to_push, 176U);
     } else {
     }
 
     // brake press
     if (addr == 0x175) {
-      brake_pressed = GET_BIT(to_push, 81U) != 0U;
+      brake_pressed = GET_BIT(to_push, 81U);
     }
 
     // vehicle moving
@@ -235,7 +235,7 @@ static bool hyundai_canfd_tx_hook(const CANPacket_t *to_send) {
   const int steer_addr = (hyundai_canfd_hda2 && !hyundai_longitudinal) ? hyundai_canfd_hda2_get_lkas_addr() : 0x12a;
   if (addr == steer_addr) {
     int desired_torque = (((GET_BYTE(to_send, 6) & 0xFU) << 7U) | (GET_BYTE(to_send, 5) >> 1U)) - 1024U;
-    bool steer_req = GET_BIT(to_send, 52U) != 0U;
+    bool steer_req = GET_BIT(to_send, 52U);
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, HYUNDAI_CANFD_STEERING_LIMITS)) {
       tx = false;

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -152,7 +152,7 @@ static void subaru_rx_hook(const CANPacket_t *to_push) {
 
   // enter controls on rising edge of ACC, exit controls on ACC off
   if ((addr == MSG_SUBARU_CruiseControl) && (bus == alt_main_bus)) {
-    bool cruise_engaged = GET_BIT(to_push, 41U) != 0U;
+    bool cruise_engaged = GET_BIT(to_push, 41U);
     pcm_cruise_check(cruise_engaged);
   }
 
@@ -169,7 +169,7 @@ static void subaru_rx_hook(const CANPacket_t *to_push) {
   }
 
   if ((addr == MSG_SUBARU_Brake_Status) && (bus == alt_main_bus)) {
-    brake_pressed = GET_BIT(to_push, 62U) != 0U;
+    brake_pressed = GET_BIT(to_push, 62U);
   }
 
   if ((addr == MSG_SUBARU_Throttle) && (bus == SUBARU_MAIN_BUS)) {
@@ -189,7 +189,7 @@ static bool subaru_tx_hook(const CANPacket_t *to_send) {
     int desired_torque = ((GET_BYTES(to_send, 0, 4) >> 16) & 0x1FFFU);
     desired_torque = -1 * to_signed(desired_torque, 13);
 
-    bool steer_req = GET_BIT(to_send, 29U) != 0U;
+    bool steer_req = GET_BIT(to_send, 29U);
 
     const SteeringLimits limits = subaru_gen2 ? SUBARU_GEN2_STEERING_LIMITS : SUBARU_STEERING_LIMITS;
     violation |= steer_torque_cmd_checks(desired_torque, steer_req, limits);
@@ -204,7 +204,7 @@ static bool subaru_tx_hook(const CANPacket_t *to_send) {
   // check es_distance cruise_throttle limits
   if (addr == MSG_SUBARU_ES_Distance) {
     int cruise_throttle = (GET_BYTES(to_send, 2, 2) & 0x1FFFU);
-    bool cruise_cancel = GET_BIT(to_send, 56U) != 0U;
+    bool cruise_cancel = GET_BIT(to_send, 56U);
 
     if (subaru_longitudinal) {
       violation |= longitudinal_gas_checks(cruise_throttle, SUBARU_LONG_LIMITS);

--- a/board/safety/safety_subaru_preglobal.h
+++ b/board/safety/safety_subaru_preglobal.h
@@ -56,7 +56,7 @@ static void subaru_preglobal_rx_hook(const CANPacket_t *to_push) {
 
     // enter controls on rising edge of ACC, exit controls on ACC off
     if (addr == MSG_SUBARU_PG_CruiseControl) {
-      bool cruise_engaged = GET_BIT(to_push, 49U) != 0U;
+      bool cruise_engaged = GET_BIT(to_push, 49U);
       pcm_cruise_check(cruise_engaged);
     }
 
@@ -86,7 +86,7 @@ static bool subaru_preglobal_tx_hook(const CANPacket_t *to_send) {
     int desired_torque = ((GET_BYTES(to_send, 0, 4) >> 8) & 0x1FFFU);
     desired_torque = -1 * to_signed(desired_torque, 13);
 
-    bool steer_req = (GET_BIT(to_send, 24U) != 0U);
+    bool steer_req = GET_BIT(to_send, 24U);
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, SUBARU_PG_STEERING_LIMITS)) {
       tx = false;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -138,7 +138,7 @@ static bool toyota_get_quality_flag_valid(const CANPacket_t *to_push) {
 
   bool valid = false;
   if (addr == 0x260) {
-    valid = GET_BIT(to_push, 3U) == 0U;  // STEER_ANGLE_INITIALIZING
+    valid = !GET_BIT(to_push, 3U);  // STEER_ANGLE_INITIALIZING
   }
   return valid;
 }
@@ -169,7 +169,7 @@ static void toyota_rx_hook(const CANPacket_t *to_push) {
 
       // LTA request angle should match current angle while inactive, clipped to max accepted angle.
       // note that angle can be relative to init angle on some TSS2 platforms, LTA has the same offset
-      bool steer_angle_initializing = GET_BIT(to_push, 3U) != 0U;
+      bool steer_angle_initializing = GET_BIT(to_push, 3U);
       if (!steer_angle_initializing) {
         int angle_meas_new = (GET_BYTE(to_push, 3) << 8U) | GET_BYTE(to_push, 4);
         angle_meas_new = CLAMP(to_signed(angle_meas_new, 16), -TOYOTA_LTA_MAX_ANGLE, TOYOTA_LTA_MAX_ANGLE);
@@ -181,12 +181,12 @@ static void toyota_rx_hook(const CANPacket_t *to_push) {
     // exit controls on rising edge of gas press
     if (addr == 0x1D2) {
       // 5th bit is CRUISE_ACTIVE
-      bool cruise_engaged = GET_BIT(to_push, 5U) != 0U;
+      bool cruise_engaged = GET_BIT(to_push, 5U);
       pcm_cruise_check(cruise_engaged);
 
       // sample gas pedal
       if (!enable_gas_interceptor) {
-        gas_pressed = GET_BIT(to_push, 4U) == 0U;
+        gas_pressed = !GET_BIT(to_push, 4U);
       }
     }
 
@@ -207,7 +207,7 @@ static void toyota_rx_hook(const CANPacket_t *to_push) {
     // most cars have brake_pressed on 0x226, corolla and rav4 on 0x224
     if (((addr == 0x224) && toyota_alt_brake) || ((addr == 0x226) && !toyota_alt_brake)) {
       uint8_t bit = (addr == 0x224) ? 5U : 37U;
-      brake_pressed = GET_BIT(to_push, bit) != 0U;
+      brake_pressed = GET_BIT(to_push, bit);
     }
 
     // sample gas interceptor
@@ -252,7 +252,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
 
       // only ACC messages that cancel are allowed when openpilot is not controlling longitudinal
       if (toyota_stock_longitudinal) {
-        bool cancel_req = GET_BIT(to_send, 24U) != 0U;
+        bool cancel_req = GET_BIT(to_send, 24U);
         if (!cancel_req) {
           violation = true;
         }
@@ -278,8 +278,8 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
     // LTA angle steering check
     if (addr == 0x191) {
       // check the STEER_REQUEST, STEER_REQUEST_2, TORQUE_WIND_DOWN, STEER_ANGLE_CMD signals
-      bool lta_request = GET_BIT(to_send, 0U) != 0U;
-      bool lta_request2 = GET_BIT(to_send, 25U) != 0U;
+      bool lta_request = GET_BIT(to_send, 0U);
+      bool lta_request2 = GET_BIT(to_send, 25U);
       int torque_wind_down = GET_BYTE(to_send, 5);
       int lta_angle = (GET_BYTE(to_send, 1) << 8) | GET_BYTE(to_send, 2);
       lta_angle = to_signed(lta_angle, 16);
@@ -327,7 +327,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
     if (addr == 0x2E4) {
       int desired_torque = (GET_BYTE(to_send, 1) << 8) | GET_BYTE(to_send, 2);
       desired_torque = to_signed(desired_torque, 16);
-      bool steer_req = GET_BIT(to_send, 0U) != 0U;
+      bool steer_req = GET_BIT(to_send, 0U);
       // When using LTA (angle control), assert no actuation on LKA message
       if (!toyota_lta) {
         if (steer_torque_cmd_checks(desired_torque, steer_req, TOYOTA_STEERING_LIMITS)) {

--- a/board/safety/safety_volkswagen_mqb.h
+++ b/board/safety/safety_volkswagen_mqb.h
@@ -170,7 +170,7 @@ static void volkswagen_mqb_rx_hook(const CANPacket_t *to_push) {
       }
       // Always exit controls on rising edge of Cancel
       // Signal: GRA_ACC_01.GRA_Abbrechen
-      if (GET_BIT(to_push, 13U) == 1U) {
+      if (GET_BIT(to_push, 13U)) {
         controls_allowed = false;
       }
     }
@@ -210,7 +210,7 @@ static bool volkswagen_mqb_tx_hook(const CANPacket_t *to_send) {
       desired_torque *= -1;
     }
 
-    bool steer_req = GET_BIT(to_send, 30U) != 0U;
+    bool steer_req = GET_BIT(to_send, 30U);
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, VOLKSWAGEN_MQB_STEERING_LIMITS)) {
       tx = false;

--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -141,7 +141,7 @@ static void volkswagen_pq_rx_hook(const CANPacket_t *to_push) {
         volkswagen_resume_button_prev = resume_button;
         // Exit controls on rising edge of Cancel, override Set/Resume if present simultaneously
         // Signal: GRA_ACC_01.GRA_Abbrechen
-        if (GET_BIT(to_push, 9U) == 1U) {
+        if (GET_BIT(to_push, 9U)) {
           controls_allowed = false;
         }
       }

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define GET_BIT(msg, b) (((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U)
+#define GET_BIT(msg, b) (!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
 #define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask))
 

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define GET_BIT(msg, b) (!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
+#define GET_BIT(msg, b) ((bool)!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
 #define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask))
 


### PR DESCRIPTION
Refactor GET_BIT to return a `bool`, which makes it easier to use while maintaining MISRA compliance.

Cast directly from an int to a bool doesn't work, but old-school double-negation does the job and seems to be permitted. It did leave a [single breakage in the Chrysler port](https://github.com/commaai/panda/pull/1877/commits/a2e87257a8a220fd0bca707957c34e1759b479d3). While MISRA 10.4 does make specific mention of matching essential types on both sides of a ternary op, it's not clear why it didn't think both sides were the same here. An additional cast to bool worked, so there may be a subtlety between Boolean and _essentially_ Boolean types, or perhaps a bug in the type checker.