### PR TITLE
Keep supporting White/Black pandas from Python side

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -114,6 +114,8 @@ class Panda:
 
   # from https://github.com/commaai/openpilot/blob/103b4df18cbc38f4129555ab8b15824d1a672bdf/cereal/log.capnp#L648
   HW_TYPE_UNKNOWN = b'\x00'
+  HW_TYPE_WHITE = b'\x01'
+  HW_TYPE_BLACK = b'\x03'
   HW_TYPE_DOS = b'\x06'
   HW_TYPE_RED_PANDA = b'\x07'
   HW_TYPE_TRES = b'\x09'
@@ -125,10 +127,11 @@ class Panda:
   HEALTH_STRUCT = struct.Struct("<IIIIIIIIBBBBBHBBBHfBBHBHHB")
   CAN_HEALTH_STRUCT = struct.Struct("<BIBBBBBBBBIIIIIIIHHBBBIIII")
 
-  F4_DEVICES = [HW_TYPE_DOS, ]
+  F4_DEVICES = [HW_TYPE_WHITE, HW_TYPE_BLACK, HW_TYPE_DOS, ]
   H7_DEVICES = [HW_TYPE_RED_PANDA, HW_TYPE_TRES, HW_TYPE_CUATRO]
 
   INTERNAL_DEVICES = (HW_TYPE_DOS, HW_TYPE_TRES, HW_TYPE_CUATRO)
+  DEPRECATED_DEVICES = (HW_TYPE_WHITE, HW_TYPE_BLACK)
 
   MAX_FAN_RPMs = {
     HW_TYPE_DOS: 6500,
@@ -230,6 +233,10 @@ class Panda:
     self._mcu_type = self.get_mcu_type()
     self.health_version, self.can_version, self.can_health_version = self.get_packets_versions()
     logger.debug("connected")
+
+    hw_type = self.get_type()
+    if hw_type in Panda.DEPRECATED_DEVICES:
+      print("WARNING: Using deprecated HW")
 
     # disable openpilot's heartbeat checks
     if self._disable_checks:
@@ -459,6 +466,10 @@ class Panda:
     if self.up_to_date(fn=fn):
       logger.info("flash: already up to date")
       return
+
+    hw_type = self.get_type()
+    if hw_type in Panda.DEPRECATED_DEVICES:
+      raise RuntimeError(f"HW type {hw_type.hex()} is deprecated and can no longer be flashed.")
 
     if not fn:
       fn = os.path.join(FW_PATH, self._mcu_type.config.app_fn)


### PR DESCRIPTION
Noticed support for white and black pandas was dropped. Does it make sense to support them from the Python side only while they still work? I still use white pandas quite often with the UdsClient for interacting with ECUs on the bench. 

Feel free to close if you're not interested in supporting this anymore and/or have bigger changes planned on the panda side that would break support anyway. I guess red pandas are only $100 these days :smile: 

