### PR TITLE
SocketPanda improvements

### DIFF
--- a/python/socketpanda.py
+++ b/python/socketpanda.py
@@ -23,6 +23,9 @@ CAN_HEADER_LEN = struct.calcsize(CAN_HEADER_FMT)
 CAN_MAX_DLEN = 8
 CANFD_MAX_DLEN = 64
 
+CAN_CONFIRM_FLAG = 0x800
+CAN_EFF_FLAG = 0x80000000
+
 CANFD_BRS = 0x01 # bit rate switch (second bitrate for payload data)
 CANFD_FDF = 0x04 # mark CAN FD for dual use of struct canfd_frame
 
@@ -32,11 +35,12 @@ SO_RXQ_OVFL = 40
 
 import typing
 @typing.no_type_check # mypy struggles with macOS here...
-def create_socketcan(interface:str, recv_buffer_size:int, fd:bool) -> socket.socket:
+def create_socketcan(interface:str, recv_buffer_size:int) -> socket.socket:
   # settings mostly from https://github.com/linux-can/can-utils/blob/master/candump.c
   socketcan = socket.socket(socket.AF_CAN, socket.SOCK_RAW, socket.CAN_RAW)
-  if fd:
-    socketcan.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_FD_FRAMES, 1)
+  socketcan.setblocking(False)
+  socketcan.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_FD_FRAMES, 1)
+  socketcan.setsockopt(socket.SOL_CAN_RAW, socket.CAN_RAW_RECV_OWN_MSGS, 1)
   socketcan.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, recv_buffer_size)
   # TODO: why is it always 2x the requested size?
   assert socketcan.getsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF) == recv_buffer_size * 2
@@ -47,50 +51,68 @@ def create_socketcan(interface:str, recv_buffer_size:int, fd:bool) -> socket.soc
 
 # Panda class substitute for socketcan device (to support using the uds/iso-tp/xcp/ccp library)
 class SocketPanda():
-  def __init__(self, interface:str="can0", bus:int=0, fd:bool=False, recv_buffer_size:int=212992) -> None:
+  def __init__(self, interface:str="can0", recv_buffer_size:int=212992) -> None:
     self.interface = interface
-    self.bus = bus
-    self.fd = fd
-    self.flags = CANFD_BRS | CANFD_FDF if fd else 0
-    self.data_len = CANFD_MAX_DLEN if fd else CAN_MAX_DLEN
     self.recv_buffer_size = recv_buffer_size
-    self.socket = create_socketcan(interface, recv_buffer_size, fd)
+    self.socket = create_socketcan(interface, recv_buffer_size)
 
   def __del__(self):
     self.socket.close()
 
   def get_serial(self) -> tuple[int, int]:
-    return (0, 0) # TODO: implemented in panda socketcan driver
+    return (0, 0)
 
   def get_version(self) -> int:
-    return 0 # TODO: implemented in panda socketcan driver
+    return 0
 
   def can_clear(self, bus:int) -> None:
-    # TODO: implemented in panda socketcan driver
     self.socket.close()
-    self.socket = create_socketcan(self.interface, self.recv_buffer_size, self.fd)
+    self.socket = create_socketcan(self.interface, self.recv_buffer_size)
 
   def set_safety_mode(self, mode:int, param=0) -> None:
-    pass # TODO: implemented in panda socketcan driver
+    pass
 
-  def has_obd(self) -> bool:
-    return False # TODO: implemented in panda socketcan driver
+  def can_send_many(self, arr, *, fd=False, timeout=0) -> None:
+    for msg in arr:
+      self.can_send(*msg, fd=fd, timeout=timeout)
 
-  def can_send(self, addr, dat, bus=0, timeout=0) -> None:
+  def can_send(self, addr, dat, bus, *, fd=False, timeout=0) -> None:
+    # Even if the CANFD_FDF flag is not set, the data still must be 8 bytes for classic CAN frames.
+    data_len = CANFD_MAX_DLEN if fd else CAN_MAX_DLEN
     msg_len = len(dat)
-    msg_dat = dat.ljust(self.data_len, b'\x00')
-    can_frame = struct.pack(CAN_HEADER_FMT, addr, msg_len, self.flags) + msg_dat
-    self.socket.sendto(can_frame, (self.interface,))
+    msg_dat = dat.ljust(data_len, b'\x00')
+
+    # Set extended ID flag
+    if addr > 0x7ff:
+      addr |= CAN_EFF_FLAG
+
+    # Set FD flags
+    flags = CANFD_BRS | CANFD_FDF if fd else 0
+
+    can_frame = struct.pack(CAN_HEADER_FMT, addr, msg_len, flags) + msg_dat
+
+    # Block until the message is sent
+    # TODO: implement timeout
+    while True:
+      try:
+        self.socket.sendto(can_frame, (self.interface,))
+        break
+      except BlockingIOError:
+        continue
 
   def can_recv(self) -> list[tuple[int, bytes, int]]:
     msgs = list()
     while True:
       try:
-        dat, _ = self.socket.recvfrom(self.recv_buffer_size, socket.MSG_DONTWAIT)
-        assert len(dat) == CAN_HEADER_LEN + self.data_len, f"ERROR: received {len(dat)} bytes"
+        dat, _, msg_flags, _ = self.socket.recvmsg(self.recv_buffer_size)
+        assert len(dat) >= CAN_HEADER_LEN, f"ERROR: received {len(dat)} bytes"
+
         can_id, msg_len, _ = struct.unpack(CAN_HEADER_FMT, dat[:CAN_HEADER_LEN])
+        assert len(dat) >= CAN_HEADER_LEN + msg_len, f"ERROR: received {len(dat)} bytes, expected at least {CAN_HEADER_LEN + msg_len} bytes"
+
         msg_dat = dat[CAN_HEADER_LEN:CAN_HEADER_LEN+msg_len]
-        msgs.append((can_id, msg_dat, self.bus))
+        bus = 128 if (msg_flags & CAN_CONFIRM_FLAG) else 0
+        msgs.append((can_id, msg_dat, bus))
       except BlockingIOError:
         break # buffered data exhausted
     return msgs


### PR DESCRIPTION
Some small SocketPanda improvements

- Always use the FD socket. As far as I'm aware this is fine, even for adapters that don't support FD.
- Support Extended IDs
- Properly loopback sent messages on 128 once ACKed