### PR TITLE
Dockerfile: opendbc: small fixes and use the latest ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN pip3 install --break-system-packages --no-cache-dir $PYTHONPATH/panda/[dev]
 
 # TODO: this should be a "pip install" or not even in this repo at all
 RUN git config --global --add safe.directory $PYTHONPATH/panda
-ENV OPENDBC_REF="b89fe79950121ca93d8a1f0d3fd17df31703be2a"
+ENV OPENDBC_REF="7af6f3885dc43be8ecf331df1f0914cf3338de50"
 RUN cd /tmp/ && \
     git clone --depth 1 https://github.com/commaai/opendbc opendbc_repo && \
     cd opendbc_repo && git fetch origin $OPENDBC_REF && git checkout FETCH_HEAD && rm -rf .git/ && \

--- a/examples/query_fw_versions.py
+++ b/examples/query_fw_versions.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
         resp = {}
         for uds_data_id in sorted(uds_data_ids):
           try:
-            data = uds_client.read_data_by_identifier(uds_data_id)
+            data = uds_client.read_data_by_identifier(DATA_IDENTIFIER_TYPE(uds_data_id))
             if data:
               resp[uds_data_id] = data
           except (NegativeResponseError, MessageTimeoutError, InvalidSubAddressError):

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -333,7 +333,7 @@ class TestToyotaSecOcSafety(TestToyotaStockLongitudinalBase):
   FWD_BLACKLISTED_ADDRS = {2: [0x2E4, 0x412, 0x191, 0x131]}
 
   def setUp(self):
-    self.packer = CANPackerPanda("toyota_rav4_prime_generated")
+    self.packer = CANPackerPanda("toyota_secoc_pt_generated")
     self.safety = libpanda_py.libpanda
     self.safety.set_safety_hooks(Panda.SAFETY_TOYOTA, self.EPS_SCALE | Panda.FLAG_TOYOTA_STOCK_LONGITUDINAL | Panda.FLAG_TOYOTA_SECOC)
     self.safety.init_tests()


### PR DESCRIPTION
**Description**

The generated DBC file used for Toyota SecOC platforms has been updated with the latest name.

This PR:
- Pointed the opendbc ref to the latest on [`commaai/opendbc`](https://github.com/commaai/opendbc)
- Updated `test_toyota.py` with the up-to-date generated DBC file name.