### PR TITLE
Add guards around platform-specific code

### DIFF
--- a/board/crc.h
+++ b/board/crc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined(ENABLE_SPI) || defined(BOOTSTUB)
 uint8_t crc_checksum(const uint8_t *dat, int len, const uint8_t poly) {
   uint8_t crc = 0xFFU;
   int i;
@@ -17,3 +18,4 @@ uint8_t crc_checksum(const uint8_t *dat, int len, const uint8_t poly) {
   }
   return crc;
 }
+#endif

--- a/board/drivers/gpio.h
+++ b/board/drivers/gpio.h
@@ -10,11 +10,6 @@
 #define OUTPUT_TYPE_PUSH_PULL 0U
 #define OUTPUT_TYPE_OPEN_DRAIN 1U
 
-typedef struct {
-  GPIO_TypeDef * const bank;
-  uint8_t pin;
-} gpio_t;
-
 void set_gpio_mode(GPIO_TypeDef *GPIO, unsigned int pin, unsigned int mode) {
   ENTER_CRITICAL();
   uint32_t tmp = GPIO->MODER;
@@ -68,6 +63,12 @@ int get_gpio_input(const GPIO_TypeDef *GPIO, unsigned int pin) {
   return (GPIO->IDR & (1UL << pin)) == (1UL << pin);
 }
 
+#ifdef PANDA_JUNGLE
+typedef struct gpio_tag {
+  GPIO_TypeDef * const bank;
+  uint8_t pin;
+} gpio_t;
+
 void gpio_set_all_output(gpio_t *pins, uint8_t num_pins, bool enabled) {
   for (uint8_t i = 0; i < num_pins; i++) {
     set_gpio_output(pins[i].bank, pins[i].pin, enabled);
@@ -79,6 +80,7 @@ void gpio_set_bitmask(gpio_t *pins, uint8_t num_pins, uint32_t bitmask) {
     set_gpio_output(pins[i].bank, pins[i].pin, (bitmask >> i) & 1U);
   }
 }
+#endif
 
 // Detection with internal pullup
 #define PULL_EFFECTIVE_DELAY 4096

--- a/board/drivers/gpio.h
+++ b/board/drivers/gpio.h
@@ -64,7 +64,7 @@ int get_gpio_input(const GPIO_TypeDef *GPIO, unsigned int pin) {
 }
 
 #ifdef PANDA_JUNGLE
-typedef struct gpio_tag {
+typedef struct {
   GPIO_TypeDef * const bank;
   uint8_t pin;
 } gpio_t;

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -130,6 +130,7 @@ void soft_flasher_start(void) {
   enter_bootloader_mode = 0;
 
   flasher_peripherals_init();
+  
   gpio_usart2_init();
   gpio_usb_init();
   led_init();

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -139,8 +139,10 @@ void soft_flasher_start(void) {
   usb_init();
 
 #ifdef ENABLE_SPI
+  if (current_board->has_spi) {
     gpio_spi_init();
     spi_init();
+  }
 #endif
 
   // green LED on for flashing

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -128,20 +128,25 @@ void soft_flasher_start(void) {
 
   enter_bootloader_mode = 0;
 
+#ifdef BOOTSTUB
   flasher_peripherals_init();
-
+#ifdef ENABLE_SPI
   gpio_usart2_init();
+#endif
+#endif
   gpio_usb_init();
   led_init();
 
   // enable USB
   usb_init();
 
+#if defined(ENABLE_SPI) || defined(BOOTSTUB)
   // enable SPI
   if (current_board->has_spi) {
     gpio_spi_init();
     spi_init();
   }
+#endif
 
   // green LED on for flashing
   led_set(LED_GREEN, 1);

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -1,4 +1,3 @@
-#ifdef BOOTSTUB
 // from the linker script
 #ifdef STM32H7
   #define APP_START_ADDRESS 0x8020000U
@@ -158,5 +157,3 @@ void soft_flasher_start(void) {
     delay(500000);
   }
 }
-
-#endif // BOOTSTUB

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -130,7 +130,7 @@ void soft_flasher_start(void) {
   enter_bootloader_mode = 0;
 
   flasher_peripherals_init();
-  
+
   gpio_usart2_init();
   gpio_usb_init();
   led_init();

--- a/board/flasher.h
+++ b/board/flasher.h
@@ -1,3 +1,4 @@
+#ifdef BOOTSTUB
 // from the linker script
 #ifdef STM32H7
   #define APP_START_ADDRESS 0x8020000U
@@ -128,24 +129,17 @@ void soft_flasher_start(void) {
 
   enter_bootloader_mode = 0;
 
-#ifdef BOOTSTUB
   flasher_peripherals_init();
-#ifdef ENABLE_SPI
   gpio_usart2_init();
-#endif
-#endif
   gpio_usb_init();
   led_init();
 
   // enable USB
   usb_init();
 
-#if defined(ENABLE_SPI) || defined(BOOTSTUB)
-  // enable SPI
-  if (current_board->has_spi) {
+#ifdef ENABLE_SPI
     gpio_spi_init();
     spi_init();
-  }
 #endif
 
   // green LED on for flashing
@@ -161,3 +155,5 @@ void soft_flasher_start(void) {
     delay(500000);
   }
 }
+
+#endif // BOOTSTUB

--- a/board/stm32f4/peripherals.h
+++ b/board/stm32f4/peripherals.h
@@ -9,7 +9,7 @@ static void gpio_usb_init(void) {
   GPIOA->OSPEEDR = GPIO_OSPEEDER_OSPEEDR11 | GPIO_OSPEEDER_OSPEEDR12;
 }
 
-#if defined(ENABLE_SPI)
+#ifdef ENABLE_SPI
 void gpio_spi_init(void) {
   // A4-A7: SPI
   set_gpio_alternate(GPIOA, 4, GPIO_AF5_SPI1);

--- a/board/stm32f4/peripherals.h
+++ b/board/stm32f4/peripherals.h
@@ -9,7 +9,7 @@ static void gpio_usb_init(void) {
   GPIOA->OSPEEDR = GPIO_OSPEEDER_OSPEEDR11 | GPIO_OSPEEDER_OSPEEDR12;
 }
 
-#if defined(ENABLE_SPI) || defined(BOOTSTUB)
+#if defined(ENABLE_SPI)
 void gpio_spi_init(void) {
   // A4-A7: SPI
   set_gpio_alternate(GPIOA, 4, GPIO_AF5_SPI1);
@@ -18,13 +18,13 @@ void gpio_spi_init(void) {
   set_gpio_alternate(GPIOA, 7, GPIO_AF5_SPI1);
   register_set_bits(&(GPIOA->OSPEEDR), GPIO_OSPEEDER_OSPEEDR4 | GPIO_OSPEEDER_OSPEEDR5 | GPIO_OSPEEDER_OSPEEDR6 | GPIO_OSPEEDER_OSPEEDR7);
 }
+#endif
 
 void gpio_usart2_init(void) {
   // A2,A3: USART 2 for debugging
   set_gpio_alternate(GPIOA, 2, GPIO_AF7_USART2);
   set_gpio_alternate(GPIOA, 3, GPIO_AF7_USART2);
 }
-#endif
 
 // Common GPIO initialization
 void common_init_gpio(void) {
@@ -47,14 +47,12 @@ void common_init_gpio(void) {
   set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
 }
 
-#ifdef BOOTSTUB
 void flasher_peripherals_init(void) {
   RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
   RCC->APB2ENR |= RCC_APB2ENR_SPI1EN;
   RCC->AHB2ENR |= RCC_AHB2ENR_OTGFSEN;
   RCC->APB1ENR |= RCC_APB1ENR_USART2EN;
 }
-#endif
 
 // Peripheral initialization
 void peripherals_init(void) {

--- a/board/stm32f4/peripherals.h
+++ b/board/stm32f4/peripherals.h
@@ -20,11 +20,13 @@ void gpio_spi_init(void) {
 }
 #endif
 
+#ifdef BOOTSTUB
 void gpio_usart2_init(void) {
   // A2,A3: USART 2 for debugging
   set_gpio_alternate(GPIOA, 2, GPIO_AF7_USART2);
   set_gpio_alternate(GPIOA, 3, GPIO_AF7_USART2);
 }
+#endif
 
 // Common GPIO initialization
 void common_init_gpio(void) {
@@ -47,12 +49,14 @@ void common_init_gpio(void) {
   set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
 }
 
+#ifdef BOOTSTUB
 void flasher_peripherals_init(void) {
   RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
   RCC->APB2ENR |= RCC_APB2ENR_SPI1EN;
   RCC->AHB2ENR |= RCC_AHB2ENR_OTGFSEN;
   RCC->APB1ENR |= RCC_APB1ENR_USART2EN;
 }
+#endif
 
 // Peripheral initialization
 void peripherals_init(void) {

--- a/board/stm32f4/peripherals.h
+++ b/board/stm32f4/peripherals.h
@@ -9,6 +9,7 @@ static void gpio_usb_init(void) {
   GPIOA->OSPEEDR = GPIO_OSPEEDER_OSPEEDR11 | GPIO_OSPEEDER_OSPEEDR12;
 }
 
+#if defined(ENABLE_SPI) || defined(BOOTSTUB)
 void gpio_spi_init(void) {
   // A4-A7: SPI
   set_gpio_alternate(GPIOA, 4, GPIO_AF5_SPI1);
@@ -23,6 +24,7 @@ void gpio_usart2_init(void) {
   set_gpio_alternate(GPIOA, 2, GPIO_AF7_USART2);
   set_gpio_alternate(GPIOA, 3, GPIO_AF7_USART2);
 }
+#endif
 
 // Common GPIO initialization
 void common_init_gpio(void) {
@@ -45,12 +47,14 @@ void common_init_gpio(void) {
   set_gpio_alternate(GPIOB, 9, GPIO_AF8_CAN1);
 }
 
+#ifdef BOOTSTUB
 void flasher_peripherals_init(void) {
   RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
   RCC->APB2ENR |= RCC_APB2ENR_SPI1EN;
   RCC->AHB2ENR |= RCC_AHB2ENR_OTGFSEN;
   RCC->APB1ENR |= RCC_APB1ENR_USART2EN;
 }
+#endif
 
 // Peripheral initialization
 void peripherals_init(void) {

--- a/board/stm32h7/peripherals.h
+++ b/board/stm32h7/peripherals.h
@@ -9,7 +9,7 @@ static void gpio_usb_init(void) {
   GPIOA->OSPEEDR = GPIO_OSPEEDR_OSPEED11 | GPIO_OSPEEDR_OSPEED12;
 }
 
-#if defined(ENABLE_SPI)
+#ifdef ENABLE_SPI
 void gpio_spi_init(void) {
   set_gpio_alternate(GPIOE, 11, GPIO_AF5_SPI4);
   set_gpio_alternate(GPIOE, 12, GPIO_AF5_SPI4);

--- a/board/stm32h7/peripherals.h
+++ b/board/stm32h7/peripherals.h
@@ -9,7 +9,7 @@ static void gpio_usb_init(void) {
   GPIOA->OSPEEDR = GPIO_OSPEEDR_OSPEED11 | GPIO_OSPEEDR_OSPEED12;
 }
 
-#if defined(ENABLE_SPI) || defined(BOOTSTUB)
+#if defined(ENABLE_SPI)
 void gpio_spi_init(void) {
   set_gpio_alternate(GPIOE, 11, GPIO_AF5_SPI4);
   set_gpio_alternate(GPIOE, 12, GPIO_AF5_SPI4);
@@ -17,13 +17,13 @@ void gpio_spi_init(void) {
   set_gpio_alternate(GPIOE, 14, GPIO_AF5_SPI4);
   register_set_bits(&(GPIOE->OSPEEDR), GPIO_OSPEEDR_OSPEED11 | GPIO_OSPEEDR_OSPEED12 | GPIO_OSPEEDR_OSPEED13 | GPIO_OSPEEDR_OSPEED14);
 }
+#endif
 
 void gpio_usart2_init(void) {
   // A2,A3: USART 2 for debugging
   set_gpio_alternate(GPIOA, 2, GPIO_AF7_USART2);
   set_gpio_alternate(GPIOA, 3, GPIO_AF7_USART2);
 }
-#endif
 
 void gpio_uart7_init(void) {
   // E7,E8: UART 7 for debugging
@@ -64,7 +64,6 @@ void common_init_gpio(void) {
   set_gpio_alternate(GPIOG, 10, GPIO_AF2_FDCAN3);
 }
 
-#ifdef BOOTSTUB
 void flasher_peripherals_init(void) {
   RCC->AHB1ENR |= RCC_AHB1ENR_USB1OTGHSEN;
 
@@ -72,7 +71,6 @@ void flasher_peripherals_init(void) {
   RCC->APB2ENR |= RCC_APB2ENR_SPI4EN;
   RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
 }
-#endif
 
 // Peripheral initialization
 void peripherals_init(void) {

--- a/board/stm32h7/peripherals.h
+++ b/board/stm32h7/peripherals.h
@@ -9,6 +9,7 @@ static void gpio_usb_init(void) {
   GPIOA->OSPEEDR = GPIO_OSPEEDR_OSPEED11 | GPIO_OSPEEDR_OSPEED12;
 }
 
+#if defined(ENABLE_SPI) || defined(BOOTSTUB)
 void gpio_spi_init(void) {
   set_gpio_alternate(GPIOE, 11, GPIO_AF5_SPI4);
   set_gpio_alternate(GPIOE, 12, GPIO_AF5_SPI4);
@@ -22,6 +23,7 @@ void gpio_usart2_init(void) {
   set_gpio_alternate(GPIOA, 2, GPIO_AF7_USART2);
   set_gpio_alternate(GPIOA, 3, GPIO_AF7_USART2);
 }
+#endif
 
 void gpio_uart7_init(void) {
   // E7,E8: UART 7 for debugging
@@ -62,6 +64,7 @@ void common_init_gpio(void) {
   set_gpio_alternate(GPIOG, 10, GPIO_AF2_FDCAN3);
 }
 
+#ifdef BOOTSTUB
 void flasher_peripherals_init(void) {
   RCC->AHB1ENR |= RCC_AHB1ENR_USB1OTGHSEN;
 
@@ -69,6 +72,7 @@ void flasher_peripherals_init(void) {
   RCC->APB2ENR |= RCC_APB2ENR_SPI4EN;
   RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
 }
+#endif
 
 // Peripheral initialization
 void peripherals_init(void) {

--- a/board/stm32h7/peripherals.h
+++ b/board/stm32h7/peripherals.h
@@ -19,11 +19,13 @@ void gpio_spi_init(void) {
 }
 #endif
 
+#ifdef BOOTSTUB
 void gpio_usart2_init(void) {
   // A2,A3: USART 2 for debugging
   set_gpio_alternate(GPIOA, 2, GPIO_AF7_USART2);
   set_gpio_alternate(GPIOA, 3, GPIO_AF7_USART2);
 }
+#endif
 
 void gpio_uart7_init(void) {
   // E7,E8: UART 7 for debugging
@@ -64,6 +66,7 @@ void common_init_gpio(void) {
   set_gpio_alternate(GPIOG, 10, GPIO_AF2_FDCAN3);
 }
 
+#ifdef BOOTSTUB
 void flasher_peripherals_init(void) {
   RCC->AHB1ENR |= RCC_AHB1ENR_USB1OTGHSEN;
 
@@ -71,6 +74,7 @@ void flasher_peripherals_init(void) {
   RCC->APB2ENR |= RCC_APB2ENR_SPI4EN;
   RCC->AHB1ENR |= RCC_AHB1ENR_DMA2EN;
 }
+#endif
 
 // Peripheral initialization
 void peripherals_init(void) {


### PR DESCRIPTION
For https://github.com/commaai/panda/issues/2171.

Add guards around platform/target-specific code. This way we won't have add cpp rule supression later.