### PR TITLE
Enable CAN3 printer

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -26,7 +26,7 @@ logging.basicConfig(level=LOGLEVEL, format='%(message)s')
 CANPACKET_HEAD_SIZE = 0x6
 DLC_TO_LEN = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]
 LEN_TO_DLC = {length: dlc for (dlc, length) in enumerate(DLC_TO_LEN)}
-PANDA_BUS_CNT = 4
+PANDA_BUS_CNT = 3
 
 
 def calculate_checksum(data):

--- a/tests/can_printer.py
+++ b/tests/can_printer.py
@@ -17,7 +17,12 @@ def can_printer():
   start = sec_since_boot()
   lp = sec_since_boot()
   msgs = defaultdict(list)
+
   canbus = int(os.getenv("CAN", "0"))
+  if canbus == 3:
+    canbus = 1
+    p.set_obd(True)
+
   while True:
     can_recv = p.can_recv()
     for address, dat, src in can_recv:


### PR DESCRIPTION
~~I was struggling to get canbus 3 (aka canbus 1 in obd mode) to print anything when I had only 1 other node connected on the CAN.~~  
~~I don't fully understand what is going on, but `can_reset_communications()` but it seems to help to at least show few messages, before it stops.~~

Print CAN3.