### PR TITLE
make uds and isotp general imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ from .python.spi import PandaSpiException, PandaProtocolMismatch, STBootloaderSP
 from .python.serial import PandaSerial  # noqa: F401
 from .python.canhandle import CanHandle # noqa: F401
 from .python.utils import logger # noqa: F401
-from .python import (Panda, PandaDFU, # noqa: F401
+from .python import (Panda, PandaDFU, uds, isotp, # noqa: F401
                      pack_can_buffer, unpack_can_buffer, calculate_checksum,
                      DLC_TO_LEN, LEN_TO_DLC, ALTERNATIVE_EXPERIENCE, CANPACKET_HEAD_SIZE)
 


### PR DESCRIPTION
Needed for https://github.com/commaai/opendbc/pull/1049, so that both opendbc CI (pip package) and openpilot (submodule) can import uds and isotp properly. `panda.python` isn't available in the pip package, but everything defined in this file is.