### PR TITLE
windows: fix fcntl import

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,22 @@ jobs:
       - uses: actions/checkout@v4
       - run: ./test.sh
 
+  windows:
+    name: windows pip package test
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v5
+      - name: Install package with uv
+        run: uv pip install --system .
+      - name: Verify importing panda
+        run: python -c "from panda import Panda"
+
+
   misra_linter:
     name: MISRA C:2012 Linter
     runs-on: ubuntu-latest

--- a/python/spi.py
+++ b/python/spi.py
@@ -13,9 +13,9 @@ from .utils import logger
 
 # No fcntl on Windows
 try:
-    import fcntl
+  import fcntl
 except ImportError:
-    fcntl = None # type: ignore
+  fcntl = None # type: ignore
 
 # No spidev on MacOS/Windows
 try:

--- a/python/spi.py
+++ b/python/spi.py
@@ -1,6 +1,5 @@
 import binascii
 import os
-import fcntl
 import math
 import time
 import struct
@@ -12,6 +11,13 @@ from .base import BaseHandle, BaseSTBootloaderHandle, TIMEOUT
 from .constants import McuType, MCU_TYPE_BY_IDCODE, USBPACKET_MAX_SIZE
 from .utils import logger
 
+# No fcntl on Windows
+try:
+    import fcntl
+except ImportError:
+    fcntl = None # type: ignore
+
+# No spidev on MacOS/Windows
 try:
   import spidev
 except ImportError:

--- a/python/spi.py
+++ b/python/spi.py
@@ -11,11 +11,7 @@ from .base import BaseHandle, BaseSTBootloaderHandle, TIMEOUT
 from .constants import McuType, MCU_TYPE_BY_IDCODE, USBPACKET_MAX_SIZE
 from .utils import logger
 
-# No fcntl on Windows
-try:
-  import fcntl
-except ImportError:
-  fcntl = None # type: ignore
+import fcntl
 
 # No spidev on MacOS/Windows
 try:

--- a/python/spi.py
+++ b/python/spi.py
@@ -11,7 +11,11 @@ from .base import BaseHandle, BaseSTBootloaderHandle, TIMEOUT
 from .constants import McuType, MCU_TYPE_BY_IDCODE, USBPACKET_MAX_SIZE
 from .utils import logger
 
-import fcntl
+# No fcntl on Windows
+try:
+  import fcntl
+except ImportError:
+  fcntl = None # type: ignore
 
 # No spidev on MacOS/Windows
 try:


### PR DESCRIPTION
Like spidev, we need to gate the fcntl import as it's only available on *nix.

This can also be combined into a single try/except if needed. If one of them is not available, it's probably fine to mock out the other one too. E.g.


```python
try:
    import fcntl # No fcntl on Windows
    import spidev # No spidev on Windows/MacOS
except ImportError:
    fcntl = None # type: ignore
    spidev = None

```