### PR TITLE
Panda.list() optimization for comma three

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -352,9 +352,10 @@ class Panda:
     return isinstance(self._handle, PandaUsbHandle)
 
   @classmethod
-  def list(cls):
+  def list(cls, usb_only: bool = False):
     ret = cls.usb_list()
-    ret += cls.spi_list()
+    if not usb_only:
+      ret += cls.spi_list()
     return list(set(ret))
 
   @classmethod


### PR DESCRIPTION
Checking SPI is expensive (~100ms) on comma threes, so we can skip it if we know it's not there.