### PR TITLE
Tesla: Panda safety update

### DIFF
--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -126,7 +126,7 @@ static bool tesla_tx_hook(const CANPacket_t *to_send) {
 
       violation |= longitudinal_accel_checks(raw_accel_max, TESLA_LONG_LIMITS);
       violation |= longitudinal_accel_checks(raw_accel_min, TESLA_LONG_LIMITS);
-    } else if(!tesla_longitudinal && acc_state == 13) {
+    } else if(acc_state == 13) {
       // Allow to cancel if not using openpilot longitudinal
     } else {
       violation = true;

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -33,7 +33,7 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
       brake_pressed = (GET_BYTE(to_push, 2) & 0x03U)  == 2U;
     }
 
-    // Cruise state & standstill
+    // Cruise state
     if(addr == 0x286) {
       int cruise_state = ((GET_BYTE(to_push, 1) << 1 ) >> 5);
       bool cruise_engaged = (cruise_state == 2) ||  // ENABLED

--- a/board/safety/safety_tesla.h
+++ b/board/safety/safety_tesla.h
@@ -33,16 +33,16 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
       brake_pressed = (GET_BYTE(to_push, 2) & 0x03U)  == 2U;
     }
 
-    // Cruise state
+    // Cruise state & standstill
     if(addr == 0x286) {
-      vehicle_moving = ((GET_BYTE(to_push, 5) & 0x1CU) >> 2) != 3U;
-
       int cruise_state = ((GET_BYTE(to_push, 1) << 1 ) >> 5);
       bool cruise_engaged = (cruise_state == 2) ||  // ENABLED
                             (cruise_state == 3) ||  // STANDSTILL
                             (cruise_state == 4) ||  // OVERRIDE
                             (cruise_state == 6) ||  // PRE_FAULT
                             (cruise_state == 7);    // PRE_CANCEL
+
+      vehicle_moving = cruise_state != 3; // STANDSTILL
       pcm_cruise_check(cruise_engaged);
     }
   }
@@ -102,6 +102,7 @@ static bool tesla_tx_hook(const CANPacket_t *to_send) {
 
   if(addr == 0x2b9) {
     // DAS_control: longitudinal control message
+    int acc_state = ((GET_BYTE(to_send, 1) & 0xF0U) >> 4);
     if (tesla_longitudinal) {
       // No AEB events may be sent by openpilot
       int aeb_event = GET_BYTE(to_send, 2) & 0x03U;
@@ -125,6 +126,8 @@ static bool tesla_tx_hook(const CANPacket_t *to_send) {
 
       violation |= longitudinal_accel_checks(raw_accel_max, TESLA_LONG_LIMITS);
       violation |= longitudinal_accel_checks(raw_accel_min, TESLA_LONG_LIMITS);
+    } else if(!tesla_longitudinal && acc_state == 13) {
+      // Allow to cancel if not using openpilot longitudinal
     } else {
       violation = true;
     }

--- a/tests/safety/test_tesla.py
+++ b/tests/safety/test_tesla.py
@@ -14,7 +14,7 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest):
   FWD_BLACKLISTED_ADDRS = {2: [MSG_DAS_steeringControl, MSG_APS_eacMonitor]}
   TX_MSGS = [[MSG_DAS_steeringControl, 0], [MSG_APS_eacMonitor, 0], [MSG_DAS_Control, 0]]
 
-  STANDSTILL_THRESHOLD = 1
+  STANDSTILL_THRESHOLD = 0.1
   GAS_PRESSED_THRESHOLD = 3
   FWD_BUS_LOOKUP = {0: 2, 2: 0}
 
@@ -34,7 +34,7 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest):
     return self.packer.make_can_msg_panda("DI_speed", 0, values)
 
   def _vehicle_moving_msg(self, speed: float):
-    values = {"DI_vehicleHoldState": 3 if speed <= self.STANDSTILL_THRESHOLD else 0}
+    values = {"DI_cruiseState": 3 if speed <= self.STANDSTILL_THRESHOLD else 2}
     return self.packer.make_can_msg_panda("DI_state", 0, values)
 
   def _user_gas_msg(self, gas):


### PR DESCRIPTION
- match `vehicle_moving` signal with opendbc Implementation
- allow cancel if openpilot Longitudinal Control is not enabled