### PR TITLE
GPIO: Explicitly casts constants to `uint32_t`

### DIFF
--- a/board/drivers/gpio.h
+++ b/board/drivers/gpio.h
@@ -58,7 +58,7 @@ void set_gpio_alternate(GPIO_TypeDef *GPIO, unsigned int pin, unsigned int mode)
 void set_gpio_pullup(GPIO_TypeDef *GPIO, unsigned int pin, unsigned int mode) {
   ENTER_CRITICAL();
   uint32_t tmp = GPIO->PUPDR;
-  tmp &= ~(3U << (pin * 2U));
+  tmp &= ~((uint32_t)3U << ((uint32_t)(pin * 2U)));
   tmp |= (mode << (pin * 2U));
   register_set(&(GPIO->PUPDR), tmp, 0xFFFFFFFFU);
   EXIT_CRITICAL();


### PR DESCRIPTION
**Description**

Explicitly casts constants (`3U` and `pin * 2U`) to `uint32_t` to prevent type promotion or mismatches.

Noticed this MISRA violation when we were working on sunnypilot's panda using upstream's CI: https://github.com/sunnypilot/panda/actions/runs/12314225225/job/34369895304

![image](https://github.com/user-attachments/assets/69bf2460-6816-4764-aca8-e6f74564eef1)
