### PR TITLE
ford - reset steering angle state when driver stops overriding steering

### DIFF
--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -173,6 +173,7 @@ bool safety_tx_hook(CANPacket_t *to_send);
 uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last);
 int to_signed(int d, int bits);
 void update_sample(struct sample_t *sample, int sample_new);
+void update_steering_pressed(bool steer_pressed, uint8_t steering_pressed_min_count);
 bool get_longitudinal_allowed(void);
 int ROUND(float val);
 void gen_crc_lookup_table_8(uint8_t poly, uint8_t crc_lut[]);


### PR DESCRIPTION
Currently if the driver manually steers faster than the angle rate limits for Ford (and others) then openpilot will not be able to resume from the current curvature/steering angle until the rate limit catches up to the actual state.

This resets the steering angle with the previous measured angle upon detecting the user has stopped overriding. This means that rate limit clips will be centered on the currently measured angle for the first frame after done overriding.