### PR TITLE
drivers: log can core reset when switching multiplexing

### DIFF
--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -23,6 +23,11 @@ bool can_set_speed(uint8_t can_number) {
   return ret;
 }
 
+void can_clear_send(CAN_TypeDef *CANx, uint8_t can_number) {
+  can_health[can_number].can_core_reset_cnt += 1U;
+  llcan_clear_send(CANx);
+}
+
 void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
   CAN_TypeDef *CANx = CANIF_FROM_CAN_NUM(can_number);
   uint32_t esr_reg = CANx->ESR;
@@ -52,8 +57,7 @@ void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {
       can_health[can_number].total_rx_lost_cnt += 1U;
       CANx->RF0R &= ~(CAN_RF0R_FOVR0);
     }
-    can_health[can_number].can_core_reset_cnt += 1U;
-    llcan_clear_send(CANx);
+    can_clear_send(CANx, can_number);
   }
 }
 

--- a/board/main.c
+++ b/board/main.c
@@ -99,7 +99,7 @@ void set_safety_mode(uint16_t mode, uint16_t param) {
       if (current_board->has_obd) {
         // Clear any pending messages in the can core (i.e. sending while comma power is unplugged)
         // TODO: rewrite using hardware queues rather than fifo to cancel specific messages
-        llcan_clear_send(CANIF_FROM_CAN_NUM(1));
+        can_clear_send(CANIF_FROM_CAN_NUM(1), 1);
         if (param == 0U) {
           current_board->set_can_mode(CAN_MODE_OBD_CAN2);
         } else {


### PR DESCRIPTION
fdcan: log lost tx messages when resetting can core for multiplexing and can core reset
bxcan: log can core reset

follow up to https://github.com/commaai/panda/pull/1967