### PR TITLE
Defining types in return dictionaries

### DIFF
--- a/python/ccp.py
+++ b/python/ccp.py
@@ -3,6 +3,30 @@ import time
 import struct
 from enum import IntEnum, Enum
 
+from typing import TypedDict, Optional
+
+class ExchangeStationIdsReturn(TypedDict):
+    id_length: int
+    data_type: int
+    available: int  
+    protected: int  
+
+class GetDaqListSizeReturn(TypedDict):
+    list_size: int
+    first_pid: int
+
+class GetSessionStatusReturn(TypedDict):
+    status: int
+    info: Optional[int]   
+
+class DiagnosticServiceReturn(TypedDict):
+    length: int
+    type: int
+
+class ActionServiceReturn(TypedDict):
+    length: int
+    type: int
+
 class COMMAND_CODE(IntEnum):
   CONNECT = 0x01
   SET_MTA = 0x02
@@ -140,10 +164,10 @@ class CcpClient():
     self._send_cro(COMMAND_CODE.CONNECT, struct.pack("<H", station_addr))
     self._recv_dto(0.025)
 
-  def exchange_station_ids(self, device_id_info: bytes = b"") -> dict:
+  def exchange_station_ids(self, device_id_info: bytes = b"") -> ExchangeStationIdsReturn:
     self._send_cro(COMMAND_CODE.EXCHANGE_ID, device_id_info)
     resp = self._recv_dto(0.025)
-    return { # TODO: define a type
+    return { 
       "id_length": resp[0],
       "data_type": resp[1],
       "available": resp[2],
@@ -211,12 +235,12 @@ class CcpClient():
     self._send_cro(COMMAND_CODE.SELECT_CAL_PAGE)
     self._recv_dto(0.025)
 
-  def get_daq_list_size(self, list_num: int, can_id: int = 0) -> dict:
+  def get_daq_list_size(self, list_num: int, can_id: int = 0) -> GetDaqListSizeReturn:
     if list_num > 255:
       raise ValueError("list number must be less than 256")
     self._send_cro(COMMAND_CODE.GET_DAQ_SIZE, bytes([list_num, 0]) + struct.pack(f"{self.byte_order.value}I", can_id))
     resp = self._recv_dto(0.025)
-    return { # TODO: define a type
+    return { 
       "list_size": resp[0],
       "first_pid": resp[1],
     }
@@ -266,10 +290,10 @@ class CcpClient():
     self._send_cro(COMMAND_CODE.SET_S_STATUS, bytes([status]))
     self._recv_dto(0.025)
 
-  def get_session_status(self) -> dict:
+  def get_session_status(self) -> GetSessionStatusReturn:
     self._send_cro(COMMAND_CODE.GET_S_STATUS)
     resp = self._recv_dto(0.025)
-    return { # TODO: define a type
+    return { 
       "status": resp[0],
       "info": resp[2] if resp[1] else None,
     }
@@ -310,26 +334,26 @@ class CcpClient():
     self._send_cro(COMMAND_CODE.MOVE, struct.pack(f"{self.byte_order.value}I", size))
     self._recv_dto(0.025)
 
-  def diagnostic_service(self, service_num: int, data: bytes = b"") -> dict:
+  def diagnostic_service(self, service_num: int, data: bytes = b"") -> DiagnosticServiceReturn:
     if service_num > 65535:
       raise ValueError("service number must be less than 65536")
     if len(data) > 4:
       raise ValueError("max data size is 4 bytes")
     self._send_cro(COMMAND_CODE.DIAG_SERVICE, struct.pack(f"{self.byte_order.value}H", service_num) + data)
     resp = self._recv_dto(0.025)
-    return { # TODO: define a type
+    return { 
       "length": resp[0],
       "type": resp[1],
     }
 
-  def action_service(self, service_num: int, data: bytes = b"") -> dict:
+  def action_service(self, service_num: int, data: bytes = b"") -> ActionServiceReturn:
     if service_num > 65535:
       raise ValueError("service number must be less than 65536")
     if len(data) > 4:
       raise ValueError("max data size is 4 bytes")
     self._send_cro(COMMAND_CODE.ACTION_SERVICE, struct.pack(f"{self.byte_order.value}H", service_num) + data)
     resp = self._recv_dto(0.025)
-    return { # TODO: define a type
+    return { 
       "length": resp[0],
       "type": resp[1],
     }

--- a/python/ccp.py
+++ b/python/ccp.py
@@ -9,8 +9,8 @@ from typing import Optional
 class ExchangeStationIdsReturn:
   id_length: int
   data_type: int
-  available: int  
-  protected: int  
+  available: int
+  protected: int
 
 @dataclass
 class GetDaqListSizeReturn:
@@ -20,7 +20,7 @@ class GetDaqListSizeReturn:
 @dataclass
 class GetSessionStatusReturn:
   status: int
-  info: Optional[int]   
+  info: Optional[int]
 
 @dataclass
 class DiagnosticServiceReturn:

--- a/python/ccp.py
+++ b/python/ccp.py
@@ -6,26 +6,26 @@ from enum import IntEnum, Enum
 from typing import TypedDict, Optional
 
 class ExchangeStationIdsReturn(TypedDict):
-    id_length: int
-    data_type: int
-    available: int  
-    protected: int  
+  id_length: int
+  data_type: int
+  available: int  
+  protected: int  
 
 class GetDaqListSizeReturn(TypedDict):
-    list_size: int
-    first_pid: int
+  list_size: int
+  first_pid: int
 
 class GetSessionStatusReturn(TypedDict):
-    status: int
-    info: Optional[int]   
+  status: int
+  info: Optional[int]   
 
 class DiagnosticServiceReturn(TypedDict):
-    length: int
-    type: int
+  length: int
+  type: int
 
 class ActionServiceReturn(TypedDict):
-    length: int
-    type: int
+  length: int
+  type: int
 
 class COMMAND_CODE(IntEnum):
   CONNECT = 0x01

--- a/python/ccp.py
+++ b/python/ccp.py
@@ -5,25 +5,25 @@ from enum import IntEnum, Enum
 
 from typing import TypedDict, Optional
 
-class ExchangeStationIdsReturn(TypedDict):
+class ExchangeStationIdsReturn:
   id_length: int
   data_type: int
   available: int  
   protected: int  
 
-class GetDaqListSizeReturn(TypedDict):
+class GetDaqListSizeReturn:
   list_size: int
   first_pid: int
 
-class GetSessionStatusReturn(TypedDict):
+class GetSessionStatusReturn:
   status: int
   info: Optional[int]   
 
-class DiagnosticServiceReturn(TypedDict):
+class DiagnosticServiceReturn:
   length: int
   type: int
 
-class ActionServiceReturn(TypedDict):
+class ActionServiceReturn:
   length: int
   type: int
 
@@ -167,12 +167,7 @@ class CcpClient():
   def exchange_station_ids(self, device_id_info: bytes = b"") -> ExchangeStationIdsReturn:
     self._send_cro(COMMAND_CODE.EXCHANGE_ID, device_id_info)
     resp = self._recv_dto(0.025)
-    return { 
-      "id_length": resp[0],
-      "data_type": resp[1],
-      "available": resp[2],
-      "protected": resp[3],
-    }
+    return ExchangeStationIdsReturn(id_length=resp[0], data_type=resp[1], available=resp[2], protected=resp[3])
 
   def get_seed(self, resource_mask: int) -> bytes:
     if resource_mask > 255:
@@ -240,10 +235,7 @@ class CcpClient():
       raise ValueError("list number must be less than 256")
     self._send_cro(COMMAND_CODE.GET_DAQ_SIZE, bytes([list_num, 0]) + struct.pack(f"{self.byte_order.value}I", can_id))
     resp = self._recv_dto(0.025)
-    return { 
-      "list_size": resp[0],
-      "first_pid": resp[1],
-    }
+    return GetDaqListSizeReturn(list_size=resp[0], first_pid=resp[1])
 
   def set_daq_list_pointer(self, list_num: int, odt_num: int, element_num: int) -> None:
     if list_num > 255:
@@ -293,10 +285,8 @@ class CcpClient():
   def get_session_status(self) -> GetSessionStatusReturn:
     self._send_cro(COMMAND_CODE.GET_S_STATUS)
     resp = self._recv_dto(0.025)
-    return { 
-      "status": resp[0],
-      "info": resp[2] if resp[1] else None,
-    }
+    info = resp[2] if resp[1] else None
+    return GetSessionStatusReturn(status=resp[0], info=info)
 
   def build_checksum(self, size: int) -> bytes:
     self._send_cro(COMMAND_CODE.BUILD_CHKSUM, struct.pack(f"{self.byte_order.value}I", size))
@@ -341,10 +331,7 @@ class CcpClient():
       raise ValueError("max data size is 4 bytes")
     self._send_cro(COMMAND_CODE.DIAG_SERVICE, struct.pack(f"{self.byte_order.value}H", service_num) + data)
     resp = self._recv_dto(0.025)
-    return { 
-      "length": resp[0],
-      "type": resp[1],
-    }
+    return DiagnosticServiceReturn(length=resp[0], type=resp[1])
 
   def action_service(self, service_num: int, data: bytes = b"") -> ActionServiceReturn:
     if service_num > 65535:
@@ -353,10 +340,7 @@ class CcpClient():
       raise ValueError("max data size is 4 bytes")
     self._send_cro(COMMAND_CODE.ACTION_SERVICE, struct.pack(f"{self.byte_order.value}H", service_num) + data)
     resp = self._recv_dto(0.025)
-    return { 
-      "length": resp[0],
-      "type": resp[1],
-    }
+    return ActionServiceReturn(length=resp[0], type=resp[1])
 
   def test_availability(self, station_addr: int) -> None:
     if station_addr > 65535:

--- a/python/ccp.py
+++ b/python/ccp.py
@@ -2,27 +2,32 @@ import sys
 import time
 import struct
 from enum import IntEnum, Enum
+from dataclasses import dataclass
+from typing import Optional
 
-from typing import TypedDict, Optional
-
+@dataclass
 class ExchangeStationIdsReturn:
   id_length: int
   data_type: int
   available: int  
   protected: int  
 
+@dataclass
 class GetDaqListSizeReturn:
   list_size: int
   first_pid: int
 
+@dataclass
 class GetSessionStatusReturn:
   status: int
   info: Optional[int]   
 
+@dataclass
 class DiagnosticServiceReturn:
   length: int
   type: int
 
+@dataclass
 class ActionServiceReturn:
   length: int
   type: int


### PR DESCRIPTION
It was under "TODO" in python/ccp.py to define types for couple of function returns. 