### PR TITLE
fix test_mutation.py performace

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -100,7 +100,7 @@ jobs:
         timeout-minutes: 1
         run: ${{ env.RUN }} "cd tests/misra && ./test_misra.sh"
       - name: MISRA mutation tests
-        timeout-minutes: 5
+        timeout-minutes: 4
         run: ${{ env.RUN }} "cd tests/misra && pytest -n8 test_mutation.py"
 
   static_analysis:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,4 +12,4 @@ flake8-implicit-str-concat.allow-multiline=false
 "pytest.main".msg = "pytest.main requires special handling that is easy to mess up!"
 
 [tool.pytest.ini_options]
-addopts = "-n auto"
+addopts = "-n auto --ignore-glob='*.sh'"


### PR DESCRIPTION
Makes `test_mutation.py` 3x faster when run locally:
```
real    3m0.221s
user    25m4.861s
sys     1m2.424s
vs
real    1m7.962s
user    8m0.304s
sys     0m33.491s
```

This is due to naming of `test_misra.sh`.  It was executed by pytest workers on their respective workpsace copy. They were compiling cppcheck and running all misra tests during test collection phase.  


