### PR TITLE
Hyundai: Synchronize flag names

### DIFF
--- a/board/safety/safety_hyundai_canfd.h
+++ b/board/safety/safety_hyundai_canfd.h
@@ -225,8 +225,8 @@ static int hyundai_canfd_fwd_hook(int bus_num, int addr) {
 }
 
 static safety_config hyundai_canfd_init(uint16_t param) {
-  const int HYUNDAI_PARAM_CANFD_HDA2_ALT_STEERING = 128;
-  const int HYUNDAI_PARAM_CANFD_ALT_BUTTONS = 32;
+  const int FLAG_HYUNDAI_CANFD_HDA2_ALT_STEERING = 128;
+  const int FLAG_HYUNDAI_CANFD_ALT_BUTTONS = 32;
 
   static const CanMsg HYUNDAI_CANFD_HDA2_TX_MSGS[] = {
     {0x50, 0, 16},  // LKAS
@@ -267,8 +267,8 @@ static safety_config hyundai_canfd_init(uint16_t param) {
   hyundai_common_init(param);
 
   gen_crc_lookup_table_16(0x1021, hyundai_canfd_crc_lut);
-  hyundai_canfd_alt_buttons = GET_FLAG(param, HYUNDAI_PARAM_CANFD_ALT_BUTTONS);
-  hyundai_canfd_hda2_alt_steering = GET_FLAG(param, HYUNDAI_PARAM_CANFD_HDA2_ALT_STEERING);
+  hyundai_canfd_alt_buttons = GET_FLAG(param, FLAG_HYUNDAI_CANFD_ALT_BUTTONS);
+  hyundai_canfd_hda2_alt_steering = GET_FLAG(param, FLAG_HYUNDAI_CANFD_HDA2_ALT_STEERING);
 
   // no long for radar-SCC HDA1 yet
   if (!hyundai_canfd_hda2 && !hyundai_camera_scc) {

--- a/board/safety/safety_hyundai_common.h
+++ b/board/safety/safety_hyundai_common.h
@@ -39,23 +39,23 @@ bool hyundai_alt_limits = false;
 static uint8_t hyundai_last_button_interaction;  // button messages since the user pressed an enable button
 
 void hyundai_common_init(uint16_t param) {
-  const int HYUNDAI_PARAM_EV_GAS = 1;
-  const int HYUNDAI_PARAM_HYBRID_GAS = 2;
-  const int HYUNDAI_PARAM_CAMERA_SCC = 8;
-  const int HYUNDAI_PARAM_CANFD_HDA2 = 16;
-  const int HYUNDAI_PARAM_ALT_LIMITS = 64; // TODO: shift this down with the rest of the common flags
+  const int FLAG_HYUNDAI_EV_GAS = 1;
+  const int FLAG_HYUNDAI_HYBRID_GAS = 2;
+  const int FLAG_HYUNDAI_CAMERA_SCC = 8;
+  const int FLAG_HYUNDAI_CANFD_HDA2 = 16;
+  const int FLAG_HYUNDAI_ALT_LIMITS = 64; // TODO: shift this down with the rest of the common flags
 
-  hyundai_ev_gas_signal = GET_FLAG(param, HYUNDAI_PARAM_EV_GAS);
-  hyundai_hybrid_gas_signal = !hyundai_ev_gas_signal && GET_FLAG(param, HYUNDAI_PARAM_HYBRID_GAS);
-  hyundai_camera_scc = GET_FLAG(param, HYUNDAI_PARAM_CAMERA_SCC);
-  hyundai_canfd_hda2 = GET_FLAG(param, HYUNDAI_PARAM_CANFD_HDA2);
-  hyundai_alt_limits = GET_FLAG(param, HYUNDAI_PARAM_ALT_LIMITS);
+  hyundai_ev_gas_signal = GET_FLAG(param, FLAG_HYUNDAI_EV_GAS);
+  hyundai_hybrid_gas_signal = !hyundai_ev_gas_signal && GET_FLAG(param, FLAG_HYUNDAI_HYBRID_GAS);
+  hyundai_camera_scc = GET_FLAG(param, FLAG_HYUNDAI_CAMERA_SCC);
+  hyundai_canfd_hda2 = GET_FLAG(param, FLAG_HYUNDAI_CANFD_HDA2);
+  hyundai_alt_limits = GET_FLAG(param, FLAG_HYUNDAI_ALT_LIMITS);
 
   hyundai_last_button_interaction = HYUNDAI_PREV_BUTTON_SAMPLES;
 
 #ifdef ALLOW_DEBUG
-  const int HYUNDAI_PARAM_LONGITUDINAL = 4;
-  hyundai_longitudinal = GET_FLAG(param, HYUNDAI_PARAM_LONGITUDINAL);
+  const int FLAG_HYUNDAI_LONG = 4;
+  hyundai_longitudinal = GET_FLAG(param, FLAG_HYUNDAI_LONG);
 #else
   hyundai_longitudinal = false;
 #endif


### PR DESCRIPTION
**Description**

- Refactor flag names in Hyundai safety to make them more descriptive and consistent.
- Variable names starting with `HYUNDAI_PARAM_` have been updated to start with `FLAG_HYUNDAI_`.
- The functionality remains unchanged; only the naming has been updated for improved clarity and readability.
- This change helps maintain a standardized naming convention across the Python and C++ codebase, making future development and debugging easier.
- No logic or functional behavior of the code is altered in this PR.

https://github.com/commaai/panda/blob/bedee405d69c781b34b9cb18564d1973b2a81294/python/__init__.py#L197-L204