### PR TITLE
Use numpy instead of numpy-stubs in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,8 @@ repos:
   rev: v1.10.0
   hooks:
     - id: mypy
-      additional_dependencies: ['types-requests', 'types-atomicwrites', 'types-pycurl']
+      additional_dependencies: ['numpy', 'types-requests', 'types-atomicwrites',
+                                'types-pycurl']
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.7
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,7 @@ repos:
   rev: v1.10.0
   hooks:
     - id: mypy
-      additional_dependencies: ['git+https://github.com/numpy/numpy-stubs', 'types-requests', 'types-atomicwrites',
-                                'types-pycurl']
+      additional_dependencies: ['types-requests', 'types-atomicwrites', 'types-pycurl']
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.4.7
   hooks:


### PR DESCRIPTION
numpy-stubs is deprecated. This fixes pre-commit errors.