### PR TITLE
update bash scripts to #!/usr/bin/env bash

### DIFF
--- a/board/debug/debug_h7.sh
+++ b/board/debug/debug_h7.sh
@@ -1,3 +1,3 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 sudo openocd -f "interface/stlink.cfg" -c "transport select hla_swd" -f "target/stm32h7x.cfg" -c "init"

--- a/board/debug/debug_h7.sh
+++ b/board/debug/debug_h7.sh
@@ -1,3 +1,4 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e
 
 sudo openocd -f "interface/stlink.cfg" -c "transport select hla_swd" -f "target/stm32h7x.cfg" -c "init"

--- a/board/gdb.sh
+++ b/board/gdb.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 gdb-multiarch  --eval-command="target extended-remote localhost:3333"

--- a/drivers/spi/load.sh
+++ b/drivers/spi/load.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"

--- a/drivers/spi/pull-src.sh
+++ b/drivers/spi/pull-src.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"

--- a/release/make_release.sh
+++ b/release/make_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"

--- a/tests/ci_shell.sh
+++ b/tests/ci_shell.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 OP_ROOT="$DIR/../../"

--- a/tests/ci_shell.sh
+++ b/tests/ci_shell.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash -e
+#!/usr/bin/env bash
+set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 OP_ROOT="$DIR/../../"

--- a/tests/hitl/run_parallel_tests.sh
+++ b/tests/hitl/run_parallel_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"

--- a/tests/hitl/run_serial_tests.sh
+++ b/tests/hitl/run_serial_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"

--- a/tests/misra/install.sh
+++ b/tests/misra/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
@@ -51,7 +51,7 @@ cppcheck() {
           --suppress=*:*include/* --error-exitcode=2 --check-level=exhaustive \
           --platform=arm32-wchar_t4 $COMMON_DEFINES --checkers-report=$CHECKLIST.tmp \
           --std=c11 "$@" |& tee $OUTPUT
-  
+
   cat $CHECKLIST.tmp >> $CHECKLIST
   rm $CHECKLIST.tmp
   # cppcheck bug: some MISRA errors won't result in the error exit code,

--- a/tests/read_st_flash.sh
+++ b/tests/read_st_flash.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 rm -f /tmp/dump_bootstub
 rm -f /tmp/dump_main
 dfu-util -a 0 -s 0x08000000 -U /tmp/dump_bootstub

--- a/tests/setup_device_ci.sh
+++ b/tests/setup_device_ci.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -19,7 +19,7 @@ fi
 
 CONTINUE_PATH="/data/continue.sh"
 tee $CONTINUE_PATH << EOF
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 sudo abctl --set_success
 

--- a/tests/som_debug.sh
+++ b/tests/som_debug.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"


### PR DESCRIPTION
Mostly for macOS.

A good explaination [here](https://stackoverflow.com/a/58494728/639708).

Needed this to run `som_debug.sh` on macOS, but decided to update all scripts.

Same thing for:
- openpilot https://github.com/commaai/openpilot/pull/33111
- agnos-builder https://github.com/commaai/agnos-builder/pull/268