### PR TITLE
Dockerfile: opendbc: symlink fix and use the latest ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,13 @@ RUN pip3 install --break-system-packages --no-cache-dir $PYTHONPATH/panda/[dev]
 
 # TODO: this should be a "pip install" or not even in this repo at all
 RUN git config --global --add safe.directory $PYTHONPATH/panda
-ENV OPENDBC_REF="e1ce3619a5db661ef2b406ccf258a253baf6eebc"
+ENV OPENDBC_REF="b89fe79950121ca93d8a1f0d3fd17df31703be2a"
 RUN cd /tmp/ && \
     git clone --depth 1 https://github.com/commaai/opendbc opendbc_repo && \
     cd opendbc_repo && git fetch origin $OPENDBC_REF && git checkout FETCH_HEAD && rm -rf .git/ && \
     pip3 install --break-system-packages --no-cache-dir Cython numpy  && \
-    scons -j8 --minimal opendbc/ && \
-    ln -s $PWD/opendbc $PYTHONPATH/opendbc
+    ln -s $PWD/opendbc $PYTHONPATH/opendbc && \
+    scons -j8 --minimal opendbc/
 
 # for Jenkins
 COPY README.md panda.tar.* /tmp/


### PR DESCRIPTION
**Description**
- **Updated Dependency Reference**: Updated `OPENDBC_REF` to a new commit hash (https://github.com/commaai/opendbc/commit/551081b32f4c1a76537ad2c777571ef5b93a849c) to use the latest version of the `commaai/opendbc` repository.
- **Fix in Symlink Creation Order**: Adjusted the sequence so that the symbolic link to the `opendbc` directory is created before running the `scons` build process, resolving potential setup or reference issues
  - Bug introduced in https://github.com/commaai/opendbc/pull/1519
  - Issue: https://github.com/commaai/panda/pull/2102
- **Improved Build Process**: Ensured the build commands (`scons`) work more reliably by properly referencing the `opendbc` symlink beforehand.