### PR TITLE
remove mcu_type

### DIFF
--- a/board/jungle/__init__.py
+++ b/board/jungle/__init__.py
@@ -52,7 +52,7 @@ class PandaJungle(Panda):
 
   def flash(self, fn=None, code=None, reconnect=True):
     if not fn:
-      fn = os.path.join(FW_PATH, self._mcu_type.config.app_fn.replace("panda", "panda_jungle"))
+      fn = os.path.join(FW_PATH, McuType.H7.config.app_fn.replace("panda", "panda_jungle"))
     super().flash(fn=fn, code=code, reconnect=reconnect)
 
   def recover(self, timeout: int | None = 60, reset: bool = True) -> bool:
@@ -73,15 +73,9 @@ class PandaJungle(Panda):
     self.flash()
     return True
 
-  def get_mcu_type(self) -> McuType:
-    hw_type = self.get_type()
-    if hw_type in PandaJungle.H7_DEVICES:
-      return McuType.H7
-    raise ValueError(f"unknown HW type: {hw_type}")
-
   def up_to_date(self, fn=None) -> bool:
     if fn is None:
-      fn = os.path.join(FW_PATH, self.get_mcu_type().config.app_fn.replace("panda", "panda_jungle"))
+      fn = os.path.join(FW_PATH, McuType.H7.config.app_fn.replace("panda", "panda_jungle"))
     return super().up_to_date(fn=fn)
 
   # ******************* health *******************

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -212,10 +212,9 @@ class Panda:
     # reset comms
     self.can_reset_communications()
 
-    # disable automatic CAN-FD switching (only supported on H7 devices)
-    if self.get_type() in self.H7_DEVICES:
-      for bus in range(PANDA_CAN_CNT):
-        self.set_canfd_auto(bus, False)
+    # disable automatic CAN-FD switching
+    for bus in range(PANDA_CAN_CNT):
+      self.set_canfd_auto(bus, False)
 
     # set CAN speed
     for bus in range(PANDA_CAN_CNT):

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -330,6 +330,8 @@ class Panda:
     return []
 
   def reset(self, enter_bootstub=False, enter_bootloader=False, reconnect=True):
+    assert (hw_type := self.get_type()) in self.SUPPORTED_DEVICES, f"Unknown HW: {hw_type}"
+
     # no response is expected since it resets right away
     timeout = 5000 if isinstance(self._handle, PandaSpiHandle) else 15000
     try:
@@ -409,9 +411,7 @@ class Panda:
       pass
 
   def flash(self, fn=None, code=None, reconnect=True):
-    hw_type = self.get_type()
-    if hw_type not in self.SUPPORTED_DEVICES:
-      raise RuntimeError(f"HW type {hw_type.hex()} is deprecated and can no longer be flashed.")
+    assert (hw_type := self.get_type()) in self.SUPPORTED_DEVICES, f"Unknown HW: {hw_type}"
 
     if self.up_to_date(fn=fn):
       logger.info("flash: already up to date")
@@ -440,6 +440,8 @@ class Panda:
       self.reconnect()
 
   def recover(self, timeout: int | None = 60, reset: bool = True) -> bool:
+    assert (hw_type := self.get_type()) in self.SUPPORTED_DEVICES, f"Unknown HW: {hw_type}"
+
     dfu_serial = self.get_dfu_serial()
 
     if reset:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -411,7 +411,7 @@ class Panda:
   def flash(self, fn=None, code=None, reconnect=True):
     hw_type = self.get_type()
     if hw_type not in self.SUPPORTED_DEVICES:
-      raise RuntimeError(f"HW type {hw_type.hex()} is not supported for flashing.")
+      raise RuntimeError(f"HW type {hw_type.hex()} is deprecated and can no longer be flashed.")
 
     if self.up_to_date(fn=fn):
       logger.info("flash: already up to date")

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -441,8 +441,6 @@ class Panda:
       self.reconnect()
 
   def recover(self, timeout: int | None = 60, reset: bool = True) -> bool:
-    assert (hw_type := self.get_type()) in self.SUPPORTED_DEVICES, f"Unknown HW: {hw_type}"
-
     dfu_serial = self.get_dfu_serial()
 
     if reset:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -330,7 +330,8 @@ class Panda:
     return []
 
   def reset(self, enter_bootstub=False, enter_bootloader=False, reconnect=True):
-    assert (hw_type := self.get_type()) in self.SUPPORTED_DEVICES, f"Unknown HW: {hw_type}"
+    if enter_bootstub or enter_bootloader:
+      assert (hw_type := self.get_type()) in self.SUPPORTED_DEVICES, f"Unknown HW: {hw_type}"
 
     # no response is expected since it resets right away
     timeout = 5000 if isinstance(self._handle, PandaSpiHandle) else 15000

--- a/tests/hitl/1_program.py
+++ b/tests/hitl/1_program.py
@@ -11,7 +11,6 @@ def check_signature(p):
 
 
 def test_dfu(p):
-  app_mcu_type = p.get_mcu_type()
   dfu_serial = p.get_dfu_serial()
 
   p.reset(enter_bootstub=True)
@@ -19,7 +18,7 @@ def test_dfu(p):
   assert Panda.wait_for_dfu(dfu_serial, timeout=19), "failed to enter DFU"
 
   dfu = PandaDFU(dfu_serial)
-  assert dfu.get_mcu_type() == app_mcu_type
+  assert dfu.get_mcu_type() == McuType.H7
 
   assert dfu_serial in PandaDFU.list()
 
@@ -38,9 +37,9 @@ def test_known_bootstub(p):
     McuType.H7: ["bootstub.panda_h7.bin"],
   }
 
-  for kb in known_bootstubs[p.get_mcu_type()]:
-    app_ids = (p.get_mcu_type(), p.get_usb_serial())
-    assert None not in app_ids
+  for kb in known_bootstubs[McuType.H7]:
+    app_serial = p.get_usb_serial()
+    assert app_serial is not None
 
     p.reset(enter_bootstub=True)
     p.reset(enter_bootloader=True)
@@ -57,10 +56,9 @@ def test_known_bootstub(p):
 
     p.connect(claim=False, wait=True)
 
-    # check for MCU or serial mismatch
+    # check for serial mismatch
     with Panda(p._serial, claim=False) as np:
-      bootstub_ids = (np.get_mcu_type(), np.get_usb_serial())
-      assert app_ids == bootstub_ids
+      assert np.get_usb_serial() == app_serial
 
     # ensure we can flash app and it jumps to app
     p.flash()

--- a/tests/hitl/2_health.py
+++ b/tests/hitl/2_health.py
@@ -17,8 +17,6 @@ def test_hw_type(p):
   """
 
   hw_type = p.get_type()
-  mcu_type = p.get_mcu_type()
-  assert mcu_type is not None
 
   app_uid =  p.get_uid()
   usb_serial = p.get_usb_serial()
@@ -30,7 +28,6 @@ def test_hw_type(p):
   with Panda(p.get_usb_serial()) as pp:
     assert pp.bootstub
     assert pp.get_type() == hw_type, "Bootstub and app hw type mismatch"
-    assert pp.get_mcu_type() == mcu_type, "Bootstub and app MCU type mismatch"
     assert pp.get_uid() == app_uid
 
 def test_heartbeat(p, panda_jungle):

--- a/tests/hitl/reset_jungles.py
+++ b/tests/hitl/reset_jungles.py
@@ -15,7 +15,6 @@ def recover(s):
 def flash(s):
   with PandaJungle(s) as p:
     p.flash()
-    return p.get_mcu_type()
 
 # Reset + flash all CI hardware to get it into a consistent state
 # * port 1: jungles-under-test
@@ -42,5 +41,4 @@ if __name__ == "__main__":
       for s in SERIALS:
         assert PandaJungle.wait_for_panda(s, timeout=10)
       assert set(PandaJungle.list()) >= SERIALS
-      mcu_types = list(exc.map(flash, SERIALS, timeout=20))
-      assert set(mcu_types) == {McuType.H7, }
+      list(exc.map(flash, SERIALS, timeout=20))


### PR DESCRIPTION
Redo of https://github.com/commaai/panda/pull/2324

pandad tests now pass, removed assert in recover since you can't reset an F4 to bootloader anyway (guarded)

though, if you put an F4 forcefully in DFU and try to recover it with the H7 bootstub,  it gives: `Unkown MCU: sector_count=16` (mind the typo) so, if you manage to reset an F4 to bootloader, you can't do anything with it, so the only option is to power cycle it

*without the flash and reset guards, it's the only way you can flash an F4 with H7 firmware and brick it, but you still can't flash the H7 bootstub*

conclusion: it's *impossible* to brick an F4