### PR TITLE
723 power init

### DIFF
--- a/board/stm32h7/clock.h
+++ b/board/stm32h7/clock.h
@@ -21,11 +21,13 @@ void clock_init(void) {
   // Set power mode to direct SMPS power supply(depends on the board layout)
 #ifndef STM32H723
   register_set(&(PWR->CR3), PWR_CR3_SMPSEN, 0xFU); // powered only by SMPS
+#else
+  register_set(&(PWR->CR3), PWR_CR3_LDOEN, 0xFU);
+#endif
   // Set VOS level (VOS3 to 170Mhz, VOS2 to 300Mhz, VOS1 to 400Mhz, VOS0 to 550Mhz)
   register_set(&(PWR->D3CR), PWR_D3CR_VOS_1 | PWR_D3CR_VOS_0, 0xC000U); //VOS1, needed for 80Mhz CAN FD
   while ((PWR->CSR1 & PWR_CSR1_ACTVOSRDY) == 0);
   while ((PWR->CSR1 & PWR_CSR1_ACTVOS) != (PWR->D3CR & PWR_D3CR_VOS)); // check that VOS level was actually set
-#endif
 
   // Configure Flash ACR register LATENCY and WRHIGHFREQ (VOS0 range!)
   register_set(&(FLASH->ACR), FLASH_ACR_LATENCY_2WS | 0x20U, 0x3FU); // VOS2, AXI 100MHz-150MHz


### PR DESCRIPTION
First byte of `PWR->CR3` is locked after the first write, so we can't init all H7 with the LDO, then switch to SMPS if available. We'll have to figure out another way to detect package or panda type before this init.