### PR TITLE
workflow: update readme with straightforward setup [ubuntu]

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In addition, we run the [ruff linter](https://github.com/astral-sh/ruff) and [my
 Setup dependencies:
 ```bash
 # Ubuntu
-sudo apt-get install dfu-util gcc-arm-none-eabi python3-pip libffi-dev git
+./install_ubuntu_dependencies.sh
 
 # macOS
 brew install --cask gcc-arm-embedded
@@ -61,8 +61,11 @@ Clone panda repository and install:
 git clone https://github.com/commaai/panda.git
 cd panda
 
-# install dependencies
+# install dependencies - you'll need python version > 3.11; use venv or pyenv
 pip install -r requirements.txt
+
+# update directory ownership to be your user/group id
+sudo chown -R <user-id>:<group-id> .
 
 # install panda
 python setup.py install

--- a/install_ubuntu_dependencies.sh
+++ b/install_ubuntu_dependencies.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e
+
+SUDO=""
+
+# Use sudo if not root
+if [[ ! $(id -u) -eq 0 ]]; then
+  if [[ -z $(which sudo) ]]; then
+    echo "Please install sudo or run as root"
+    exit 1
+  fi
+  SUDO="sudo"
+fi
+
+$SUDO apt-get update 
+$SUDO apt-get install -y --no-install-recommends \
+    make \
+    bzip2 \
+    ca-certificates \
+    capnproto \
+    clang \
+    g++ \
+    gcc-arm-none-eabi libnewlib-arm-none-eabi \
+    git \
+    libarchive-dev \
+    libbz2-dev \
+    libcapnp-dev \
+    libffi-dev \
+    libtool \
+    libusb-1.0-0 \
+    libzmq3-dev \
+    locales \
+    opencl-headers \
+    ocl-icd-opencl-dev \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    python-is-python3 \
+    zlib1g-dev \


### PR DESCRIPTION
dependencies didn't seem to match the setup that CI has, with the readme having missing apt packages such as `python3-dev` which is important for setup.

their is also no mention of the python version which must at least be 3.9

I've also included a section for updating permissions since even after using the appropriate permissions this was still the last step needed to be able to successfully run `python setup.py install`