### PR TITLE
Reduce heartbeat beeper false positives

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -216,7 +216,7 @@ static void tick_handler(void) {
       }
 
       if (controls_allowed || heartbeat_engaged) {
-        controls_allowed_countdown = 30U;
+        controls_allowed_countdown = 5U;
       } else if (controls_allowed_countdown > 0U) {
         controls_allowed_countdown -= 1U;
       } else {


### PR DESCRIPTION
Fixes the case where you're engaged -> park -> unplug device all in <30s. Not sure why we chose 30s initially, but 5s is more than enough.