### PR TITLE
Add support for generating clang compilation database by default

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -8,17 +8,12 @@ AddOption('--ubsan',
           action='store_true',
           help='turn on UBSan')
 
-AddOption('--compile_db',
-          action='store_true',
-          help='build clang compilation database')
-
 env = Environment(
   COMPILATIONDB_USE_ABSPATH=True,
   tools=["default", "compilation_db"],
 )
 
-if GetOption('compile_db'):
-  env.CompilationDatabase("compile_commands.json")
+env.CompilationDatabase("compile_commands.json")
 
 # panda fw & test files
 SConscript('SConscript')


### PR DESCRIPTION
> [!NOTE]
> Sister PRs: 
> * https://github.com/commaai/opendbc/pull/2428
> * https://github.com/commaai/openpilot/pull/35629

This brings the `compilation_db` functionality to **panda**, similar to what we already have in **openpilot**, which helps with IDE integration and code navigation.

_This feature was originally introduced in openpilot via [commaai/openpilot#19533](https://github.com/commaai/openpilot/pull/19533) by @adeebshihadeh._

Previously, the behavior in panda required the `--compile-db` flag to generate `compile_commands.json`. We've now improved this:

### What's changed
- **`compile_commands.json` is now always generated**—no need to pass a flag.
- Whether you build panda standalone or as part of openpilot, the compilation database is created automatically.

### Behavior
1. **Standalone Build**  
   When building the panda project on its own, a `compile_commands.json` will be created in the `panda/` folder containing only panda-related entries.

2. **Submodule in openpilot**  
   When panda is built as a submodule of openpilot, its entries will be added automatically to the top-level `compile_commands.json` in the openpilot root directory. This is achieved by configuring the build environment in `panda/SConscript`.

This ensures that both IDEs and code analysis tools work seamlessly across the full openpilot + panda codebase.



