### PR TITLE
Update udev rules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,11 @@ And to send one on bus 0:
 Note that you may have to setup [udev rules](https://github.com/commaai/panda/tree/master/drivers/linux) for Linux, such as
 ``` bash
 sudo tee /etc/udev/rules.d/11-panda.rules <<EOF
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddcc", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="3801", ATTRS{idProduct}=="ddee", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddcc", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="bbaa", ATTRS{idProduct}=="ddee", MODE="0666"
 EOF
 sudo udevadm control --reload-rules && sudo udevadm trigger
 ```


### PR DESCRIPTION
Update udev rules to fix various permission-related problems that users may encounter. Matches the rules set up by openpilot. This should probably move to a shared setup script someday.

Ideally the Panda and PandaDFU classes should provide better exceptions, but that's a project for another day.

Background:

* commaai/openpilot#34632
* commaai/openpilot#34674