### PR TITLE
jungle: assume F4 MCU

### DIFF
--- a/board/jungle/__init__.py
+++ b/board/jungle/__init__.py
@@ -80,6 +80,12 @@ class PandaJungle(Panda):
       return McuType.F4
     elif hw_type in PandaJungle.H7_DEVICES:
       return McuType.H7
+    else:
+      # have to assume F4, see comment in Panda.connect
+      # initially Jungle V1 has HW type: bytearray(b'')
+      if hw_type == b'' or self._assume_f4_mcu:
+        return McuType.F4
+
     raise ValueError(f"unknown HW type: {hw_type}")
 
   def up_to_date(self, fn=None) -> bool:


### PR DESCRIPTION
On the panda jungle that I received, when trying to flash it, I was getting:
```
./flash.py
...
Traceback (most recent call last):
  File "/home/gutek/openpilot/panda/board/jungle/./flash.py", line 16, in <module>
    with PandaJungle(serial=s) as p:
         ^^^^^^^^^^^^^^^^^^^^^
  File "/home/gutek/openpilot/panda/python/__init__.py", line 244, in __init__
    self.connect(claim)
  File "/home/gutek/openpilot/panda/python/__init__.py", line 294, in connect
    self._mcu_type = self.get_mcu_type()
                     ^^^^^^^^^^^^^^^^^^^
  File "/home/gutek/openpilot/panda/board/jungle/__init__.py", line 99, in get_mcu_type
    raise ValueError(f"unknown HW type: {hw_type}")
ValueError: unknown HW type: bytearray(b'')
```

My solution is to assume that it's **McuType.F4** `if hw_type == b'' or self._assume_f4_mcu`.

Just setting `if hw_type == b''` doesn't work since immediately after it has `hw_type = b'\xff\x00\xc1\x3e\xde\xad\xd0\x0d\x00\x00\x00\x00' which is (already) detected by `self._assume_f4_mcu` if checked.

So, with this change, it works succesfully:
```
./flash.py
...
flash: unlocking
flash: erasing sectors 1 - 4
flash: flashing
flash: resetting
```
Not sure it's totally correct, but I can change it according to feedback. This will help other people hitting this problem.