### PR TITLE
Fix openpilot build

### DIFF
--- a/board/can.h
+++ b/board/can.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "can_declarations.h"
 
-const uint8_t PANDA_CAN_CNT = 3U;
-const uint8_t PANDA_BUS_CNT = 3U;
+static const uint8_t PANDA_CAN_CNT = 3U;
+static const uint8_t PANDA_BUS_CNT = 3U;
 
-const unsigned char dlc_to_len[DLC_TO_LEN_ARRAY_SIZE] = {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 12U, 16U, 20U, 24U, 32U, 48U, 64U};
+static const unsigned char dlc_to_len[] = {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 12U, 16U, 20U, 24U, 32U, 48U, 64U};

--- a/board/can.h
+++ b/board/can.h
@@ -2,6 +2,6 @@
 #include "can_declarations.h"
 
 static const uint8_t PANDA_CAN_CNT = 3U;
-static  const uint8_t PANDA_BUS_CNT = 3U;
+static const uint8_t PANDA_BUS_CNT = 3U;
 
 static const unsigned char dlc_to_len[] = {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 12U, 16U, 20U, 24U, 32U, 48U, 64U};

--- a/board/can.h
+++ b/board/can.h
@@ -2,6 +2,6 @@
 #include "can_declarations.h"
 
 static const uint8_t PANDA_CAN_CNT = 3U;
-static const uint8_t PANDA_BUS_CNT = 3U;
+static  const uint8_t PANDA_BUS_CNT = 3U;
 
 static const unsigned char dlc_to_len[] = {0U, 1U, 2U, 3U, 4U, 5U, 6U, 7U, 8U, 12U, 16U, 20U, 24U, 32U, 48U, 64U};

--- a/board/can_declarations.h
+++ b/board/can_declarations.h
@@ -1,8 +1,5 @@
 #pragma once
 
-extern const uint8_t PANDA_CAN_CNT;
-extern const uint8_t PANDA_BUS_CNT;
-
 // bump this when changing the CAN packet
 #define CAN_PACKET_VERSION 4
 
@@ -26,9 +23,6 @@ typedef struct {
   unsigned char checksum;
   unsigned char data[CANPACKET_DATA_SIZE_MAX];
 } __attribute__((packed, aligned(4))) CANPacket_t;
-
-#define DLC_TO_LEN_ARRAY_SIZE 16
-extern const unsigned char dlc_to_len[DLC_TO_LEN_ARRAY_SIZE];
 
 #define GET_BUS(msg) ((msg)->bus)
 #define GET_LEN(msg) (dlc_to_len[(msg)->data_len_code])


### PR DESCRIPTION
In `c++`, const have internal linkage by default. In `c`, const have external linkage by default.

We recently switched to explicitly declaring `PANDA_CAN_CNT` with external linkage (with the `extern` keyword) in order to comply with misra8.4. This does not affect anything in panda, since again in `c` const have external linkage by default and panda is a `c` project.

Because we are still defining variable in header (`PANDA_CAN_CNT` in `can.h`) and declaring them with external linkage now, we get redefinition errors when compiling pandad in openpilot because `can.h` is included in multiple translation units (`pandad.cc`, `main.cc`). This was not a problem before since pandad is a `c++` process, which mean that all those variables were already declared with internal linkage.