### PR TITLE
Enable misra-c2012-1.2

### DIFF
--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -2,7 +2,7 @@
 
 #define GET_BIT(msg, b) ((bool)!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
-#define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask))
+#define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask)) // cppcheck-suppress misra-c2012-1.2; allow __typeof__
 
 #define BUILD_SAFETY_CFG(rx, tx) ((safety_config){(rx), (sizeof((rx)) / sizeof((rx)[0])), \
                                                   (tx), (sizeof((tx)) / sizeof((tx)[0]))})

--- a/board/utils.h
+++ b/board/utils.h
@@ -1,15 +1,18 @@
+// cppcheck-suppress-macro misra-c2012-1.2; allow __typeof__ extension
 #define MIN(a, b) ({ \
   __typeof__ (a) _a = (a); \
   __typeof__ (b) _b = (b); \
   (_a < _b) ? _a : _b; \
 })
 
+// cppcheck-suppress-macro misra-c2012-1.2; allow __typeof__ extension
 #define MAX(a, b) ({ \
   __typeof__ (a) _a = (a); \
   __typeof__ (b) _b = (b); \
   (_a > _b) ? _a : _b; \
 })
 
+// cppcheck-suppress-macro misra-c2012-1.2; allow __typeof__ extension
 #define CLAMP(x, low, high) ({ \
   __typeof__(x) __x = (x); \
   __typeof__(low) __low = (low);\
@@ -17,6 +20,7 @@
   (__x > __high) ? __high : ((__x < __low) ? __low : __x); \
 })
 
+// cppcheck-suppress-macro misra-c2012-1.2; allow __typeof__ extension
 #define ABS(a) ({ \
   __typeof__ (a) _a = (a); \
   (_a > 0) ? _a : (-_a); \

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -18,7 +18,6 @@ unusedFunction:*/interrupt_handlers*.h
 # all of the below suppressions are from new checks introduced after updating
 # cppcheck from 2.5 -> 2.13. they are listed here to separate the update from
 # fixing the violations and all are intended to be removed soon after
-misra-c2012-1.2   # this is from the extensions (e.g. __typeof__) used in the MIN, MAX, ABS, and CLAMP macros
 misra-c2012-2.5   # unused macros. a few legit, rest aren't common between F4/H7 builds. should we do this in the unusedFunction pass?
 misra-c2012-8.7
 misra-c2012-8.4

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -48,7 +48,7 @@ cppcheck() {
           --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
           --suppress=*:*include/* --error-exitcode=2 --check-level=exhaustive \
           --platform=arm32-wchar_t4 $COMMON_DEFINES --checkers-report=$CHECKLIST.tmp \
-          "$@" |& tee $OUTPUT
+          --std=c11 "$@" |& tee $OUTPUT
   
   cat $CHECKLIST.tmp >> $CHECKLIST
   rm $CHECKLIST.tmp


### PR DESCRIPTION
Allow gcc's (and compatible compilers) `__typeof__` extension for type safety and concise code.


Btw, [C23](https://en.cppreference.com/w/c/language/typeof) has `typeof` natively, but cppcheck doesn't support yet - according to the [manual](https://cppcheck.sourceforge.io/manual.pdf).

Links https://github.com/commaai/panda/issues/1954 https://github.com/commaai/panda/issues/1794 https://github.com/commaai/panda/pull/1926