### PR TITLE
mutation test: add more ops

### DIFF
--- a/tests/safety/mutation.sh
+++ b/tests/safety/mutation.sh
@@ -8,7 +8,7 @@ $DIR/install_mull.sh
 
 GIT_REF="${GIT_REF:-origin/master}"
 GIT_ROOT=$(git rev-parse --show-toplevel)
-MULL_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_boundary, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic, cxx_remove_negation]"
+MULL_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_boundary, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic, cxx_remove_negation, cxx_replace_scalar_call]"
 echo -e "$MULL_OPS" > $GIT_ROOT/mull.yml
 scons --mutation -j$(nproc) -D
 echo -e "timeout: 10000\ngitDiffRef: $GIT_REF\ngitProjectRoot: $GIT_ROOT" >> $GIT_ROOT/mull.yml

--- a/tests/safety/mutation.sh
+++ b/tests/safety/mutation.sh
@@ -8,7 +8,7 @@ $DIR/install_mull.sh
 
 GIT_REF="${GIT_REF:-origin/master}"
 GIT_ROOT=$(git rev-parse --show-toplevel)
-MULL_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_boundary, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic]"
+MULL_OPS="mutators: [cxx_increment, cxx_decrement, cxx_comparison, cxx_boundary, cxx_bitwise_assignment, cxx_bitwise, cxx_arithmetic_assignment, cxx_arithmetic, cxx_remove_negation]"
 echo -e "$MULL_OPS" > $GIT_ROOT/mull.yml
 scons --mutation -j$(nproc) -D
 echo -e "timeout: 10000\ngitDiffRef: $GIT_REF\ngitProjectRoot: $GIT_ROOT" >> $GIT_ROOT/mull.yml


### PR DESCRIPTION
We are currently missing 2 ops group:

`cxx_const_assignment` is buggy in our code base, will need to open an issue 

`cxx_logical` is known to be buggy: https://github.com/mull-project/mull/issues/994