### PR TITLE
safety: don't silently skip classes with missing abstract methods

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+import unittest
+
+
+def pytest_pycollect_makeitem(collector, name, obj):
+  if isinstance(obj, type) and issubclass(obj, unittest.TestCase):
+    abstract_methods = getattr(obj, '__abstractmethods__', None)
+    if abstract_methods:
+      raise TypeError(f"Test class {name} is abstract and missing implementations for: {abstract_methods}")

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,8 @@
-import pytest
 import unittest
 
 
 def pytest_pycollect_makeitem(collector, name, obj):
-  if isinstance(obj, type) and issubclass(obj, unittest.TestCase):
+  if isinstance(obj, type) and issubclass(obj, unittest.TestCase):  # TODO: fix this
     abstract_methods = getattr(obj, '__abstractmethods__', None)
     if abstract_methods:
       raise TypeError(f"Test class {name} is abstract and missing implementations for: {abstract_methods}")


### PR DESCRIPTION
@adeebshihadeh did you know pytest does this?? unittest.main() catches these and throws a TypeError, but pytest just skips the class. can't believe this hasn't happened yet, just hit it in: https://github.com/commaai/panda/pull/2036

```
TypeError: Can't instantiate abstract class TestTeslaLongitudinalSafety without an implementation for abstract method '_accel_msg'
```