### PR TITLE
ADC VDDA calibration

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -284,6 +284,9 @@ int main(void) {
   led_set(LED_RED, true);
   led_set(LED_GREEN, true);
   adc_init(ADC1);
+  #ifdef STM32H7 // TODO fix
+  adc_calibrate_vdda();
+  #endif
 
   // print hello
   print("\n\n\n************************ MAIN START ************************\n");

--- a/board/main.c
+++ b/board/main.c
@@ -284,9 +284,6 @@ int main(void) {
   led_set(LED_RED, true);
   led_set(LED_GREEN, true);
   adc_init(ADC1);
-  #ifdef STM32H7 // TODO fix
-  adc_calibrate_vdda();
-  #endif
 
   // print hello
   print("\n\n\n************************ MAIN START ************************\n");

--- a/board/stm32h7/lladc.h
+++ b/board/stm32h7/lladc.h
@@ -1,5 +1,7 @@
 #include "lladc_declarations.h"
 
+uint16_t adc_avdd_mV = 0U;
+
 void adc_init(ADC_TypeDef *adc) {
   adc->CR &= ~(ADC_CR_DEEPPWD); // Reset deep-power-down mode
   adc->CR |= ADC_CR_ADVREGEN; // Enable ADC regulator
@@ -9,7 +11,7 @@ void adc_init(ADC_TypeDef *adc) {
     adc->CR &= ~(ADC_CR_ADCALDIF); // Choose single-ended calibration
     adc->CR |= ADC_CR_ADCALLIN; // Lineriality calibration
   }
-  adc->CR |= ADC_CR_ADCAL; // Start calibrtation
+  adc->CR |= ADC_CR_ADCAL; // Start calibration
   while((adc->CR & ADC_CR_ADCAL) != 0U);
 
   adc->ISR |= ADC_ISR_ADRDY;
@@ -50,9 +52,31 @@ uint16_t adc_get_raw(const adc_signal_t *signal) {
 uint16_t adc_get_mV(const adc_signal_t *signal) {
   uint16_t ret = 0;
   if ((signal->adc == ADC1) || (signal->adc == ADC2)) {
-    ret = (adc_get_raw(signal) * current_board->avdd_mV) / 65535U;
+    ret = (adc_get_raw(signal) * adc_avdd_mV) / 65535U;
   } else if (signal->adc == ADC3) {
-    ret = (adc_get_raw(signal) * current_board->avdd_mV) / 4095U;
+    ret = (adc_get_raw(signal) * adc_avdd_mV) / 4095U;
   } else {}
   return ret;
+}
+
+void adc_calibrate_vdda(void) {
+  // ADC2 used for calibration
+  adc_init(ADC2);
+
+  // enable VREFINT channel
+  ADC3_COMMON->CCR |= ADC_CCR_VREFEN;
+  SYSCFG->ADC2ALT |= SYSCFG_ADC2ALT_ADC2_ROUT1;
+
+  // measure VREFINT
+  uint16_t raw_vrefint = adc_get_raw(&(adc_signal_t){.adc = ADC2, .channel = 17U, .sample_time = SAMPLETIME_810_CYCLES, .oversampling = OVERSAMPLING_256});
+  print("raw vrefint "); puth(raw_vrefint); print("\n");
+
+  // get factory calibration value
+  uint16_t factory_cal = *VREFINT_CAL_ADDR;
+
+  print("factory vrefint "); puth(factory_cal); print("\n");
+
+  adc_avdd_mV = (uint32_t) factory_cal * 16U * 3300U / raw_vrefint;
+
+  print("calibrated avdd_mV "); puth(adc_avdd_mV); print("\n");
 }

--- a/board/stm32h7/lladc.h
+++ b/board/stm32h7/lladc.h
@@ -58,18 +58,10 @@ void adc_calibrate_vdda(void) {
   ADC3_COMMON->CCR |= ADC_CCR_VREFEN;
   SYSCFG->ADC2ALT |= SYSCFG_ADC2ALT_ADC2_ROUT1;
 
-  // measure VREFINT
+  // measure VREFINT and derive AVDD
   uint16_t raw_vrefint = adc_get_raw(&(adc_signal_t){.adc = ADC2, .channel = 17U, .sample_time = SAMPLETIME_810_CYCLES, .oversampling = OVERSAMPLING_256});
-  print("raw vrefint "); puth(raw_vrefint); print("\n");
-
-  // get factory calibration value
-  uint16_t factory_cal = *VREFINT_CAL_ADDR;
-
-  print("factory vrefint "); puth(factory_cal); print("\n");
-
-  adc_avdd_mV = (uint32_t) factory_cal * 16U * 3300U / raw_vrefint;
-
-  print("calibrated avdd_mV "); puth(adc_avdd_mV); print("\n");
+  adc_avdd_mV = (uint32_t) *VREFINT_CAL_ADDR * 16U * 3300U / raw_vrefint;
+  print("  AVDD: 0x"); puth(adc_avdd_mV); print(" mV\n");
 }
 
 uint16_t adc_get_mV(const adc_signal_t *signal) {

--- a/board/stm32h7/lladc.h
+++ b/board/stm32h7/lladc.h
@@ -1,6 +1,6 @@
 #include "lladc_declarations.h"
 
-uint16_t adc_avdd_mV = 0U;
+static uint32_t adc_avdd_mV = 0U;
 
 void adc_init(ADC_TypeDef *adc) {
   adc->CR &= ~(ADC_CR_ADEN); // Disable ADC
@@ -50,7 +50,7 @@ uint16_t adc_get_raw(const adc_signal_t *signal) {
   return res;
 }
 
-void adc_calibrate_vdda(void) {
+static void adc_calibrate_vdda(void) {
   // ADC2 used for calibration
   adc_init(ADC2);
 

--- a/board/stm32h7/lladc_declarations.h
+++ b/board/stm32h7/lladc_declarations.h
@@ -33,3 +33,5 @@ typedef struct {
 } adc_signal_t;
 
 #define ADC_CHANNEL_DEFAULT(a, c) {.adc = (a), .channel = (c), .sample_time = SAMPLETIME_32_CYCLES, .oversampling = OVERSAMPLING_64}
+
+#define VREFINT_CAL_ADDR ((uint16_t *)0x1FF1E860UL)

--- a/board/stm32h7/peripherals.h
+++ b/board/stm32h7/peripherals.h
@@ -108,6 +108,7 @@ void peripherals_init(void) {
 
   // Analog
   RCC->AHB1ENR |= RCC_AHB1ENR_ADC12EN; // Enable ADC12 clocks
+  RCC->AHB4ENR |= RCC_AHB4ENR_ADC3EN; // Enable ADC3 clocks
   RCC->APB1LENR |= RCC_APB1LENR_DAC12EN; // DAC
 
   // Audio
@@ -126,7 +127,6 @@ void peripherals_init(void) {
 
 #ifdef PANDA_JUNGLE
   RCC->AHB3ENR |= RCC_AHB3ENR_SDMMC1EN; // SDMMC
-  RCC->AHB4ENR |= RCC_AHB4ENR_ADC3EN; // Enable ADC3 clocks
 #endif
 }
 


### PR DESCRIPTION
You can calibrate the VDDA reference voltage based on the internal reference voltage source. This improves measurement accuracy to at least <1% absolute error