### PR TITLE
misra2.5: safety modes + stm32*

### DIFF
--- a/board/flasher.h
+++ b/board/flasher.h
@@ -1,3 +1,10 @@
+// from the linker script
+#ifdef STM32H7
+  #define APP_START_ADDRESS 0x8020000U
+#elif defined(STM32F4)
+  #define APP_START_ADDRESS 0x8004000U
+#endif
+
 // flasher state variables
 uint32_t *prog_ptr = NULL;
 bool unlocked = false;

--- a/board/safety/safety_mazda.h
+++ b/board/safety/safety_mazda.h
@@ -13,7 +13,6 @@
 
 // CAN bus numbers
 #define MAZDA_MAIN 0
-#define MAZDA_AUX  1
 #define MAZDA_CAM  2
 
 // track msgs coming from OP so that we know what CAM msgs to drop and what to forward

--- a/board/safety/safety_subaru.h
+++ b/board/safety/safety_subaru.h
@@ -27,7 +27,6 @@
 #define MSG_SUBARU_Wheel_Speeds          0x13a
 
 #define MSG_SUBARU_ES_LKAS               0x122
-#define MSG_SUBARU_ES_LKAS_ANGLE         0x124
 #define MSG_SUBARU_ES_Brake              0x220
 #define MSG_SUBARU_ES_Distance           0x221
 #define MSG_SUBARU_ES_Status             0x222

--- a/board/stm32f4/llbxcan_declarations.h
+++ b/board/stm32f4/llbxcan_declarations.h
@@ -1,10 +1,5 @@
 #pragma once
 
-// Flasher and pedal use raw mailbox access
-#define GET_MAILBOX_BYTE(msg, b) (((int)(b) > 3) ? (((msg)->RDHR >> (8U * ((unsigned int)(b) % 4U))) & 0xFFU) : (((msg)->RDLR >> (8U * (unsigned int)(b))) & 0xFFU))
-#define GET_MAILBOX_BYTES_04(msg) ((msg)->RDLR)
-#define GET_MAILBOX_BYTES_48(msg) ((msg)->RDHR)
-
 // SAE 2284-3 : minimum 16 tq, SJW 3, sample point at 81.3%
 #define CAN_QUANTA 16U
 #define CAN_SEQ1 12U

--- a/board/stm32f4/llusb_declarations.h
+++ b/board/stm32f4/llusb_declarations.h
@@ -2,7 +2,6 @@
 
 extern USB_OTG_GlobalTypeDef *USBx;
 
-#define USBx_HOST       ((USB_OTG_HostTypeDef *)((uint32_t)USBx + USB_OTG_HOST_BASE))
 #define USBx_DEVICE     ((USB_OTG_DeviceTypeDef *)((uint32_t)USBx + USB_OTG_DEVICE_BASE))
 #define USBx_INEP(i)    ((USB_OTG_INEndpointTypeDef *)((uint32_t)USBx + USB_OTG_IN_ENDPOINT_BASE + ((i) * USB_OTG_EP_REG_SIZE)))
 #define USBx_OUTEP(i)   ((USB_OTG_OUTEndpointTypeDef *)((uint32_t)USBx + USB_OTG_OUT_ENDPOINT_BASE + ((i) * USB_OTG_EP_REG_SIZE)))

--- a/board/stm32f4/stm32f4_config.h
+++ b/board/stm32f4/stm32f4_config.h
@@ -2,9 +2,6 @@
 #include "stm32f4/inc/stm32f4xx_hal_gpio_ex.h"
 #define MCU_IDCODE 0x463U
 
-// from the linker script
-#define APP_START_ADDRESS 0x8004000U
-
 #define CORE_FREQ 96U // in MHz
 #define APB1_FREQ (CORE_FREQ/2U)
 #define APB1_TIMER_FREQ (APB1_FREQ*2U)  // APB1 is multiplied by 2 for the timer peripherals

--- a/board/stm32h7/llfdcan_declarations.h
+++ b/board/stm32h7/llfdcan_declarations.h
@@ -13,11 +13,9 @@
 #define CAN_SEG2(tq, sp) ((tq) * (100U - (sp)) / 100U)
 
 // FDCAN core settings
-#define FDCAN_MESSAGE_RAM_SIZE 0x2800UL
 #define FDCAN_START_ADDRESS 0x4000AC00UL
 #define FDCAN_OFFSET 3384UL // bytes for each FDCAN module, equally
 #define FDCAN_OFFSET_W 846UL // words for each FDCAN module, equally
-#define FDCAN_END_ADDRESS 0x4000D3FCUL // Message RAM has a width of 4 bytes
 
 // FDCAN_RX_FIFO_0_EL_CNT + FDCAN_TX_FIFO_EL_CNT can't exceed 47 elements (47 * 72 bytes = 3,384 bytes) per FDCAN module
 
@@ -34,7 +32,6 @@
 #define FDCAN_TX_FIFO_HEAD_SIZE 8UL // bytes
 #define FDCAN_TX_FIFO_DATA_SIZE 64UL // bytes
 #define FDCAN_TX_FIFO_EL_SIZE (FDCAN_TX_FIFO_HEAD_SIZE + FDCAN_TX_FIFO_DATA_SIZE)
-#define FDCAN_TX_FIFO_EL_W_SIZE (FDCAN_TX_FIFO_EL_SIZE / 4UL)
 #define FDCAN_TX_FIFO_OFFSET (FDCAN_RX_FIFO_0_OFFSET + (FDCAN_RX_FIFO_0_EL_CNT * FDCAN_RX_FIFO_0_EL_W_SIZE))
 
 #define CAN_NAME_FROM_CANIF(CAN_DEV) (((CAN_DEV)==FDCAN1) ? "FDCAN1" : (((CAN_DEV) == FDCAN2) ? "FDCAN2" : "FDCAN3"))

--- a/board/stm32h7/llusb_declarations.h
+++ b/board/stm32h7/llusb_declarations.h
@@ -2,7 +2,6 @@
 
 extern USB_OTG_GlobalTypeDef *USBx;
 
-#define USBx_HOST       ((USB_OTG_HostTypeDef *)((uint32_t)USBx + USB_OTG_HOST_BASE))
 #define USBx_DEVICE     ((USB_OTG_DeviceTypeDef *)((uint32_t)USBx + USB_OTG_DEVICE_BASE))
 #define USBx_INEP(i)    ((USB_OTG_INEndpointTypeDef *)((uint32_t)USBx + USB_OTG_IN_ENDPOINT_BASE + ((i) * USB_OTG_EP_REG_SIZE)))
 #define USBx_OUTEP(i)   ((USB_OTG_OUTEndpointTypeDef *)((uint32_t)USBx + USB_OTG_OUT_ENDPOINT_BASE + ((i) * USB_OTG_EP_REG_SIZE)))

--- a/board/stm32h7/stm32h7_config.h
+++ b/board/stm32h7/stm32h7_config.h
@@ -2,9 +2,6 @@
 #include "stm32h7/inc/stm32h7xx_hal_gpio_ex.h"
 #define MCU_IDCODE 0x483U
 
-// from the linker script
-#define APP_START_ADDRESS 0x8020000U
-
 #define CORE_FREQ 240U // in Mhz
 //APB1 - 120Mhz, APB2 - 120Mhz
 #define APB1_FREQ (CORE_FREQ/4U)


### PR DESCRIPTION
cppcheck does not work well for Misra2.5 for 2 reasons:

 1. It will flag `SOMETHING` as unused when `CANFD` is not defined in the following example:

```c
#ifdef CANFD
  #define SOMETHING
#endif

...

#ifdef CANFD
  use SOMETHING
#endif
```

2. It will also consider a macro declared in a file included behing `#ifdef...` (even if the condition is false) but it will not check for usages of that macro in that file if the condition is false, making that macro a violation of Misra2.5

Because of that we won't be able to fix all Misra2.5 right now