### PR TITLE
fdcan: rate limit CAN core reset

### DIFF
--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -23,7 +23,7 @@ void can_clear_send(FDCAN_GlobalTypeDef *FDCANx, uint8_t can_number) {
   uint32_t time = microsecond_timer_get();
 
   // Resetting CAN core is a slow blocking operation, limit frequency
-  if ((time - last_reset) > 100000) {  // 10 Hz
+  if (get_ts_elapsed(time, last_reset) > 100000) {  // 10 Hz
     can_health[can_number].can_core_reset_cnt += 1U;
     can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
     llcan_clear_send(FDCANx);

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -23,7 +23,7 @@ void can_clear_send(FDCAN_GlobalTypeDef *FDCANx, uint8_t can_number) {
   uint32_t time = microsecond_timer_get();
 
   // Resetting CAN core is a slow blocking operation, limit frequency
-  if (get_ts_elapsed(time, last_reset) > 100000) {  // 10 Hz
+  if (get_ts_elapsed(time, last_reset) > 100000U) {  // 10 Hz
     can_health[can_number].can_core_reset_cnt += 1U;
     can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
     llcan_clear_send(FDCANx);

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -19,9 +19,16 @@ static bool can_set_speed(uint8_t can_number) {
 }
 
 void can_clear_send(FDCAN_GlobalTypeDef *FDCANx, uint8_t can_number) {
-  can_health[can_number].can_core_reset_cnt += 1U;
-  can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
-  llcan_clear_send(FDCANx);
+  static uint32_t last_reset = 0U;
+  uint32_t time = microsecond_timer_get();
+
+  // Resetting CAN core is a slow blocking operation, limit frequency
+  if ((time - last_reset) > 100000) {  // 10 Hz
+    can_health[can_number].can_core_reset_cnt += 1U;
+    can_health[can_number].total_tx_lost_cnt += (FDCAN_TX_FIFO_EL_CNT - (FDCANx->TXFQS & FDCAN_TXFQS_TFFL)); // TX FIFO msgs will be lost after reset
+    llcan_clear_send(FDCANx);
+    last_reset = time;
+  }
 }
 
 void update_can_health_pkt(uint8_t can_number, uint32_t ir_reg) {


### PR DESCRIPTION
Closes https://github.com/commaai/panda/issues/2132 and https://github.com/commaai/openpilot/issues/33840.

Ignition off w/ canState1 and canState2 active receiving messages w/ forced resetting on canState0 (bus 2, similar case to right after ignition off in https://github.com/commaai/openpilot/issues/33840):

- No resetting: 0.13 interrupt load
- Resetting at 10Hz: 0.15 interrupt load (**this PR**)
- Resetting at 100Hz: 0.35 interrupt load
- Resetting w/o restrictions (~286Hz): 0.8 interrupt load (**similar to issue**)