### PR TITLE
Fix cppcheck warning: Make 'status != 0' explicit in spidev_open

### DIFF
--- a/drivers/spi/spidev_panda.c
+++ b/drivers/spi/spidev_panda.c
@@ -600,7 +600,7 @@ static int spidev_open(struct inode *inode, struct file *filp)
 		}
 	}
 
-	if (status) {
+	if (status != 0) {{
 		pr_debug("spidev: nothing for minor %d\n", iminor(inode));
 		goto err_find_dev;
 	}


### PR DESCRIPTION
### Summary
This PR resolves the cppcheck warning:
> style: Condition 'status' is always true [knownConditionTrueFalse]

### What I changed
- Replaced `if (status)` with `if (status != 0)` in `spidev_open()` to make the check explicit
- This removes false positives from static analysis tools like cppcheck

### Verification
- Ran `cppcheck --enable=all` locally
- The warning is now gone

Closes: commaai/panda#2105
