### PR TITLE
Increase ADC accuracy

### DIFF
--- a/board/stm32h7/lladc.h
+++ b/board/stm32h7/lladc.h
@@ -19,9 +19,9 @@ static uint16_t adc_get_raw(uint8_t channel) {
   ADC1->SQR1 &= ~(ADC_SQR1_L);
   ADC1->SQR1 = (uint32_t)channel << 6U;
 
-  ADC1->SMPR1 = 0x2UL << (channel * 3UL);
+  ADC1->SMPR1 = 0x4UL << (channel * 3UL);
   ADC1->PCSEL_RES0 = (0x1UL << channel);
-  ADC1->CFGR2 = (127UL << ADC_CFGR2_OVSR_Pos) | (0x7U << ADC_CFGR2_OVSS_Pos) | ADC_CFGR2_ROVSE;
+  ADC1->CFGR2 = (63UL << ADC_CFGR2_OVSR_Pos) | (0x6U << ADC_CFGR2_OVSS_Pos) | ADC_CFGR2_ROVSE;
 
   ADC1->CR |= ADC_CR_ADSTART;
   while (!(ADC1->ISR & ADC_ISR_EOC));


### PR DESCRIPTION
With the short sampling time, the internal hold cap wasn't close enough to fully charged yet