### PR TITLE
SPI: spi_error_count is a better name

### DIFF
--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -14,7 +14,7 @@ uint8_t spi_buf_rx[SPI_BUF_SIZE];
 uint8_t spi_buf_tx[SPI_BUF_SIZE];
 #endif
 
-uint16_t spi_checksum_error_count = 0;
+uint16_t spi_error_count = 0;
 
 static uint8_t spi_state = SPI_STATE_HEADER;
 static uint16_t spi_data_len_mosi;
@@ -205,8 +205,8 @@ void spi_rx_done(void) {
   llspi_miso_dma(spi_buf_tx, response_len);
 
   spi_state = next_rx_state;
-  if (!checksum_valid && (spi_checksum_error_count < UINT16_MAX)) {
-    spi_checksum_error_count += 1U;
+  if (!checksum_valid && (spi_error_count < UINT16_MAX)) {
+    spi_error_count += 1U;
   }
 }
 

--- a/board/drivers/spi_declarations.h
+++ b/board/drivers/spi_declarations.h
@@ -35,7 +35,7 @@ enum {
   SPI_STATE_DATA_TX
 };
 
-extern uint16_t spi_checksum_error_count;
+extern uint16_t spi_error_count;
 
 #define SPI_HEADER_SIZE 7U
 

--- a/board/health.h
+++ b/board/health.h
@@ -23,7 +23,7 @@ struct __attribute__((packed)) health_t {
   float interrupt_load_pkt;
   uint8_t fan_power;
   uint8_t safety_rx_checks_invalid_pkt;
-  uint16_t spi_checksum_error_count_pkt;
+  uint16_t spi_error_count_pkt;
   uint8_t fan_stall_count;
   uint16_t sbu1_voltage_mV;
   uint16_t sbu2_voltage_mV;

--- a/board/main_comms.h
+++ b/board/main_comms.h
@@ -29,7 +29,7 @@ static int get_health_pkt(void *dat) {
   health->safety_rx_checks_invalid_pkt = safety_rx_checks_invalid;
 
   #ifndef STM32F4
-  health->spi_checksum_error_count_pkt = spi_checksum_error_count;
+  health->spi_error_count_pkt = spi_error_count;
   #endif
 
   health->fault_status_pkt = fault_status;


### PR DESCRIPTION
Checksums are just one of the things this is used to track; these end up mostly being mismatches in the SPI state machine. 