### PR TITLE
Control over FD flag of CAN messages

### DIFF
--- a/board/can_declarations.h
+++ b/board/can_declarations.h
@@ -13,7 +13,7 @@
 #endif
 
 typedef struct {
-  unsigned char reserved : 1;
+  unsigned char fd : 1;
   unsigned char bus : 3;
   unsigned char data_len_code : 4;  // lookup length with dlc_to_len
   unsigned char rejected : 1;

--- a/board/drivers/bxcan.h
+++ b/board/drivers/bxcan.h
@@ -89,6 +89,7 @@ void process_can(uint8_t can_number) {
       if ((CANx->TSR & CAN_TSR_RQCP0) == CAN_TSR_RQCP0) {
         if ((CANx->TSR & CAN_TSR_TXOK0) == CAN_TSR_TXOK0) {
           CANPacket_t to_push;
+          to_push.fd = 0U;
           to_push.returned = 1U;
           to_push.rejected = 0U;
           to_push.extended = (CANx->sTxMailBox[0].TIR >> 2) & 0x1U;
@@ -144,6 +145,7 @@ void can_rx(uint8_t can_number) {
     // add to my fifo
     CANPacket_t to_push;
 
+    to_push.fd = 0U;
     to_push.returned = 0U;
     to_push.rejected = 0U;
     to_push.extended = (CANx->sFIFOMailBox[0].RIR >> 2) & 0x1U;
@@ -159,6 +161,7 @@ void can_rx(uint8_t can_number) {
     if (bus_fwd_num != -1) {
       CANPacket_t to_send;
 
+      to_send.fd = 0U;
       to_send.returned = 0U;
       to_send.rejected = 0U;
       to_send.extended = to_push.extended; // TXRQ

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -131,10 +131,10 @@ void can_clear(can_ring *q) {
 // Helpers
 // Panda:       Bus 0=CAN1   Bus 1=CAN2   Bus 2=CAN3
 bus_config_t bus_config[BUS_CONFIG_ARRAY_SIZE] = {
-  { .bus_lookup = 0U, .can_num_lookup = 0U, .forwarding_bus = -1, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
-  { .bus_lookup = 1U, .can_num_lookup = 1U, .forwarding_bus = -1, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
-  { .bus_lookup = 2U, .can_num_lookup = 2U, .forwarding_bus = -1, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
-  { .bus_lookup = 0xFFU, .can_num_lookup = 0xFFU, .forwarding_bus = -1, .can_speed = 333U, .can_data_speed = 333U, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
+  { .bus_lookup = 0U, .can_num_lookup = 0U, .forwarding_bus = -1, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_auto = false, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
+  { .bus_lookup = 1U, .can_num_lookup = 1U, .forwarding_bus = -1, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_auto = false, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
+  { .bus_lookup = 2U, .can_num_lookup = 2U, .forwarding_bus = -1, .can_speed = 5000U, .can_data_speed = 20000U, .canfd_auto = false, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
+  { .bus_lookup = 0xFFU, .can_num_lookup = 0xFFU, .forwarding_bus = -1, .can_speed = 333U, .can_data_speed = 333U, .canfd_auto = false, .canfd_enabled = false, .brs_enabled = false, .canfd_non_iso = false },
 };
 
 void can_init_all(void) {
@@ -165,7 +165,7 @@ void ignition_can_hook(CANPacket_t *to_push) {
   if (bus == 0) {
     int addr = GET_ADDR(to_push);
     int len = GET_LEN(to_push);
-    
+
     // GM exception
     if ((addr == 0x1F1) && (len == 8)) {
       // SystemPowerMode (2=Run, 3=Crank Request)

--- a/board/drivers/can_common_declarations.h
+++ b/board/drivers/can_common_declarations.h
@@ -13,6 +13,7 @@ typedef struct {
   int8_t forwarding_bus;
   uint32_t can_speed;
   uint32_t can_data_speed;
+  bool canfd_auto;
   bool canfd_enabled;
   bool brs_enabled;
   bool canfd_non_iso;

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -100,7 +100,11 @@ void process_can(uint8_t can_number) {
           fifo = (canfd_fifo *)(TxFIFOSA + (tx_index * FDCAN_TX_FIFO_EL_SIZE));
 
           fifo->header[0] = (to_send.extended << 30) | ((to_send.extended != 0U) ? (to_send.addr) : (to_send.addr << 18));
-          uint32_t canfd_enabled_header = bus_config[can_number].canfd_enabled ? (1UL << 21) : 0UL;
+
+          // If canfd_auto is set, outgoing packets will be automatically sent as CAN FD if an incoming CAN-FD packet was received
+          bool fd = bus_config[can_number].canfd_auto ? bus_config[can_number].canfd_enabled : to_send.fd;
+          uint32_t canfd_enabled_header = fd ? (1UL << 21) : 0UL;
+
           uint32_t brs_enabled_header = bus_config[can_number].brs_enabled ? (1UL << 20) : 0UL;
           fifo->header[1] = (to_send.data_len_code << 16) | canfd_enabled_header | brs_enabled_header;
 
@@ -115,6 +119,7 @@ void process_can(uint8_t can_number) {
           // Send back to USB
           CANPacket_t to_push;
 
+          to_push.fd = fd;
           to_push.returned = 1U;
           to_push.rejected = 0U;
           to_push.extended = to_send.extended;
@@ -168,15 +173,16 @@ void can_rx(uint8_t can_number) {
     // getting address
     fifo = (canfd_fifo *)(RxFIFO0SA + (rx_fifo_idx * FDCAN_RX_FIFO_0_EL_SIZE));
 
+    bool canfd_frame = ((fifo->header[1] >> 21) & 0x1U);
+    bool brs_frame = ((fifo->header[1] >> 20) & 0x1U);
+
+    to_push.fd = canfd_frame;
     to_push.returned = 0U;
     to_push.rejected = 0U;
     to_push.extended = (fifo->header[0] >> 30) & 0x1U;
     to_push.addr = ((to_push.extended != 0U) ? (fifo->header[0] & 0x1FFFFFFFU) : ((fifo->header[0] >> 18) & 0x7FFU));
     to_push.bus = bus_number;
     to_push.data_len_code = ((fifo->header[1] >> 16) & 0xFU);
-
-    bool canfd_frame = ((fifo->header[1] >> 21) & 0x1U);
-    bool brs_frame = ((fifo->header[1] >> 20) & 0x1U);
 
     uint8_t data_len_w = (dlc_to_len[to_push.data_len_code] / 4U);
     data_len_w += ((dlc_to_len[to_push.data_len_code] % 4U) > 0U) ? 1U : 0U;
@@ -193,6 +199,7 @@ void can_rx(uint8_t can_number) {
     if (bus_fwd_num != -1) {
       CANPacket_t to_send;
 
+      to_push.fd = to_push.fd;
       to_send.returned = 0U;
       to_send.rejected = 0U;
       to_send.extended = to_push.extended;

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -101,8 +101,8 @@ void process_can(uint8_t can_number) {
 
           fifo->header[0] = (to_send.extended << 30) | ((to_send.extended != 0U) ? (to_send.addr) : (to_send.addr << 18));
 
-          // If canfd_auto is set, outgoing packets will be automatically sent as CAN FD if an incoming CAN-FD packet was received
-          bool fd = bus_config[can_number].canfd_auto ? bus_config[can_number].canfd_enabled : to_send.fd;
+          // If canfd_auto is set, outgoing packets will be automatically sent as CAN-FD if an incoming CAN-FD packet was seen
+          bool fd = bus_config[can_number].canfd_auto ? bus_config[can_number].canfd_enabled : (bool)(to_send.fd > 0U);
           uint32_t canfd_enabled_header = fd ? (1UL << 21) : 0UL;
 
           uint32_t brs_enabled_header = bus_config[can_number].brs_enabled ? (1UL << 20) : 0UL;
@@ -199,7 +199,7 @@ void can_rx(uint8_t can_number) {
     if (bus_fwd_num != -1) {
       CANPacket_t to_send;
 
-      to_push.fd = to_push.fd;
+      to_send.fd = to_push.fd;
       to_send.returned = 0U;
       to_send.rejected = 0U;
       to_send.extended = to_push.extended;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -317,6 +317,10 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
     case 0xe7:
       set_power_save_state(req->param1);
       break;
+    // **** 0xe8: set can-fd auto swithing mode
+    case 0xe8:
+        bus_config[req->param1].canfd_auto = req->param2 > 0U;
+        break;
     // **** 0xf1: Clear CAN ring buffer.
     case 0xf1:
       if (req->param1 == 0xFFFFU) {

--- a/tests/libpanda/libpanda_py.py
+++ b/tests/libpanda/libpanda_py.py
@@ -12,7 +12,7 @@ ffi = FFI()
 
 ffi.cdef("""
 typedef struct {
-  unsigned char reserved : 1;
+  unsigned char fd : 1;
   unsigned char bus : 3;
   unsigned char data_len_code : 4;
   unsigned char rejected : 1;


### PR DESCRIPTION
Currently once a CAN-FD message is seen on a bus, all future messages are sent out as FD. This probably made porting the first CAN-FD cars easier, as openpilot does need to know about this.

However, with Toyota CAN-FD cars I've already ran into an issue where diagnostic messages are only accepted if they are non-FD. Also in future car ports it might be necessary to mix FD and non-FD messages.

In this PR I'm suggesting to use the reserved bit in the USB/SPI message to set the FD state of an incoming/outgoing message. I've also added an endpoint to enable the current behavior to make a smooth migration possible, when this is merged boardd should probably set this.

My questions:
- Are you interested in adding functionality like this?
- The FD flag is probably the most necessary to add, and does not require making the packet larger. But if you want to be 100% correct you also want to add flags for BRS and RTR. Is this something you'd like to add if we're messing with the `CANPacket_t` anyway?
- I've added the `fd` argument to `can_send`/`can_send_many`, but it's probably cleaner to create something like a dataclass to hold a CAN frame. If you want that I can do that in a separate PR first, but that would require many changes.

Behavior verified with a Red Panda and PeakCAN SocketCAN. But should probably tested together with the indented openpilot change before merging. Otherwise this PR is ready to merge.