### PR TITLE
IsoTpMessage: extend timeout on first frame response

### DIFF
--- a/python/uds.py
+++ b/python/uds.py
@@ -455,6 +455,7 @@ class IsoTpMessage():
         for msg in self._can_client.recv():
           frame_type = self._isotp_rx_next(msg)
           start_time = time.monotonic()
+          # Anything that signifies we're building a response
           rx_in_progress = frame_type in (ISOTP_FRAME_TYPE.FIRST, ISOTP_FRAME_TYPE.CONSECUTIVE)
           if self.tx_done and self.rx_done:
             return self.rx_dat, False
@@ -484,6 +485,7 @@ class IsoTpMessage():
       return ISOTP_FRAME_TYPE.SINGLE
 
     elif rx_data[0] >> 4 == ISOTP_FRAME_TYPE.FIRST:
+      # Once a first frame is received, further frames must be consecutive
       assert self.rx_dat == b"" or self.rx_done, "isotp - rx: first frame with active frame"
       self.rx_len = ((rx_data[0] & 0x0F) << 8) + rx_data[1]
       assert self.rx_len >= self.max_len, f"isotp - rx: invalid first frame length: {self.rx_len}"

--- a/python/uds.py
+++ b/python/uds.py
@@ -413,7 +413,7 @@ class IsoTpMessage():
 
   def send(self, dat: bytes, setup_only: bool = False) -> None:
     # throw away any stale data
-    # self._can_client.recv(drain=True)
+    self._can_client.recv(drain=True)
 
     self.tx_dat = dat
     self.tx_len = len(dat)

--- a/python/uds.py
+++ b/python/uds.py
@@ -455,7 +455,7 @@ class IsoTpMessage():
         for msg in self._can_client.recv():
           frame_type = self._isotp_rx_next(msg)
           start_time = time.monotonic()
-          rx_in_progress = frame_type == ISOTP_FRAME_TYPE.CONSECUTIVE
+          rx_in_progress = frame_type in (ISOTP_FRAME_TYPE.FIRST, ISOTP_FRAME_TYPE.CONSECUTIVE)
           if self.tx_done and self.rx_done:
             return self.rx_dat, False
         # no timeout indicates non-blocking
@@ -477,7 +477,7 @@ class IsoTpMessage():
       assert self.rx_len < self.max_len, f"isotp - rx: invalid single frame length: {self.rx_len}"
       self.rx_dat = rx_data[1:1 + self.rx_len]
       self.rx_idx = 0
-      self.rx_done = True
+      self.rx_done = error_code != 0x78  # todo me
       if self.debug:
         print(f"ISO-TP: RX - single frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")
       return ISOTP_FRAME_TYPE.SINGLE

--- a/python/uds.py
+++ b/python/uds.py
@@ -413,7 +413,7 @@ class IsoTpMessage():
 
   def send(self, dat: bytes, setup_only: bool = False) -> None:
     # throw away any stale data
-    self._can_client.recv(drain=True)
+    # self._can_client.recv(drain=True)
 
     self.tx_dat = dat
     self.tx_len = len(dat)
@@ -441,6 +441,8 @@ class IsoTpMessage():
       if self.debug and not setup_only:
         print(f"ISO-TP: TX - first frame - {hex(self._can_client.tx_addr)}")
       msg = (struct.pack("!H", 0x1000 | self.tx_len) + self.tx_dat[:self.max_len - 2]).ljust(self.max_len - 2, b"\x00")
+    print('sent msg', msg)
+    print(f'{self.tx_dat=}, {self.tx_len=}, {self.tx_idx=}, {self.tx_done=}, {self.rx_dat=}, {self.rx_len=}, {self.rx_idx=}, {self.rx_done=}')
     if not setup_only:
       self._can_client.send([msg])
 
@@ -477,23 +479,36 @@ class IsoTpMessage():
       assert self.rx_len < self.max_len, f"isotp - rx: invalid single frame length: {self.rx_len}"
       self.rx_dat = rx_data[1:1 + self.rx_len]
       self.rx_idx = 0
-      self.rx_done = error_code != 0x78  # todo me
+      self.rx_done = True  # error_code != 0x78  # todo me
       if self.debug:
         print(f"ISO-TP: RX - single frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")
+      print(f'{self.tx_dat=}, {self.tx_len=}, {self.tx_idx=}, {self.tx_done=}, {self.rx_dat=}, {self.rx_len=}, {self.rx_idx=}, {self.rx_done=}')
       return ISOTP_FRAME_TYPE.SINGLE
 
     elif rx_data[0] >> 4 == ISOTP_FRAME_TYPE.FIRST:
+
+      # rx_dat != b"" and not self.rx_done
+      assert self.rx_dat == b"" or self.rx_done, "isotp - rx: first frame with active frame"
+
       self.rx_len = ((rx_data[0] & 0x0F) << 8) + rx_data[1]
-      assert self.max_len <= self.rx_len, f"isotp - rx: invalid first frame length: {self.rx_len}"
+      assert self.rx_len >= self.max_len, f"isotp - rx: invalid first frame length: {self.rx_len}"
+      assert len(rx_data) == self.max_len, f"isotp - rx: invalid CAN frame length: {len(rx_data)}"
       self.rx_dat = rx_data[2:]
       self.rx_idx = 0
       self.rx_done = False
+
+      # if self.rx_dat == b"" or self.rx_done:
+      #   pass
+      # else:
+      #   pass
+
       if self.debug:
         print(f"ISO-TP: RX - first frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")
       if self.debug:
         print(f"ISO-TP: TX - flow control continue - {hex(self._can_client.tx_addr)}")
       # send flow control message
-      self._can_client.send([self.flow_control_msg])
+      # self._can_client.send([self.flow_control_msg])
+      print(f'{self.tx_dat=}, {self.tx_len=}, {self.tx_idx=}, {self.tx_done=}, {self.rx_dat=}, {self.rx_len=}, {self.rx_idx=}, {self.rx_done=}')
       return ISOTP_FRAME_TYPE.FIRST
 
     elif rx_data[0] >> 4 == ISOTP_FRAME_TYPE.CONSECUTIVE:
@@ -509,6 +524,7 @@ class IsoTpMessage():
         self._can_client.send([self.flow_control_msg])
       if self.debug:
         print(f"ISO-TP: RX - consecutive frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")
+      print(f'{self.tx_dat=}, {self.tx_len=}, {self.tx_idx=}, {self.tx_done=}, {self.rx_dat=}, {self.rx_len=}, {self.rx_idx=}, {self.rx_done=}')
       return ISOTP_FRAME_TYPE.CONSECUTIVE
 
     elif rx_data[0] >> 4 == ISOTP_FRAME_TYPE.FLOW:
@@ -544,6 +560,7 @@ class IsoTpMessage():
         # wait (do nothing until next flow control message)
         if self.debug:
           print(f"ISO-TP: TX - flow control wait - {hex(self._can_client.tx_addr)}")
+      print(f'{self.tx_dat=}, {self.tx_len=}, {self.tx_idx=}, {self.tx_done=}, {self.rx_dat=}, {self.rx_len=}, {self.rx_idx=}, {self.rx_done=}')
       return ISOTP_FRAME_TYPE.FLOW
 
     # 4-15 - reserved

--- a/python/uds.py
+++ b/python/uds.py
@@ -475,6 +475,7 @@ class IsoTpMessage():
     # assert len(rx_data) == self.max_len, f"isotp - rx: invalid CAN frame length: {len(rx_data)}"
 
     if rx_data[0] >> 4 == ISOTP_FRAME_TYPE.SINGLE:
+      assert self.rx_dat == b"" or self.rx_done, "isotp - rx: single frame with active frame"
       self.rx_len = rx_data[0] & 0x0F
       assert self.rx_len < self.max_len, f"isotp - rx: invalid single frame length: {self.rx_len}"
       self.rx_dat = rx_data[1:1 + self.rx_len]
@@ -496,11 +497,6 @@ class IsoTpMessage():
       self.rx_dat = rx_data[2:]
       self.rx_idx = 0
       self.rx_done = False
-
-      # if self.rx_dat == b"" or self.rx_done:
-      #   pass
-      # else:
-      #   pass
 
       if self.debug:
         print(f"ISO-TP: RX - first frame - {hex(self._can_client.rx_addr)} idx={self.rx_idx} done={self.rx_done}")


### PR DESCRIPTION
Try 2 of https://github.com/commaai/panda/pull/1487 and https://github.com/commaai/panda/pull/1610. Potentially fixes https://github.com/commaai/openpilot/issues/32242

In short, this adds checks to first and single ISO-TP frame types. If you receive a first frame, the next message must be consecutive, or the new assertions in first and single are raised. You can receive as many single frames as you want without issue.

An additional rx length check is added to ensure that `rx_dat` isn't unset in the first frame hook (it previously accepted `m._isotp_rx_next(b'\x10\x08')`) which isn't a [valid CAN frame size](https://en.wikipedia.org/wiki/ISO_15765-2).

---

This would cause the EPS to now *successfully* respond for:

- `297b4b460f361603/2023-06-14--16-55-16`
- `297b4b460f361603/2023-06-14--16-48-52`
- `297b4b460f361603/2023-06-21--04-09-15`