### PR TITLE
Enabling misra-c2012-1.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v4.6.0
   hooks:
     - id: check-ast
     - id: check-yaml
@@ -15,6 +15,6 @@ repos:
       additional_dependencies: ['git+https://github.com/numpy/numpy-stubs', 'types-requests', 'types-atomicwrites',
                                 'types-pycurl']
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.4
+  rev: v0.3.5
   hooks:
     - id: ruff

--- a/board/safety/safety_ford.h
+++ b/board/safety/safety_ford.h
@@ -226,7 +226,8 @@ static void ford_rx_hook(const CANPacket_t *to_push) {
     if (addr == FORD_Yaw_Data_FD1) {
       // Signal: VehYaw_W_Actl
       float ford_yaw_rate = (((GET_BYTE(to_push, 2) << 8U) | GET_BYTE(to_push, 3)) * 0.0002) - 6.5;
-      float current_curvature = ford_yaw_rate / MAX(vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR, 0.1);
+      float tmp_value = (((vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR) > 0.1) ? (vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR) : 0.1);
+      float current_curvature = ford_yaw_rate / tmp_value;
       // convert current curvature into units on CAN for comparison with desired curvature
       update_sample(&angle_meas, ROUND(current_curvature * FORD_STEERING_LIMITS.angle_deg_to_can));
     }

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -174,7 +174,7 @@ void reset_sample(struct sample_t *sample);
 bool max_limit_check(int val, const int MAX, const int MIN);
 bool angle_dist_to_meas_check(int val, struct sample_t *val_meas,
   const int MAX_ERROR, const int MAX_VAL);
-bool dist_to_meas_check(int val, int val_last, struct sample_t *val_meas,
+bool dist_to_meas_check(int val, int val_last, const struct sample_t *val_meas,
   const int MAX_RATE_UP, const int MAX_RATE_DOWN, const int MAX_ERROR);
 bool driver_limit_check(int val, int val_last, const struct sample_t *val_driver,
   const int MAX, const int MAX_RATE_UP, const int MAX_RATE_DOWN,

--- a/board/utils.h
+++ b/board/utils.h
@@ -1,26 +1,58 @@
-#define MIN(a, b) ({ \
-  __typeof__ (a) _a = (a); \
-  __typeof__ (b) _b = (b); \
-  (_a < _b) ? _a : _b; \
-})
+static inline unsigned int func_min(unsigned int a, unsigned int b) {
+  unsigned int result = 0;
+  if (a < b) {
+    result = a;
+  } else {
+    result = b;
+  }
 
-#define MAX(a, b) ({ \
-  __typeof__ (a) _a = (a); \
-  __typeof__ (b) _b = (b); \
-  (_a > _b) ? _a : _b; \
-})
+  return result;
+}
 
-#define CLAMP(x, low, high) ({ \
-  __typeof__(x) __x = (x); \
-  __typeof__(low) __low = (low);\
-  __typeof__(high) __high = (high);\
-  (__x > __high) ? __high : ((__x < __low) ? __low : __x); \
-})
+static inline unsigned int func_max(unsigned int a, unsigned int b) {
+  unsigned int result = 0;
+  if (a > b) {
+    result = a;
+  } else {
+    result = b;
+  }
+  return result;
+}
 
-#define ABS(a) ({ \
-  __typeof__ (a) _a = (a); \
-  (_a > 0) ? _a : (-_a); \
-})
+static inline unsigned int func_clamp(unsigned int a, unsigned int b, unsigned int c) {
+  unsigned int result = 0;
+  if (a > c) {
+    result = c;
+  } else if (a < b) {
+    result = b;
+  } else {
+    result = a;
+  }
+
+  return result;
+}
+
+static inline int func_abs(int a) {
+  int result = 0;
+  if (a > 0) {
+    result = a;
+  } else {
+    result = -a;
+  }
+  return result;
+}
+
+#define MIN(a, b) \
+  (func_min(a, b))
+
+#define MAX(a, b) \
+  (func_max(a, b))
+
+#define CLAMP(a, b, c) \
+  (func_clamp(a, b, c))
+
+#define ABS(a) \
+  (func_abs(a))
 
 #ifndef NULL
 // this just provides a standard implementation of NULL

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -18,7 +18,6 @@ unusedFunction:*/interrupt_handlers*.h
 # all of the below suppressions are from new checks introduced after updating
 # cppcheck from 2.5 -> 2.13. they are listed here to separate the update from
 # fixing the violations and all are intended to be removed soon after
-misra-c2012-1.2   # this is from the extensions (e.g. __typeof__) used in the MIN, MAX, ABS, and CLAMP macros
 misra-c2012-2.5   # unused macros. a few legit, rest aren't common between F4/H7 builds. should we do this in the unusedFunction pass?
 misra-c2012-8.7
 misra-c2012-8.4


### PR DESCRIPTION
for #1794
The problem was with the typeof expression, which is not supported by MISRA-C2012-1.2 rule. Instead of this expression, shorts static inline functions were written. There was a problem when an unsigned value is compared with zero; it reported that the value is always greater than zero. Because of that, arguments of functions are unsigned int. For signed values, conversions would be made (for example, if you want the maximum between -2 and -3, first it would be converted to unsigned, which is 254 for -2 and 253 for -3, where 254 is greater than 253, which is correct). In safety_ford.h file, instead of the MAX macro, I use the ternary operator for float values because if I use the MAX macro, floats would be converted to unsigned, where 0.1 becomes 0, and I think that could be a problem.