### PR TITLE
PSA CAN ignition

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -201,6 +201,21 @@ void ignition_can_hook(CANPacket_t *msg) {
       ignition_can_cnt = 0U;
     }
 
+  } else if (msg->bus == 2) {
+    int len = GET_LEN(msg);
+
+    // PSA exception
+    if ((msg->addr == 0x432) && (len == 8)) {
+      int counter = msg->data[1] & 0xFU;
+
+      static int prev_counter_psa = -1;
+      if ((counter == ((prev_counter_psa + 1) % 16)) && (prev_counter_psa != -1)) {
+        // Dat_BSI1->P369_Com_stElecNetRaw
+        ignition_can = (msg->data[7] >> 4) == 0x5U;
+        ignition_can_cnt = 0U;
+      }
+      prev_counter_psa = counter;
+    }
   }
 }
 


### PR DESCRIPTION
Add CAN ignition for PSA vehicles.
EV and ICE models use two separate bits.