### PR TITLE
misra21.15

### DIFF
--- a/board/can_comms.h
+++ b/board/can_comms.h
@@ -38,10 +38,10 @@ int comms_can_read(uint8_t *data, uint32_t max_len) {
     while ((pos < max_len) && can_pop(&can_rx_q, &can_packet)) {
       uint32_t pckt_len = CANPACKET_HEAD_SIZE + dlc_to_len[can_packet.data_len_code];
       if ((pos + pckt_len) <= max_len) {
-        (void)memcpy(&data[pos], &can_packet, pckt_len);
+        (void)memcpy(&data[pos], (uint8_t*)&can_packet, pckt_len);
         pos += pckt_len;
       } else {
-        (void)memcpy(&data[pos], &can_packet, max_len - pos);
+        (void)memcpy(&data[pos], (uint8_t*)&can_packet, max_len - pos);
         can_read_buffer.ptr += pckt_len - (max_len - pos);
         // cppcheck-suppress objectIndex
         (void)memcpy(can_read_buffer.data, &((uint8_t*)&can_packet)[(max_len - pos)], can_read_buffer.ptr);
@@ -69,7 +69,7 @@ void comms_can_write(const uint8_t *data, uint32_t len) {
       pos += can_write_buffer.tail_size;
 
       // send out
-      (void)memcpy(&to_push, can_write_buffer.data, can_write_buffer.ptr);
+      (void)memcpy((uint8_t*)&to_push, can_write_buffer.data, can_write_buffer.ptr);
       can_send(&to_push, to_push.bus, false);
 
       // reset overflow buffer
@@ -90,7 +90,7 @@ void comms_can_write(const uint8_t *data, uint32_t len) {
     uint32_t pckt_len = CANPACKET_HEAD_SIZE + dlc_to_len[(data[pos] >> 4U)];
     if ((pos + pckt_len) <= len) {
       CANPacket_t to_push = {0};
-      (void)memcpy(&to_push, &data[pos], pckt_len);
+      (void)memcpy((uint8_t*)&to_push, &data[pos], pckt_len);
       can_send(&to_push, to_push.bus, false);
       pos += pckt_len;
     } else {

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -153,7 +153,7 @@ void spi_rx_done(void) {
       if (spi_endpoint == 0U) {
         if (spi_data_len_mosi >= sizeof(ControlPacket_t)) {
           ControlPacket_t ctrl = {0};
-          (void)memcpy(&ctrl, &spi_buf_rx[SPI_HEADER_SIZE], sizeof(ControlPacket_t));
+          (void)memcpy((uint8_t*)&ctrl, &spi_buf_rx[SPI_HEADER_SIZE], sizeof(ControlPacket_t));
           response_len = comms_control_handler(&ctrl, &spi_buf_tx[3]);
           response_ack = true;
         } else {

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -117,7 +117,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
         can_health[req->param1].brs_enabled = bus_config[req->param1].brs_enabled;
         can_health[req->param1].canfd_non_iso = bus_config[req->param1].canfd_non_iso;
         resp_len = sizeof(can_health[req->param1]);
-        (void)memcpy(resp, &can_health[req->param1], resp_len);
+        (void)memcpy(resp, (uint8_t*)&can_health[req->param1], resp_len);
       }
       break;
     // **** 0xc3: fetch MCU UID

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -117,7 +117,7 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
         can_health[req->param1].brs_enabled = bus_config[req->param1].brs_enabled;
         can_health[req->param1].canfd_non_iso = bus_config[req->param1].canfd_non_iso;
         resp_len = sizeof(can_health[req->param1]);
-        (void)memcpy(resp, (uint8_t*)&can_health[req->param1], resp_len);
+        (void)memcpy(resp, (uint8_t*)(&can_health[req->param1]), resp_len);
       }
       break;
     // **** 0xc3: fetch MCU UID

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -21,4 +21,3 @@ unusedFunction:*/interrupt_handlers*.h
 misra-c2012-2.5   # unused macros. a few legit, rest aren't common between F4/H7 builds. should we do this in the unusedFunction pass?
 misra-c2012-8.7
 misra-c2012-8.4
-misra-c2012-21.15


### PR DESCRIPTION
Casting to uint8_t is a good solution given the nature of the structs we are copying to/from:

`can_health_t` is packed so it is fine to consider it an array of uint8_t

`ControlPacket_t` is packed so it is fine to consider it an array of uint8_t + trying to set each fields manually will make assumptions about endianness (since some `ControlPacket_t` elements are uint16_t and the buffer elements are uint8_t)

`CANPacket_t` is mostly a bit field struct that would require getting each fields manually with bit-wise operations and make assumptions about the order of the bits in the struct. But since it is also a packed struct, it is fine to just assume an array of uint8_t and proceed as before.