### PR TITLE
Toyota: SecOC longitudinal control safety

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pip3 install --break-system-packages --no-cache-dir $PYTHONPATH/panda/[dev]
 
 # TODO: this should be a "pip install" or not even in this repo at all
 RUN git config --global --add safe.directory $PYTHONPATH/panda
-ENV OPENDBC_REF="e1ce3619a5db661ef2b406ccf258a253baf6eebc"
+ENV OPENDBC_REF="d632cc5bec14d4e077fdf25e19b24b434c2653fd"
 RUN cd /tmp/ && \
     git clone --depth 1 https://github.com/commaai/opendbc opendbc_repo && \
     cd opendbc_repo && git fetch origin $OPENDBC_REF && git checkout FETCH_HEAD && rm -rf .git/ && \

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -12,7 +12,9 @@
 
 #define TOYOTA_COMMON_SECOC_TX_MSGS \
   TOYOTA_BASE_TX_MSGS \
-  {0x2E4, 0, 8}, {0x131, 0, 8}, \
+  {0x2E4, 0, 8}, {0x131, 0, 8},  /* STEERING_LKA (longer message for SecOC), STEERING_LTA_2 */  \
+  {0x183, 0, 8}, {0x411, 0, 8},  /* ACC_CONTROL_2, PCS_HUD */  \
+  {0x750, 0, 8},  /* radar diagnostic address */  \
 
 #define TOYOTA_COMMON_LONG_TX_MSGS                                                                                                          \
   TOYOTA_COMMON_TX_MSGS                                                                                                                     \
@@ -140,8 +142,8 @@ static void toyota_rx_hook(const CANPacket_t *to_push) {
     }
 
     bool stock_ecu_detected = addr == 0x2E4;  // STEERING_LKA
-    if (!toyota_stock_longitudinal && (addr == 0x343)) {
-      stock_ecu_detected = true;  // ACC_CONTROL
+    if (!toyota_stock_longitudinal && ((addr == 0x343) | (toyota_secoc && (addr == 0x183)))) {
+      stock_ecu_detected = true;  // ACC_CONTROL or ACC_CONTROL_2
     }
     generic_rx_checks(stock_ecu_detected);
   }
@@ -198,6 +200,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
       desired_accel = to_signed(desired_accel, 16);
 
       bool violation = false;
+      violation |= (desired_accel != 0) && toyota_secoc;  // SecOC cars still use 0x343, but accel itself is in 0x183
       violation |= longitudinal_accel_checks(desired_accel, TOYOTA_LONG_LIMITS);
 
       // only ACC messages that cancel are allowed when openpilot is not controlling longitudinal
@@ -210,6 +213,19 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
           violation = true;
         }
       }
+
+      if (violation) {
+        tx = false;
+      }
+    }
+
+    if (addr == 0x183) {
+      int desired_accel = (GET_BYTE(to_send, 0) << 8) | GET_BYTE(to_send, 1);
+      desired_accel = to_signed(desired_accel, 16);
+
+      bool violation = false;
+      violation |= !toyota_secoc;  // Only SecOC cars may transmit this message
+      violation |= longitudinal_accel_checks(desired_accel, TOYOTA_LONG_LIMITS);
 
       if (violation) {
         tx = false;
@@ -349,12 +365,10 @@ static safety_config toyota_init(uint16_t param) {
   toyota_dbc_eps_torque_factor = param & TOYOTA_EPS_FACTOR;
 
   safety_config ret;
-  if (toyota_stock_longitudinal) {
-    if (toyota_secoc) {
-      SET_TX_MSGS(TOYOTA_SECOC_TX_MSGS, ret);
-    } else {
-      SET_TX_MSGS(TOYOTA_TX_MSGS, ret);
-    }
+  if (toyota_secoc) {
+    SET_TX_MSGS(TOYOTA_SECOC_TX_MSGS, ret);
+  } else if (toyota_stock_longitudinal) {
+    SET_TX_MSGS(TOYOTA_TX_MSGS, ret);
   } else {
     SET_TX_MSGS(TOYOTA_LONG_TX_MSGS, ret);
   }
@@ -389,10 +403,11 @@ static int toyota_fwd_hook(int bus_num, int addr) {
     // block stock lkas messages and stock acc messages (if OP is doing ACC)
     // in TSS2, 0x191 is LTA which we need to block to avoid controls collision
     bool is_lkas_msg = ((addr == 0x2E4) || (addr == 0x412) || (addr == 0x191));
-    // on SecOC cars 0x131 is also LTA
-    is_lkas_msg |= toyota_secoc && (addr == 0x131);
     // in TSS2 the camera does ACC as well, so filter 0x343
     bool is_acc_msg = (addr == 0x343);
+    // SecOC cars use additional (not alternate) messages for lateral and longitudinal actuation
+    is_lkas_msg |= toyota_secoc && (addr == 0x131);
+    is_acc_msg |= toyota_secoc && (addr == 0x183);
     bool block_msg = is_lkas_msg || (is_acc_msg && !toyota_stock_longitudinal);
     if (!block_msg) {
       bus_fwd = 0;

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -142,7 +142,7 @@ static void toyota_rx_hook(const CANPacket_t *to_push) {
     }
 
     bool stock_ecu_detected = addr == 0x2E4;  // STEERING_LKA
-    if (!toyota_stock_longitudinal && ((addr == 0x343) | (toyota_secoc && (addr == 0x183)))) {
+    if (!toyota_stock_longitudinal && ((addr == 0x343) || (toyota_secoc && (addr == 0x183)))) {
       stock_ecu_detected = true;  // ACC_CONTROL or ACC_CONTROL_2
     }
     generic_rx_checks(stock_ecu_detected);

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -200,7 +200,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
       desired_accel = to_signed(desired_accel, 16);
 
       bool violation = false;
-      violation |= toyota_secoc && (desired_accel != 0);  // SecOC cars still use 0x343, but accel itself is in 0x183
+      violation |= toyota_secoc && (desired_accel != TOYOTA_LONG_LIMITS.inactive_accel);  // SecOC cars move this signal to 0x183
       violation |= longitudinal_accel_checks(desired_accel, TOYOTA_LONG_LIMITS);
 
       // only ACC messages that cancel are allowed when openpilot is not controlling longitudinal

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -200,7 +200,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
       desired_accel = to_signed(desired_accel, 16);
 
       bool violation = false;
-      violation |= (desired_accel != 0) && toyota_secoc;  // SecOC cars still use 0x343, but accel itself is in 0x183
+      violation |= toyota_secoc && (desired_accel != 0);  // SecOC cars still use 0x343, but accel itself is in 0x183
       violation |= longitudinal_accel_checks(desired_accel, TOYOTA_LONG_LIMITS);
 
       // only ACC messages that cancel are allowed when openpilot is not controlling longitudinal

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -223,8 +223,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
       int desired_accel = (GET_BYTE(to_send, 0) << 8) | GET_BYTE(to_send, 1);
       desired_accel = to_signed(desired_accel, 16);
 
-      bool violation = false;
-      violation |= !toyota_secoc;  // Only SecOC cars may transmit this message
+      bool violation = !toyota_secoc;  // Only SecOC cars may transmit this message
       violation |= longitudinal_accel_checks(desired_accel, TOYOTA_LONG_LIMITS);
 
       if (violation) {


### PR DESCRIPTION
Complement to commaai/opendbc#1385, intended to progress (not necessarily replace) commaai/panda#2061.

- [x] opendbc needs a corresponding change to send inactive accel in ACC_CONTROL
- [ ] common test override is lame, can we do better?
- [x] do we actually need the radar diagnostic address when we're able to MITM?
  * Radar diagnostic is permitted for all Toyota long right now, should scope better but not in this PR