### PR TITLE
misra mutations test - git diff error fix

### DIFF
--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -18,10 +18,12 @@ fi
 
 # ensure checked in coverage table is up to date
 cd $DIR
-python $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
-if ! git diff --quiet coverage_table; then
-  echo -e "${YELLOW}MISRA coverage table doesn't match. Update and commit:${NC}"
-  exit 1
+if [ -z "$SKIP_TABLES_DIFF" ]; then
+  python $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
+  if ! git diff --quiet coverage_table; then
+    echo -e "${YELLOW}MISRA coverage table doesn't match. Update and commit:${NC}"
+    exit 2
+  fi
 fi
 
 cd $PANDA_DIR
@@ -77,7 +79,7 @@ printf "\n${GREEN}Success!${NC} took $SECONDS seconds\n"
 
 # ensure list of checkers is up to date
 cd $DIR
-if ! git diff --quiet $CHECKLIST; then
+if [ -z "$SKIP_TABLES_DIFF" ] && ! git diff --quiet coverage_table; then
   echo -e "\n${YELLOW}WARNING: Cppcheck checkers.txt report has changed. Review and commit...${NC}"
-  exit 1
+  exit 3
 fi

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -77,6 +77,6 @@ def test_misra_mutation(fn, patch, should_fail):
       assert r == 0
 
     # run test
-    r = subprocess.run("tests/misra/test_misra.sh", cwd=tmp, shell=True)
+    r = subprocess.run("SKIP_TABLES_DIFF=1 tests/misra/test_misra.sh", cwd=tmp, shell=True)
     failed = r.returncode != 0
     assert failed == should_fail


### PR DESCRIPTION
Mutations test fails due to git diff running in a temp folder.  Only when running **locally** for some reason.  Error:
```
MISRA coverage table doesn't match. Update and commit:
Before: /home/dzid_/openpilot/panda/tests/misra
--------------------------------- Captured stderr call ----------------------------------
HEAD is now at 7cb8f2bc6 Fix #12726: Update for CheckOrderEvaluation (#6448)
fatal: not a git repository: /tmp/tmpowwsj6_q/../.git/modules/panda
```
This PR patches this problem.  

------
I am bit confused though:
- I verified `$DIR`, `$CPPCHECK_DIR`, `$PANDA_DIR`  point to temp folder.
- However htop shows cppcheck process running in the root, not temp
![image](https://github.com/commaai/panda/assets/841061/c20edfbc-f712-4ba4-8157-e1e9dd6b025b)
- _and_  cppcheck dump files are created in the root (and [not deleted](https://github.com/danmar/cppcheck/pull/4757)): 
```
:~/openpilot/panda/board$ ls -lt
total 391188
-rw-r--r-- 1 dzid_ dzid_ 34325973 May 31 14:41 main.c.14171.dump
-rw-r--r-- 1 dzid_ dzid_        0 May 31 14:41 main.c.14171.ctu-info
-rw-r--r-- 1 dzid_ dzid_    32331 May 31 14:41 main.c.13962.ctu-info
-rw-r--r-- 1 dzid_ dzid_ 34325982 May 31 14:41 main.c.13962.dump
-rw-r--r-- 1 dzid_ dzid_        0 May 31 14:40 main.c.13794.ctu-info
```
- _and_ `checkers.txt` is being modified in the root as well during the testing
