### PR TITLE
VW PQ: Allow either HCA mode

### DIFF
--- a/board/safety/safety_volkswagen_pq.h
+++ b/board/safety/safety_volkswagen_pq.h
@@ -185,7 +185,7 @@ static bool volkswagen_pq_tx_hook(const CANPacket_t *to_send) {
     }
 
     uint32_t hca_status = ((GET_BYTE(to_send, 1) >> 4) & 0xFU);
-    bool steer_req = (hca_status == 5U);
+    bool steer_req = ((hca_status == 5U) || (hca_status == 7U));
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, VOLKSWAGEN_PQ_STEERING_LIMITS)) {
       tx = false;

--- a/tests/safety/test_volkswagen_pq.py
+++ b/tests/safety/test_volkswagen_pq.py
@@ -69,8 +69,8 @@ class TestVolkswagenPqSafety(common.PandaCarSafetyTest, common.DriverTorqueSteer
     return self.packer.make_can_msg_panda("Lenkhilfe_3", 0, values)
 
   # openpilot steering output torque
-  def _torque_cmd_msg(self, torque, steer_req=1):
-    values = {"LM_Offset": abs(torque), "LM_OffSign": torque < 0, "HCA_Status": 5 if steer_req else 3}
+  def _torque_cmd_msg(self, torque, steer_req=1, hca_status=5):
+    values = {"LM_Offset": abs(torque), "LM_OffSign": torque < 0, "HCA_Status": hca_status if steer_req else 3}
     return self.packer.make_can_msg_panda("HCA_1", 0, values)
 
   # ACC engagement and brake light switch status
@@ -188,6 +188,12 @@ class TestVolkswagenPqLongSafety(TestVolkswagenPqSafety, common.LongitudinalAcce
     self._rx(self._motor_5_msg(main_switch=False))
     self.assertFalse(self.safety.get_controls_allowed(), "controls allowed after ACC main switch off")
 
+  def test_torque_cmd_enable_variants(self):
+    # The EPS rack accepts either 5 or 7 for an enabled status, with different low speed tuning behavior
+    self.safety.set_controls_allowed(1)
+    for enabled_status in (5, 7):
+      self.assertTrue(self._tx(self._torque_cmd_msg(self.MAX_RATE_UP, steer_req=1, hca_status=enabled_status)),
+                      f"torque cmd rejected with {enabled_status=}")
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
This is #1670 but now with a test. Won't be used immediately in stock openpilot, but will allow forks to explore tuning the other control variant. It's not yet been made to behave super well, but there's interesting potential.

PQ only. It's technically documented for MQB as well, but on the vehicles we tested, the EPS acts like it has no maps for it.