### PR TITLE
use logger info for flashing

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -515,22 +515,22 @@ class Panda:
     assert last_sector < 7, "Binary too large! Risk of overwriting provisioning chunk."
 
     # unlock flash
-    logger.warning("flash: unlocking")
+    logger.info("flash: unlocking")
     handle.controlWrite(Panda.REQUEST_IN, 0xb1, 0, 0, b'')
 
     # erase sectors
-    logger.warning(f"flash: erasing sectors 1 - {last_sector}")
+    logger.info(f"flash: erasing sectors 1 - {last_sector}")
     for i in range(1, last_sector + 1):
       handle.controlWrite(Panda.REQUEST_IN, 0xb2, i, 0, b'')
 
     # flash over EP2
     STEP = 0x10
-    logger.warning("flash: flashing")
+    logger.info("flash: flashing")
     for i in range(0, len(code), STEP):
       handle.bulkWrite(2, code[i:i + STEP])
 
     # reset
-    logger.warning("flash: resetting")
+    logger.info("flash: resetting")
     try:
       handle.controlWrite(Panda.REQUEST_IN, 0xd8, 0, 0, b'', expect_disconnect=True)
     except Exception:
@@ -538,7 +538,7 @@ class Panda:
 
   def flash(self, fn=None, code=None, reconnect=True):
     if self.up_to_date(fn=fn):
-      logger.debug("flash: already up to date")
+      logger.info("flash: already up to date")
       return
 
     if not fn:


### PR DESCRIPTION
- `flash: already up to date` was not showing up when running `flash.py`
- other messages can be `info` since they are normal flashing sequence

