### PR TITLE
Ensure auto switching FD is off in Python

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -324,6 +324,10 @@ class Panda:
     # reset comms
     self.can_reset_communications()
 
+    # disable automatic CAN-FD switching
+    for bus in range(PANDA_BUS_CNT):
+      self.set_canfd_auto(bus, False)
+
     # set CAN speed
     for bus in range(PANDA_BUS_CNT):
       self.set_can_speed_kbps(bus, self._can_speed_kbps)


### PR DESCRIPTION
Disable auto switching (= default state) on connecting using the Python API. This state is persistent, and therefore may have been left in the enabled state by openpilot.