### PR TITLE
Remove retry loop 

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -831,18 +831,13 @@ class Panda:
   @ensure_can_packet_version
   def can_send_many(self, arr, timeout=CAN_SEND_TIMEOUT_MS):
     snds = pack_can_buffer(arr)
-    while True:
-      try:
-        for tx in snds:
-          while True:
-            bs = self._handle.bulkWrite(3, tx, timeout=timeout)
-            tx = tx[bs:]
-            if len(tx) == 0:
-              break
-            logger.error("CAN: PARTIAL SEND MANY, RETRYING")
-        break
-      except (usb1.USBErrorIO, usb1.USBErrorOverflow):
-        logger.error("CAN: BAD SEND MANY, RETRYING")
+    for tx in snds:
+      while True:
+        bs = self._handle.bulkWrite(3, tx, timeout=timeout)
+        tx = tx[bs:]
+        if len(tx) == 0:
+          break
+        logger.error("CAN: PARTIAL SEND MANY, RETRYING")
 
   def can_send(self, addr, dat, bus, timeout=CAN_SEND_TIMEOUT_MS):
     self.can_send_many([[addr, dat, bus]], timeout=timeout)

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -832,12 +832,9 @@ class Panda:
   def can_send_many(self, arr, timeout=CAN_SEND_TIMEOUT_MS):
     snds = pack_can_buffer(arr)
     for tx in snds:
-      while True:
+      while len(tx) > 0:
         bs = self._handle.bulkWrite(3, tx, timeout=timeout)
         tx = tx[bs:]
-        if len(tx) == 0:
-          break
-        logger.error("CAN: PARTIAL SEND MANY, RETRYING")
 
   def can_send(self, addr, dat, bus, timeout=CAN_SEND_TIMEOUT_MS):
     self.can_send_many([[addr, dat, bus]], timeout=timeout)


### PR DESCRIPTION
Current implementation could potentially result in an endless loop, which cannot be caught or handled from outside the function. 