### PR TITLE
fix forwarded bus logging for CAN-FD hardware

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -126,7 +126,7 @@ void process_can(uint8_t can_number) {
           to_push.rejected = 0U;
           to_push.extended = to_send.extended;
           to_push.addr = to_send.addr;
-          to_push.bus = to_send.bus;
+          to_push.bus = bus_number;
           to_push.data_len_code = to_send.data_len_code;
           (void)memcpy(to_push.data, to_send.data, dlc_to_len[to_push.data_len_code]);
           can_set_checksum(&to_push);


### PR DESCRIPTION
For CAN-FD hardware, fix forwarded-to bus logging over USB/SPI to match [earlier hardware](https://github.com/commaai/panda/blob/70578a11f06a280e5f877d70e8998ba4ff001377/board/drivers/bxcan.h#L91). Actual forwarding happens correctly, but on USB/SPI it's currently logged with the received bus and should be the target bus.

**Broken:** `f39cf149898833ff/2024-02-15--17-27-50/0`

**Fixed:** `f39cf149898833ff/2024-02-22--01-17-23/0`