### PR TITLE
fdcan: don't log bad CAN messages

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -123,7 +123,8 @@ void process_can(uint8_t can_number) {
           CANPacket_t to_push;
 
           // TODO: do we want to just drop this message?
-          if ((FDCANx->PSR & FDCAN_PSR_LEC) >> FDCAN_PSR_LEC_Pos) {
+          const uint8_t last_error = (((FDCANx->PSR) & FDCAN_PSR_LEC) >> FDCAN_PSR_LEC_Pos);
+          if ((last_error != 0U) && (last_error != 7U)) {
             can_health[can_number].total_tx_lost_cnt += 1U;
 //            FDCANx->PSR &= ~FDCAN_PSR_LEC;  // TODO: clear?
             to_push.rejected = 1U;

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -123,7 +123,7 @@ void process_can(uint8_t can_number) {
           CANPacket_t to_push;
 
           // TODO: do we want to just drop this message?
-          if ((psr_reg & FDCAN_PSR_LEC) >> FDCAN_PSR_LEC_Pos) {
+          if ((FDCANx->PSR & FDCAN_PSR_LEC) >> FDCAN_PSR_LEC_Pos) {
             can_health[can_number].total_tx_lost_cnt += 1U;
 //            FDCANx->PSR &= ~FDCAN_PSR_LEC;  // TODO: clear?
             to_push.rejected = 1U;

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -45,7 +45,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
   can_health[can_number].error_warning = ((psr_reg & FDCAN_PSR_EW) >> FDCAN_PSR_EW_Pos);
   can_health[can_number].error_passive = ((psr_reg & FDCAN_PSR_EP) >> FDCAN_PSR_EP_Pos);
 
-  can_health[can_number].last_error = psr_reg & FDCAN_PSR_LEC;
+  can_health[can_number].last_error = ((psr_reg & FDCAN_PSR_LEC) >> FDCAN_PSR_LEC_Pos);
   if ((can_health[can_number].last_error != 0U) && (can_health[can_number].last_error != 7U)) {
     can_health[can_number].last_stored_error = can_health[can_number].last_error;
   }
@@ -123,7 +123,7 @@ void process_can(uint8_t can_number) {
           CANPacket_t to_push;
 
           // TODO: do we want to just drop this message?
-          if (FDCANx->PSR & FDCAN_PSR_LEC) {
+          if ((psr_reg & FDCAN_PSR_LEC) >> FDCAN_PSR_LEC_Pos) {
             can_health[can_number].total_tx_lost_cnt += 1U;
 //            FDCANx->PSR &= ~FDCAN_PSR_LEC;  // TODO: clear?
             to_push.rejected = 1U;


### PR DESCRIPTION
For https://github.com/commaai/panda/pull/1967. Now messages that we send to a missing comma power won't come back as "returned"