### PR TITLE
test: Allow running test_misra.sh easy on macos

### DIFF
--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -50,7 +50,7 @@ cppcheck() {
           --suppressions-list=$DIR/suppressions.txt --suppress=*:*inc/* \
           --suppress=*:*include/* --error-exitcode=2 --check-level=exhaustive --safety \
           --platform=arm32-wchar_t4 $COMMON_DEFINES --checkers-report=$CHECKLIST.tmp \
-          --std=c11 "$@" |& tee $OUTPUT
+          --std=c11 "$@" 2>&1 | tee $OUTPUT
 
   cat $CHECKLIST.tmp >> $CHECKLIST
   rm $CHECKLIST.tmp


### PR DESCRIPTION
simple fix to be able to run misra with macos's default bash and it should have no impact on linux / unix