### PR TITLE
clear stuck CAN messages before switching multiplexing

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -97,6 +97,8 @@ void set_safety_mode(uint16_t mode, uint16_t param) {
       heartbeat_counter = 0U;
       heartbeat_lost = false;
       if (current_board->has_obd) {
+        // Clear any pending messages in the can core (from sending while comma power is unplugged)
+        llcan_clear_send(CANIF_FROM_CAN_NUM(1));
         if (param == 0U) {
           current_board->set_can_mode(CAN_MODE_OBD_CAN2);
         } else {

--- a/board/main.c
+++ b/board/main.c
@@ -97,7 +97,8 @@ void set_safety_mode(uint16_t mode, uint16_t param) {
       heartbeat_counter = 0U;
       heartbeat_lost = false;
       if (current_board->has_obd) {
-        // Clear any pending messages in the can core (from sending while comma power is unplugged)
+        // Clear any pending messages in the can core (i.e. sending while comma power is unplugged)
+        // TODO: rewrite using hardware queues rather than fifo to cancel specific messages
         llcan_clear_send(CANIF_FROM_CAN_NUM(1));
         if (param == 0U) {
           current_board->set_can_mode(CAN_MODE_OBD_CAN2);


### PR DESCRIPTION
Potential fix for https://github.com/commaai/openpilot/issues/32070.

I was able to very easily reproduce:

- send a query to the OBD port while comma power is unplugged
- get a returned CAN message from the can core (?!) which we log as if it actually sent
- wait 5s, then switch away from the OBD port/to the powertrain bus 1
- message still in the can core gets sent with no returned can packet

this then puts the ECU into either one of two states, both are bad:

1. it's waiting for our flow control continue while we're sending another single frame, so it doesn't respond
2. the gateway sends the flow control continue for us and we end up skipping the first few consecutive frames

---

If I understand this correctly, we already had a fix for this, but might have not have always triggered: https://github.com/commaai/panda/pull/1502