### PR TITLE
chrysler safety: fix mutations failures 

### DIFF
--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -86,9 +86,9 @@ static void chrysler_rx_hook(const CANPacket_t *to_push) {
     vehicle_moving = (GET_BYTE(to_push, 4) != 0U) || (GET_BYTE(to_push, 5) != 0U);
   }
   if ((chrysler_platform == CHRYSLER_PACIFICA) && (bus == 0) && (addr == 514)) {
-    bool speed_l = ((GET_BYTE(to_push, 0) << 4) != 0U) || ((GET_BYTE(to_push, 1) >> 4) != 0U);
-    bool speed_r = ((GET_BYTE(to_push, 2) << 4) != 0U) || ((GET_BYTE(to_push, 3) >> 4) != 0U);
-    vehicle_moving = speed_l || speed_r;
+    bool speed_l_non_zero = ((GET_BYTE(to_push, 0) << 4) != 0U) || ((GET_BYTE(to_push, 1) >> 4) != 0U);
+    bool speed_r_non_zero = ((GET_BYTE(to_push, 2) << 4) != 0U) || ((GET_BYTE(to_push, 3) >> 4) != 0U);
+    vehicle_moving = speed_l_non_zero || speed_r_non_zero;
   }
 
   // exit controls on rising edge of gas press

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -83,12 +83,12 @@ static void chrysler_rx_hook(const CANPacket_t *to_push) {
   // TODO: use the same message for both
   // update vehicle moving
   if ((chrysler_platform != CHRYSLER_PACIFICA) && (bus == 0) && (addr == chrysler_addrs->ESP_8)) {
-    vehicle_moving = ((GET_BYTE(to_push, 4) << 8) + GET_BYTE(to_push, 5)) != 0U;
+    vehicle_moving = (GET_BYTE(to_push, 4) != 0) || (GET_BYTE(to_push, 5) != 0U);
   }
   if ((chrysler_platform == CHRYSLER_PACIFICA) && (bus == 0) && (addr == 514)) {
-    int speed_l = (GET_BYTE(to_push, 0) << 4) + (GET_BYTE(to_push, 1) >> 4);
-    int speed_r = (GET_BYTE(to_push, 2) << 4) + (GET_BYTE(to_push, 3) >> 4);
-    vehicle_moving = (speed_l != 0) || (speed_r != 0);
+    bool speed_l = ((GET_BYTE(to_push, 0) << 4) != 0) || ((GET_BYTE(to_push, 1) >> 4) != 0);
+    bool speed_r = ((GET_BYTE(to_push, 2) << 4) != 0) || ((GET_BYTE(to_push, 3) >> 4) != 0);
+    vehicle_moving = speed_l || speed_r;
   }
 
   // exit controls on rising edge of gas press

--- a/board/safety/safety_chrysler.h
+++ b/board/safety/safety_chrysler.h
@@ -83,11 +83,11 @@ static void chrysler_rx_hook(const CANPacket_t *to_push) {
   // TODO: use the same message for both
   // update vehicle moving
   if ((chrysler_platform != CHRYSLER_PACIFICA) && (bus == 0) && (addr == chrysler_addrs->ESP_8)) {
-    vehicle_moving = (GET_BYTE(to_push, 4) != 0) || (GET_BYTE(to_push, 5) != 0U);
+    vehicle_moving = (GET_BYTE(to_push, 4) != 0U) || (GET_BYTE(to_push, 5) != 0U);
   }
   if ((chrysler_platform == CHRYSLER_PACIFICA) && (bus == 0) && (addr == 514)) {
-    bool speed_l = ((GET_BYTE(to_push, 0) << 4) != 0) || ((GET_BYTE(to_push, 1) >> 4) != 0);
-    bool speed_r = ((GET_BYTE(to_push, 2) << 4) != 0) || ((GET_BYTE(to_push, 3) >> 4) != 0);
+    bool speed_l = ((GET_BYTE(to_push, 0) << 4) != 0U) || ((GET_BYTE(to_push, 1) >> 4) != 0U);
+    bool speed_r = ((GET_BYTE(to_push, 2) << 4) != 0U) || ((GET_BYTE(to_push, 3) >> 4) != 0U);
     vehicle_moving = speed_l || speed_r;
   }
 

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -121,7 +121,7 @@ class TestChryslerRamSafetyBase(TestChryslerSafetyBase):
   def setUpClass(cls):
     if cls.__name__ == "TestChryslerRamSafetyBase":
       raise unittest.SkipTest
-  
+
   # test correctness of lshift and rshift operators for setting vehicle_moving
   def test_rx_hook_vehicle_moving(self):
     self.assertFalse(self.safety.get_vehicle_moving())
@@ -182,6 +182,7 @@ class TestChryslerRamHDSafety(TestChryslerRamSafetyBase):
   def _speed_msg(self, speed):
     values = {"Vehicle_Speed": speed}
     return self.packer.make_can_msg_panda("ESP_8", 0, values)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -94,25 +94,25 @@ class TestChryslerPacificaSafety(TestChryslerSafetyBase):
 
     # speed_l byte 0
     msg = self._speed_msg(0)
-    msg[0].data[0] = 15;
+    msg[0].data[0] = 15
     self.assertTrue(self._rx(msg))
     self.assertTrue(self.safety.get_vehicle_moving())
 
     # speed_l byte 1
     msg = self._speed_msg(0)
-    msg[0].data[1] = 8;
+    msg[0].data[1] = 8
     self.assertTrue(self._rx(msg))
     self.assertFalse(self.safety.get_vehicle_moving())
 
     # speed_r byte 2
     msg = self._speed_msg(0)
-    msg[0].data[2] = 15;
+    msg[0].data[2] = 15
     self.assertTrue(self._rx(msg))
     self.assertTrue(self.safety.get_vehicle_moving())
 
     # speed_r byte 3
     msg = self._speed_msg(0)
-    msg[0].data[3] = 8;
+    msg[0].data[3] = 8
     self.assertTrue(self._rx(msg))
     self.assertFalse(self.safety.get_vehicle_moving())
 
@@ -122,6 +122,7 @@ class TestChryslerRamSafetyBase(TestChryslerSafetyBase):
     if cls.__name__ == "TestChryslerRamSafetyBase":
       raise unittest.SkipTest
   
+  # test correctness of lshift and rshift operators for setting vehicle_moving
   def test_rx_hook_vehicle_moving(self):
     self.assertFalse(self.safety.get_vehicle_moving())
 

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -8,7 +8,6 @@ from panda.tests.safety.common import CANPackerPanda
 
 class TestChryslerSafetyBase(common.PandaCarSafetyTest, common.MotorTorqueSteeringSafetyTest):
   STANDSTILL_THRESHOLD = 0
-  RELAY_MALFUNCTION_ADDRS = {0: (0x292,)}
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   MAX_RT_DELTA = 112
@@ -64,15 +63,12 @@ class TestChryslerSafetyBase(common.PandaCarSafetyTest, common.MotorTorqueSteeri
 
 class TestChryslerPacificaSafety(TestChryslerSafetyBase):
   TX_MSGS = [[0x23B, 0], [0x292, 0], [0x2A6, 0]]
-  STANDSTILL_THRESHOLD = 0
   RELAY_MALFUNCTION_ADDRS = {0: (0x292,)}
   FWD_BLACKLISTED_ADDRS = {2: [0x292, 0x2A6]}
-  FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
   MAX_RATE_UP = 3
   MAX_RATE_DOWN = 3
   MAX_TORQUE = 261
-  MAX_RT_DELTA = 112
 
   LKAS_ACTIVE_VALUE = 1
 

--- a/tests/safety/test_chrysler.py
+++ b/tests/safety/test_chrysler.py
@@ -84,7 +84,6 @@ class TestChryslerPacificaSafety(TestChryslerSafetyBase):
     values = {"SPEED_LEFT": speed, "SPEED_RIGHT": speed}
     return self.packer.make_can_msg_panda("SPEED_1", 0, values)
 
-  # test correctness of lshift and rshift operators for setting vehicle_moving
   def test_rx_hook_vehicle_moving(self):
     self.assertFalse(self.safety.get_vehicle_moving())
 
@@ -118,18 +117,23 @@ class TestChryslerRamSafetyBase(TestChryslerSafetyBase):
     if cls.__name__ == "TestChryslerRamSafetyBase":
       raise unittest.SkipTest
 
-  # test correctness of lshift and rshift operators for setting vehicle_moving
   def test_rx_hook_vehicle_moving(self):
     self.assertFalse(self.safety.get_vehicle_moving())
 
-    self.assertTrue(self._rx(self._speed_msg(1)))
-    self.assertTrue(self.safety.get_vehicle_moving())
-
+    # test 4th bytes = 0, 5th bytes = 0
     self.assertTrue(self._rx(self._speed_msg(0)))
     self.assertFalse(self.safety.get_vehicle_moving())
 
+    # test 4th bytes = 0, 5th bytes = 128
+    self.assertTrue(self._rx(self._speed_msg(1)))
+    self.assertTrue(self.safety.get_vehicle_moving())
+
     # test 4th bytes = 1, 5th bytes = 0
     self.assertTrue(self._rx(self._speed_msg(2)))
+    self.assertTrue(self.safety.get_vehicle_moving())
+
+    # test 4th bytes = 1, 5th bytes = 128
+    self.assertTrue(self._rx(self._speed_msg(3)))
     self.assertTrue(self.safety.get_vehicle_moving())
 
 class TestChryslerRamDTSafety(TestChryslerRamSafetyBase):


### PR DESCRIPTION
Add coverage for these lines:
https://github.com/commaai/panda/blob/f5e1900537b39b98ca269fd3d934bac792c4ae12/board/safety/safety_chrysler.h#L85-L91

Changed the way the check is done in order to be fully testable