### PR TITLE
honda safety: fix mutations failures

### DIFF
--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -456,16 +456,16 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
     self.assertTrue(self._tx(msg))
 
     msg = self._bosh_supplemental_cmd_msg()
-    msg[0].data[0] = 42;
+    msg[0].data[0] = 42
     self.assertFalse(self._tx(msg))
 
     msg = self._bosh_supplemental_cmd_msg()
-    msg[0].data[4] = 42;
+    msg[0].data[4] = 42
     self.assertFalse(self._tx(msg))
 
     msg = self._bosh_supplemental_cmd_msg()
-    msg[0].data[4] = 0;
-    msg[0].data[7] = 42;
+    msg[0].data[4] = 0
+    msg[0].data[7] = 42
     self.assertTrue(self._tx(msg))
 
 

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -455,8 +455,18 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
     msg = self._bosh_supplemental_cmd_msg()
     self.assertTrue(self._tx(msg))
 
+    msg = self._bosh_supplemental_cmd_msg()
     msg[0].data[0] = 42;
     self.assertFalse(self._tx(msg))
+
+    msg = self._bosh_supplemental_cmd_msg()
+    msg[0].data[4] = 42;
+    self.assertFalse(self._tx(msg))
+
+    msg = self._bosh_supplemental_cmd_msg()
+    msg[0].data[4] = 0;
+    msg[0].data[7] = 42;
+    self.assertTrue(self._tx(msg))
 
 
 class TestHondaBoschAltBrakeSafety(HondaPcmEnableBase, TestHondaBoschAltBrakeSafetyBase):

--- a/tests/safety/test_honda.py
+++ b/tests/safety/test_honda.py
@@ -447,6 +447,17 @@ class TestHondaBoschSafety(HondaPcmEnableBase, TestHondaBoschSafetyBase):
     self.safety.set_safety_hooks(Panda.SAFETY_HONDA_BOSCH, 0)
     self.safety.init_tests()
 
+  def _bosh_supplemental_cmd_msg(self):
+    values = {"SET_ME_X04": 0x04, "SET_ME_X80": 0x80, "SET_ME_X10": 0x10}
+    return self.packer.make_can_msg_panda("BOSCH_SUPPLEMENTAL_1", 0, values)
+
+  def test_supplemental_control_check(self):
+    msg = self._bosh_supplemental_cmd_msg()
+    self.assertTrue(self._tx(msg))
+
+    msg[0].data[0] = 42;
+    self.assertFalse(self._tx(msg))
+
 
 class TestHondaBoschAltBrakeSafety(HondaPcmEnableBase, TestHondaBoschAltBrakeSafetyBase):
   """


### PR DESCRIPTION
Currently, this line https://github.com/commaai/panda/blob/08c95bf47ba6d0c5d11a7616e42e10b8dbde19eb/board/safety/safety_honda.h#L281 
can change without the tests catching it