### PR TITLE
Ford: ignore 2nd speed checksum

### DIFF
--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -92,9 +92,11 @@ static uint32_t ford_get_checksum(const CANPacket_t *to_push) {
   if (addr == FORD_BrakeSysFeatures) {
     // Signal: VehVActlBrk_No_Cs
     chksum = GET_BYTE(to_push, 3);
+  /*
   } else if (addr == FORD_EngVehicleSpThrottle2) {
     // Signal: VehVActlEng_No_Cs
     chksum = GET_BYTE(to_push, 1);
+  */
   } else if (addr == FORD_Yaw_Data_FD1) {
     // Signal: VehRollYawW_No_Cs
     chksum = GET_BYTE(to_push, 4);
@@ -112,11 +114,13 @@ static uint32_t ford_compute_checksum(const CANPacket_t *to_push) {
     chksum += GET_BYTE(to_push, 2) >> 6;                    // VehVActlBrk_D_Qf
     chksum += (GET_BYTE(to_push, 2) >> 2) & 0xFU;           // VehVActlBrk_No_Cnt
     chksum = 0xFFU - chksum;
+  /*
   } else if (addr == FORD_EngVehicleSpThrottle2) {
     chksum += (GET_BYTE(to_push, 2) >> 3) & 0xFU;           // VehVActlEng_No_Cnt
     chksum += (GET_BYTE(to_push, 4) >> 5) & 0x3U;           // VehVActlEng_D_Qf
     chksum += GET_BYTE(to_push, 6) + GET_BYTE(to_push, 7);  // Veh_V_ActlEng
     chksum = 0xFFU - chksum;
+  */
   } else if (addr == FORD_Yaw_Data_FD1) {
     chksum += GET_BYTE(to_push, 0) + GET_BYTE(to_push, 1);  // VehRol_W_Actl
     chksum += GET_BYTE(to_push, 2) + GET_BYTE(to_push, 3);  // VehYaw_W_Actl

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -59,9 +59,9 @@ const CanMsg FORD_CANFD_LONG_TX_MSGS[] = {
 // this may be the cause of blocked messages
 RxCheck ford_rx_checks[] = {
   {.msg = {{FORD_BrakeSysFeatures, 0, 8, .check_checksum = true, .max_counter = 15U, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
-  // TODO: FORD_EngVehicleSpThrottle2 has a counter that either randomly skips or by 2, understand and enable counter check
-  // Some hybrid models experience a bug where this checksum mismatches for one or two frames under heavy acceleration with ACC
-  // It has been confirmed that the Bronco Sport's camera only disallows ACC for bad quality flags, not counters or checksums, so match that
+  // FORD_EngVehicleSpThrottle2 has a counter that either randomly skips or by 2, likely ECU bug
+  // Some hybrid models experience also a bug where this checksum mismatches for one or two frames under heavy acceleration with ACC
+  // It has been confirmed that the Bronco Sport's camera only disallows ACC for bad quality flags, not counters or checksums, so we match that
   {.msg = {{FORD_EngVehicleSpThrottle2, 0, 8, .check_checksum = false, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
   {.msg = {{FORD_Yaw_Data_FD1, 0, 8, .check_checksum = true, .max_counter = 255U, .quality_flag=true, .frequency = 100U}, { 0 }, { 0 }}},
   // These messages have no counter or checksum
@@ -92,11 +92,6 @@ static uint32_t ford_get_checksum(const CANPacket_t *to_push) {
   if (addr == FORD_BrakeSysFeatures) {
     // Signal: VehVActlBrk_No_Cs
     chksum = GET_BYTE(to_push, 3);
-  /*
-  } else if (addr == FORD_EngVehicleSpThrottle2) {
-    // Signal: VehVActlEng_No_Cs
-    chksum = GET_BYTE(to_push, 1);
-  */
   } else if (addr == FORD_Yaw_Data_FD1) {
     // Signal: VehRollYawW_No_Cs
     chksum = GET_BYTE(to_push, 4);
@@ -114,13 +109,6 @@ static uint32_t ford_compute_checksum(const CANPacket_t *to_push) {
     chksum += GET_BYTE(to_push, 2) >> 6;                    // VehVActlBrk_D_Qf
     chksum += (GET_BYTE(to_push, 2) >> 2) & 0xFU;           // VehVActlBrk_No_Cnt
     chksum = 0xFFU - chksum;
-  /*
-  } else if (addr == FORD_EngVehicleSpThrottle2) {
-    chksum += (GET_BYTE(to_push, 2) >> 3) & 0xFU;           // VehVActlEng_No_Cnt
-    chksum += (GET_BYTE(to_push, 4) >> 5) & 0x3U;           // VehVActlEng_D_Qf
-    chksum += GET_BYTE(to_push, 6) + GET_BYTE(to_push, 7);  // Veh_V_ActlEng
-    chksum = 0xFFU - chksum;
-  */
   } else if (addr == FORD_Yaw_Data_FD1) {
     chksum += GET_BYTE(to_push, 0) + GET_BYTE(to_push, 1);  // VehRol_W_Actl
     chksum += GET_BYTE(to_push, 2) + GET_BYTE(to_push, 3);  // VehYaw_W_Actl

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -60,7 +60,7 @@ const CanMsg FORD_CANFD_LONG_TX_MSGS[] = {
 RxCheck ford_rx_checks[] = {
   {.msg = {{FORD_BrakeSysFeatures, 0, 8, .check_checksum = true, .max_counter = 15U, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
   // FORD_EngVehicleSpThrottle2 has a counter that either randomly skips or by 2, likely ECU bug
-  // Some hybrid models experience also a bug where this checksum mismatches for one or two frames under heavy acceleration with ACC
+  // Some hybrid models also experience a bug where this checksum mismatches for one or two frames under heavy acceleration with ACC
   // It has been confirmed that the Bronco Sport's camera only disallows ACC for bad quality flags, not counters or checksums, so we match that
   {.msg = {{FORD_EngVehicleSpThrottle2, 0, 8, .check_checksum = false, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
   {.msg = {{FORD_Yaw_Data_FD1, 0, 8, .check_checksum = true, .max_counter = 255U, .quality_flag=true, .frequency = 100U}, { 0 }, { 0 }}},

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -59,8 +59,10 @@ const CanMsg FORD_CANFD_LONG_TX_MSGS[] = {
 // this may be the cause of blocked messages
 RxCheck ford_rx_checks[] = {
   {.msg = {{FORD_BrakeSysFeatures, 0, 8, .check_checksum = true, .max_counter = 15U, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
-  // TODO: FORD_EngVehicleSpThrottle2 has a counter that skips by 2, understand and enable counter check
-  {.msg = {{FORD_EngVehicleSpThrottle2, 0, 8, .check_checksum = true, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
+  // TODO: FORD_EngVehicleSpThrottle2 has a counter that either randomly skips or by 2, understand and enable counter check
+  // Some hybrid models experience a bug where this checksum mismatches for one or two frames under heavy acceleration with ACC
+  // It has been confirmed that the Bronco Sport's camera only disallows ACC for bad quality flags, not counters or checksums, so match that
+  {.msg = {{FORD_EngVehicleSpThrottle2, 0, 8, .check_checksum = false, .quality_flag=true, .frequency = 50U}, { 0 }, { 0 }}},
   {.msg = {{FORD_Yaw_Data_FD1, 0, 8, .check_checksum = true, .max_counter = 255U, .quality_flag=true, .frequency = 100U}, { 0 }, { 0 }}},
   // These messages have no counter or checksum
   {.msg = {{FORD_EngBrakeData, 0, 8, .frequency = 10U}, { 0 }, { 0 }}},

--- a/tests/safety/test_ford.py
+++ b/tests/safety/test_ford.py
@@ -215,11 +215,11 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
           self.assertEqual(quality_flag, self._rx(to_push))
           self.assertEqual(quality_flag, self.safety.get_controls_allowed())
 
-        # Mess with checksum to make it fail
-        to_push[0].data[1] = 0  # Speed 2 checksum
+        # Mess with checksum to make it fail, checksum is not checked for 2nd speed
         to_push[0].data[3] = 0  # Speed checksum & half of yaw signal
-        self.assertFalse(self._rx(to_push))
-        self.assertFalse(self.safety.get_controls_allowed())
+        should_rx = msg == "speed_2" and quality_flag
+        self.assertEqual(should_rx, self._rx(to_push))
+        self.assertEqual(should_rx, self.safety.get_controls_allowed())
 
   def test_rx_hook_speed_mismatch(self):
     # Ford relies on speed for driver curvature limiting, so it checks two sources


### PR DESCRIPTION
We can't check the counter because on some platforms, it skips seemingly randomly. Both on the side the gateway that openpilot is on, and behind the gateway directly on HSCAN2 - bd37e43731e5964b|2023-06-02--20-53-11

Confirmed that the checksum mismatches are also present on the other side of the gateway https://discord.com/channels/469524606043160576/1114344869314429039/1210771260225622109

![image](https://github.com/commaai/panda/assets/25857203/6c0a3582-aa5e-4e2b-85ab-8e290254b6fe)

