### PR TITLE
CI: fix misra mutation tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,7 @@ jobs:
         run: ${{ env.RUN }} "cd tests/misra && ./test_misra.sh"
       - name: MISRA mutation tests
         timeout-minutes: 4
-        run: ${{ env.RUN }} "cd tests/misra && ./test_mutation.py"
+        run: ${{ env.RUN }} "cd tests/misra && pytest -n8 test_mutation.py"
 
   python_linter:
     name: python linter

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,12 +99,14 @@ jobs:
         run: eval "$BUILD"
       - name: Build FW
         run: ${{ env.RUN }} "scons -j$(nproc)"
+      - name: Install cppcheck
+        run: ${{ env.RUN }} "cd tests/misra && ./install.sh"
       - name: Run MISRA C:2012 analysis
         timeout-minutes: 1
-        run: ${{ env.RUN }} "cd tests/misra && ./test_misra.sh"
+        run: ${{ env.RUN }} "cd tests/misra && SKIP_BUILD=1 ./test_misra.sh"
       - name: MISRA mutation tests
         timeout-minutes: 4
-        run: ${{ env.RUN }} "cd tests/misra && pytest -n8 test_mutation.py"
+        run: ${{ env.RUN }} "cd tests/misra && SKIP_BUILD=1 pytest -n8 test_mutation.py"
 
   python_linter:
     name: python linter

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,14 +99,12 @@ jobs:
         run: eval "$BUILD"
       - name: Build FW
         run: ${{ env.RUN }} "scons -j$(nproc)"
-      - name: Install cppcheck
-        run: ${{ env.RUN }} "cd tests/misra && ./install.sh"
       - name: Run MISRA C:2012 analysis
         timeout-minutes: 1
-        run: ${{ env.RUN }} "cd tests/misra && SKIP_BUILD=1 ./test_misra.sh"
+        run: ${{ env.RUN }} "cd tests/misra && ./test_misra.sh"
       - name: MISRA mutation tests
         timeout-minutes: 4
-        run: ${{ env.RUN }} "cd tests/misra && SKIP_BUILD=1 pytest -n8 test_mutation.py"
+        run: ${{ env.RUN }} "cd tests/misra && pytest -n8 test_mutation.py"
 
   python_linter:
     name: python linter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,5 +8,8 @@ select = ["E", "F", "W", "PIE", "C4", "ISC", "RUF100", "A"]
 ignore = ["W292", "E741", "E402", "C408", "ISC003"]
 flake8-implicit-str-concat.allow-multiline=false
 
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"pytest.main".msg = "pytest.main requires special handling that is easy to mess up!"
+
 [tool.pytest.ini_options]
 addopts = "-n auto"

--- a/tests/misra/install.sh
+++ b/tests/misra/install.sh
@@ -11,6 +11,7 @@ fi
 cd $CPPCHECK_DIR
 
 VERS="2.13.4"
+git remote prune origin
 git fetch --all --tags
 git checkout $VERS
 git cherry-pick -n f6b538e855f0bacea33c4074664628024ef39dc6 b11b42087ff29569bc3740f5aa07eb6616ea4f63

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -79,6 +79,3 @@ def test_misra_mutation(fn, patch, should_fail):
     r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
     failed = r.returncode != 0
     assert failed == should_fail
-
-if __name__ == "__main__":
-  pytest.main([__file__, "-n 8"])


### PR DESCRIPTION
this has been failing but pytest.main doesn't exit, you need to exit manually...


```
 _____________________ test_misra_mutation[None-None-False] _____________________
[gw0] linux -- Python 3.11.4 /root/.pyenv/versions/3.11.4/bin/python3

fn = None, patch = None, should_fail = False

    @pytest.mark.parametrize("fn, patch, should_fail", mutations)
    def test_misra_mutation(fn, patch, should_fail):
      with tempfile.TemporaryDirectory() as tmp:
        shutil.copytree(ROOT, tmp, dirs_exist_ok=True)
    
        # apply patch
        if fn is not None:
          r = os.system(f"cd {tmp} && sed -i '{patch}' {fn}")
          assert r == 0
    
        # run test
        r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
        failed = r.returncode != 0
>       assert failed == should_fail
E       assert True == False

test_mutation.py:81: AssertionError
```