### PR TITLE
mutation tests: make coverage gradual 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,7 +118,7 @@ jobs:
         run: eval "$BUILD"
       - name: Mutation tests
         timeout-minutes: 5
-        run: ${{ env.RUN }} "GIT_REF=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }} MUTATION_MODE=${{ matrix.mutation_mode }} cd tests/safety && ./mutation.sh"
+        run: ${{ env.RUN }} "GIT_REF=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }} cd tests/safety && MUTATION_MODE=${{ matrix.mutation_mode }} ./mutation.sh"
 
   static_analysis:
     name: static analysis

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -106,6 +106,9 @@ jobs:
   mutation:
     name: Mutation tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mutation_mode: ['DIFF_COVERAGE', 'SAFETY_ONLY']
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
@@ -115,7 +118,7 @@ jobs:
         run: eval "$BUILD"
       - name: Mutation tests
         timeout-minutes: 5
-        run: ${{ env.RUN }} "GIT_REF=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }} cd tests/safety && ./mutation.sh"
+        run: ${{ env.RUN }} "GIT_REF=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }} MUTATION_MODE=${{ matrix.mutation_mode }} cd tests/safety && ./mutation.sh"
 
   static_analysis:
     name: static analysis

--- a/tests/safety/mutation.sh
+++ b/tests/safety/mutation.sh
@@ -4,15 +4,23 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
-MULL_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_boundary, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic]"
-MULL_MODE="${MULL_MODE:-SAFETY_ONLY}"
+# TODO: add more ops from https://mull.readthedocs.io/en/latest/SupportedMutations.html
+# Note that cxx_assign_const and cxx_init_const are currently broken
+MUTATION_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_boundary, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic]"
+
+# TODO: add more files from board/safety
+MUTATION_SAFETY_FILES=( safety_body.h safety_defaults.h safety_elm327.h )
+
+# MODE_SAFETY_ONLY -> verify mutations on safety_xx.h with test_xx.py
+# MODE_DIFF_COVERAGE -> verify mutations with test_xx.py on the intersection between its code coverage and the current git diff
+MUTATION_MODE="${MUTATION_MODE:-MODE_DIFF_COVERAGE}"
 
 GIT_REF="${GIT_REF:-origin/master}"
 GIT_ROOT=$(git rev-parse --show-toplevel)
-MULL_GIT="gitDiffRef: $GIT_REF\ngitProjectRoot: $GIT_ROOT"
+GIT_MULL_CONFIG="gitDiffRef: $GIT_REF\ngitProjectRoot: $GIT_ROOT"
 
 function write_conf() {
-  echo -e "timeout: 10000\n$MULL_OPS\n$1" > $GIT_ROOT/mull.yml
+  echo -e "timeout: 10000\n$MUTATION_OPS\n$1" > $GIT_ROOT/mull.yml
 }
 
 $DIR/install_mull.sh
@@ -22,14 +30,17 @@ scons --mutation -j$(nproc) -D
 
 SAFETY_TESTS=$(find * | grep "^test_.*\.py")
 for SAFETY_TEST in ${SAFETY_TESTS[@]}; do
+  if [[ $MUTATION_MODE == "MODE_SAFETY_ONLY" ]]; then
+    SAFETY_MODE=$(echo $SAFETY_TEST | sed -e 's/test_/safety_/g' | sed -e 's/\.py/\.h/g')
+    if [[ ! " ${MUTATION_SAFETY_FILES[*]} " =~ [[:space:]]${SAFETY_MODE}[[:space:]] ]]; then
+      continue
+    fi
+    write_conf "includePaths:\n - $SAFETY_MODE"
+  else
+    write_conf "$GIT_MULL_CONFIG"
+  fi
   echo ""
   echo ""
   echo -e "Testing mutations on : $SAFETY_TEST"
-  #if [[ $MULL_MODE == "SAFETY_ONLY" ]]; then
-    #SAFETY_MODE=$(echo $SAFETY_TEST | sed -e 's/test_/safety_/g' | sed -e 's/\.py/\.h/g')
-    #write_conf "includePaths:\n - $SAFETY_MODE"
-  #else
-    #write_conf "$MULL_GIT"
-  #fi
-  mull-runner-17 --ld-search-path /lib/x86_64-linux-gnu/ ../libpanda/libpanda.so -test-program=./$SAFETY_TEST > "FAILURES_$SAFETY_TEST" || true
+  mull-runner-17 --ld-search-path /lib/x86_64-linux-gnu/ ../libpanda/libpanda.so -test-program=./$SAFETY_TEST
 done

--- a/tests/safety/mutation.sh
+++ b/tests/safety/mutation.sh
@@ -4,18 +4,32 @@ set -e
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
 cd $DIR
 
-$DIR/install_mull.sh
+MULL_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic]"
+MULL_MODE="${MULL_MODE:-SAFETY_ONLY}"
 
 GIT_REF="${GIT_REF:-origin/master}"
 GIT_ROOT=$(git rev-parse --show-toplevel)
-echo -e "mutators:\n  - cxx_all" > $GIT_ROOT/mull.yml
-scons --mutation -j$(nproc) -D
-echo -e "timeout: 10000\ngitDiffRef: $GIT_REF\ngitProjectRoot: $GIT_ROOT" >> $GIT_ROOT/mull.yml
+MULL_GIT="gitDiffRef: $GIT_REF\ngitProjectRoot: $GIT_ROOT"
 
-SAFETY_MODELS=$(find * | grep "^test_.*\.py")
-for safety_model in ${SAFETY_MODELS[@]}; do
+function write_conf() {
+  echo -e "timeout: 10000\n$MULL_OPS\n$1" > $GIT_ROOT/mull.yml
+}
+
+$DIR/install_mull.sh
+
+write_conf
+scons --mutation -j$(nproc) -D
+
+SAFETY_TESTS=$(find * | grep "^test_.*\.py")
+for SAFETY_TEST in ${SAFETY_TESTS[@]}; do
   echo ""
   echo ""
-  echo -e "Testing mutations on : $safety_model"
-  mull-runner-17 --ld-search-path /lib/x86_64-linux-gnu/ ../libpanda/libpanda.so -test-program=./$safety_model
+  echo -e "Testing mutations on : $SAFETY_TEST"
+  #if [[ $MULL_MODE == "SAFETY_ONLY" ]]; then
+    #SAFETY_MODE=$(echo $SAFETY_TEST | sed -e 's/test_/safety_/g' | sed -e 's/\.py/\.h/g')
+    #write_conf "includePaths:\n - $SAFETY_MODE"
+  #else
+    #write_conf "$MULL_GIT"
+  #fi
+  mull-runner-17 --ld-search-path /lib/x86_64-linux-gnu/ ../libpanda/libpanda.so -test-program=./$SAFETY_TEST > "FAILURES_$SAFETY_TEST" || true
 done

--- a/tests/safety/mutation.sh
+++ b/tests/safety/mutation.sh
@@ -11,9 +11,9 @@ MUTATION_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_bound
 # TODO: add more files from board/safety
 MUTATION_SAFETY_FILES=( safety_body.h safety_defaults.h safety_elm327.h )
 
-# MODE_SAFETY_ONLY -> verify mutations on safety_xx.h with test_xx.py
-# MODE_DIFF_COVERAGE -> verify mutations with test_xx.py on the intersection between its code coverage and the current git diff
-MUTATION_MODE="${MUTATION_MODE:-MODE_DIFF_COVERAGE}"
+# SAFETY_ONLY -> verify mutations on safety_xx.h with test_xx.py
+# DIFF_COVERAGE -> verify mutations with test_xx.py on the intersection between its code coverage and the current git diff
+MUTATION_MODE="${MUTATION_MODE:-DIFF_COVERAGE}"
 
 GIT_REF="${GIT_REF:-origin/master}"
 GIT_ROOT=$(git rev-parse --show-toplevel)
@@ -30,7 +30,7 @@ scons --mutation -j$(nproc) -D
 
 SAFETY_TESTS=$(find * | grep "^test_.*\.py")
 for SAFETY_TEST in ${SAFETY_TESTS[@]}; do
-  if [[ $MUTATION_MODE == "MODE_SAFETY_ONLY" ]]; then
+  if [[ $MUTATION_MODE == "SAFETY_ONLY" ]]; then
     SAFETY_MODE=$(echo $SAFETY_TEST | sed -e 's/test_/safety_/g' | sed -e 's/\.py/\.h/g')
     if [[ ! " ${MUTATION_SAFETY_FILES[*]} " =~ [[:space:]]${SAFETY_MODE}[[:space:]] ]]; then
       continue


### PR DESCRIPTION
Here is my proposal for making the mutation tests coverage increase over time while still being practical.

We have 2 testing modes that are run in parallel in CI:

1. DIFF_COVERAGE. This mode verifies mutations with `test_xx.py` (all of them) on the intersection between its code coverage and the current git diff. This mode is very powerful since it will cover basically all the files if they are changed and will still run super fast.

2. SAFETY_ONLY. This mode verifies mutations on `safety_xx.h` with `test_xx.py` if safety_xx.h is in `MUTATION_SAFETY_FILES`. Overtime, the goal is to add all the safety modes in that list. We can split those nicely, add them one by one and even put them on bounties.

Regardless of the testing mode, we are using all the ops in the `MUTATION_OPS` list to mutate the code. Overtime, the goal is to add  [most ops listed here](https://mull.readthedocs.io/en/latest/SupportedMutations.html) in that list.

In the end, we can increase coverage in 3 ways: add files to `MUTATION_SAFETY_FILES`, add ops to `MUTATION_OPS` and add a third testing mode for other files we want to always check.