### PR TITLE
update pyproject.toml: include panda.python and panda.board

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,13 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["panda"]
+packages = [
+  "panda",
+  "panda.python",
+  "panda.board",
+  "panda.board.body",
+  "panda.board.jungle",
+]
 
 [tool.setuptools.package-dir]
 panda = "."


### PR DESCRIPTION
Installing the panda repo as a pip package (e.g. using `uv add git+https://github.com/commaai/panda.git`) would result in only the `__init__.py` in the root being installed.

This should also make importing consistent between openpilot and external programs, e.g. `from panda.python import Panda` now works everywhere.