### PR TITLE
jungle: support replaying CAN messages from an SD card (#1981)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,115 @@
+# CLAUDE.md
+
+## Project overview
+
+Panda is an open-source car interface device by comma.ai. This repo contains:
+- STM32H7 firmware (C, in `board/`)
+- Python userspace library (`python/` and `board/jungle/__init__.py`)
+- Tests (unit, protocol, MISRA static analysis, hardware-in-loop)
+
+Adjacent repo **opendbc** lives at `../opendbc` and provides the safety model (`opendbc/safety/safety.h`), `CarParams`, and CAN packet definitions. The firmware includes it as `opendbc/safety/safety.h` and the SConscript uses `opendbc.INCLUDE_PATH`.
+
+## Build
+
+```bash
+./setup.sh                                         # install deps into .venv (first time)
+PATH="$(pwd)/.venv/bin:$PATH" .venv/bin/scons     # debug build (all targets)
+RELEASE=1 CERT=board/certs/debug PATH="$(pwd)/.venv/bin:$PATH" .venv/bin/scons  # release build
+```
+
+The `PATH` prefix is required on macOS so that `board/crypto/sign.py` (shebang: `#!/usr/bin/env python3`) resolves to the venv Python 3.12 (which has `pycryptodome`) rather than the system Python.
+
+Firmware binaries are output to `board/obj/`. Each target builds a bootstub (RSA-2048 signed) and main app binary. `board/obj/gitversion.h` is auto-generated from git HEAD.
+
+Compiler: `arm-none-eabi-gcc`, C standard: GNU11, flags include `-Wall -Wextra -Wstrict-prototypes -Werror -fmax-errors=1`.
+
+## Tests
+
+```bash
+./test.sh          # scons + ruff check + pytest (non-HITL, non-MISRA)
+pytest tests/      # same subset
+
+pytest tests/misra/       # MISRA C:2012 static analysis via cppcheck
+pytest tests/hitl/        # hardware-in-loop (requires physical device)
+```
+
+pytest config (pyproject.toml): `-nauto --maxprocesses=8`, excludes `tests/som/` and `tests/hitl/` by default.
+
+## Code style
+
+**C (board/):**
+- MISRA C:2012 compliance enforced by cppcheck; see `tests/misra/coverage_table` for tracked suppressions
+- 2-space indentation in most headers
+- Suppress MISRA violations with inline comments: `// misra-c2012-17.7: ...`
+
+**Python:**
+- Ruff linter: `ruff check .` (line length 160, target Python 3.11)
+- Enabled rule sets: E, F, W, PIE, C4, ISC, RUF100, A
+- Ignored: W292, E741, E402, C408, ISC003
+
+## Key directories
+
+| Path | Contents |
+|------|----------|
+| `board/` | STM32 firmware |
+| `board/drivers/` | HAL drivers (CAN, USB, SPI, UART, timers, …) |
+| `board/stm32h7/` | STM32H7 linker scripts, startup, peripheral includes |
+| `board/jungle/` | Jungle board firmware and Python library |
+| `board/jungle/stm32h7/` | Jungle-specific STM32H7 drivers (SDMMC, SD replay) |
+| `board/jungle/scripts/` | Jungle utility scripts (CAN printer, spam, provision SD) |
+| `board/boards/` | Board variant hardware abstraction layers |
+| `board/crypto/` | RSA/SHA implementation and firmware signing |
+| `python/` | Core `Panda` class (USB + SPI transports) |
+| `tests/libpanda/` | C unit tests via libpanda.so (compiled shared library) |
+| `tests/hitl/` | Hardware-in-loop tests |
+| `tests/misra/` | cppcheck MISRA analysis |
+| `tests/usbprotocol/` | USB/CAN protocol tests |
+
+## Jungle V2 SD card replay
+
+The jungle V2 has an SD card slot that can replay openpilot CAN routes autonomously. See `board/jungle/README.md` for usage. Key files:
+
+- `board/jungle/stm32h7/llsdmmc.h` — SDMMC driver (raw sector read/write via IDMA)
+- `board/jungle/stm32h7/sd_replay.h` — replay state machine; call `sd_replay_tick()` from the main loop
+- `board/jungle/scripts/provision_sd.py` — writes openpilot rlog → SD binary image
+- USB commands: `0xa5` start/stop, `0xa6` status
+- Python API: `PandaJungle.sd_replay_start/stop/status()`
+
+## CANPacket_t
+
+Defined in `../opendbc/opendbc/safety/can.h`:
+```c
+typedef struct {
+  unsigned char fd : 1;
+  unsigned char bus : 3;
+  unsigned char data_len_code : 4;  // look up byte length with dlc_to_len[]
+  unsigned char rejected : 1;
+  unsigned char returned : 1;
+  unsigned char extended : 1;
+  unsigned int  addr : 29;
+  unsigned char checksum;
+  unsigned char data[64];
+} __attribute__((packed, aligned(4))) CANPacket_t;
+```
+
+Use `can_set_checksum()` before calling `can_send()`. Use `dlc_to_len[data_len_code]` to get byte length.
+
+## USB control protocol (jungle)
+
+Jungle-specific USB control requests are handled in `board/jungle/main_comms.h`. Assigned codes:
+
+| Code | Direction | Description |
+|------|-----------|-------------|
+| 0xa0 | OUT | Set panda power (all channels) |
+| 0xa1 | OUT | Set harness orientation |
+| 0xa2 | OUT | Set ignition |
+| 0xa3 | OUT | Set panda power (individual channel) |
+| 0xa4 | OUT | Enable generated CAN traffic |
+| 0xa5 | OUT | SD replay start (param1=1) / stop (param1=0) |
+| 0xa6 | IN  | SD replay status (9 bytes: uint8 state, uint32 total, uint32 current) |
+| 0xa8 | IN  | Microsecond timer (4 bytes) |
+| 0xd2 | IN  | Jungle health packet |
+| 0xde | OUT | Set CAN bitrate |
+| 0xf5 | OUT | CAN silent mode |
+| 0xf7 | OUT | Header pin enable/disable |
+| 0xf9 | OUT | CAN-FD data bitrate |

--- a/board/jungle/README.md
+++ b/board/jungle/README.md
@@ -24,3 +24,38 @@ Updating the firmware is easy! In the `board/jungle/` folder, run:
 
 If you somehow bricked your jungle, you'll need a [comma key](https://comma.ai/shop/products/comma-key) to put the microcontroller in DFU mode for the V1.
 For V2, the onboard button serves this purpose. When powered on while holding the button to put it in DFU mode, running `./recover.sh` in `board/` should unbrick it.
+
+## SD card CAN replay (V2 only)
+
+The jungle V2 SD card slot can replay CAN messages from an openpilot route autonomously, without needing a host PC.
+
+### Provision the SD card
+
+From an openpilot checkout, run:
+``` bash
+python board/jungle/scripts/provision_sd.py /path/to/rlog /dev/sdX
+```
+
+Or write to a binary file and `dd` it to the card:
+``` bash
+python board/jungle/scripts/provision_sd.py /path/to/rlog replay.bin
+sudo dd if=replay.bin of=/dev/sdX bs=512
+```
+
+### Start/stop replay
+
+``` python
+from panda import PandaJungle
+
+p = PandaJungle()
+p.sd_replay_start()
+
+# Poll progress
+status = p.sd_replay_status()
+# {"state": 1, "total_records": 12345, "current_record": 500}
+# state: 0=idle, 1=active, 2=done, 3=error
+
+p.sd_replay_stop()
+```
+
+Messages are sent in real time, preserving the original inter-message timing from the route. The jungle replays from the SD card automatically on the next `sd_replay_start()` call without re-provisioning.

--- a/board/jungle/__init__.py
+++ b/board/jungle/__init__.py
@@ -149,3 +149,16 @@ class PandaJungle(Panda):
 
   def set_header_pin(self, pin_num, enabled):
     self._handle.controlWrite(Panda.REQUEST_OUT, 0xf7, int(pin_num), int(enabled), b'')
+
+  # ******************* SD card CAN replay *******************
+
+  def sd_replay_start(self):
+    self._handle.controlWrite(PandaJungle.REQUEST_OUT, 0xa5, 1, 0, b'')
+
+  def sd_replay_stop(self):
+    self._handle.controlWrite(PandaJungle.REQUEST_OUT, 0xa5, 0, 0, b'')
+
+  def sd_replay_status(self):
+    dat = self._handle.controlRead(PandaJungle.REQUEST_IN, 0xa6, 0, 0, 9)
+    state, total, current = struct.unpack("<BII", dat)
+    return {"state": state, "total_records": total, "current_record": current}

--- a/board/jungle/main.c
+++ b/board/jungle/main.c
@@ -19,6 +19,11 @@
 
 #include "board/obj/gitversion.h"
 
+#ifdef STM32H7
+  #include "board/jungle/stm32h7/llsdmmc.h"
+  #include "board/jungle/stm32h7/sd_replay.h"
+#endif
+
 #include "board/can_comms.h"
 #include "board/jungle/main_comms.h"
 
@@ -155,9 +160,24 @@ int main(void) {
   can_init_all();
   current_board->set_harness_orientation(HARNESS_ORIENTATION_1);
 
+#ifdef STM32H7
+  gpio_sdmmc_init();
+  if (sdmmc_reset() == sd_err_ok) {
+    sd_replay_init();
+  } else {
+    print("SD card not detected\n");
+  }
+#endif
+
   // LED should keep on blinking all the time
   uint32_t cnt = 0;
   for (cnt=0;;cnt++) {
+#ifdef STM32H7
+    if (sd_replay_state == SD_REPLAY_ACTIVE) {
+      sd_replay_tick();
+      continue;
+    }
+#endif
     if (generated_can_traffic) {
       // fill up all the queues
       can_ring *qs[] = {&can_tx1_q, &can_tx2_q, &can_tx3_q};

--- a/board/jungle/main_comms.h
+++ b/board/jungle/main_comms.h
@@ -68,6 +68,33 @@ int comms_control_handler(ControlPacket_t *req, uint8_t *resp) {
     case 0xa4:
       generated_can_traffic = (req->param1 > 0U);
       break;
+    // **** 0xa5: SD card CAN replay control (param1: 0=stop, 1=start)
+    case 0xa5:
+#ifdef STM32H7
+      if (req->param1 == 1U) {
+        sd_replay_start();
+      } else {
+        sd_replay_stop();
+      }
+#endif
+      break;
+    // **** 0xa6: Get SD card replay status
+    case 0xa6:
+#ifdef STM32H7
+      {
+        struct __attribute__((packed)) {
+          uint8_t  state;
+          uint32_t total_records;
+          uint32_t current_record;
+        } status;
+        status.state          = (uint8_t)sd_replay_state;
+        status.total_records  = sd_replay_total_records;
+        status.current_record = sd_replay_current_record;
+        (void)memcpy(resp, &status, sizeof(status));
+        resp_len = sizeof(status);
+      }
+#endif
+      break;
     // **** 0xa8: get microsecond timer
     case 0xa8:
       time = microsecond_timer_get();

--- a/board/jungle/scripts/provision_sd.py
+++ b/board/jungle/scripts/provision_sd.py
@@ -84,7 +84,14 @@ def read_can_messages(rlog_path):
 
 
 def build_records(messages):
-  """Convert (mono_time_ns, addr, bus, data) list to binary record bytes."""
+  """Convert (mono_time_ns, addr, bus, data) list to binary record bytes.
+
+  messages must be non-empty. Records are sorted by timestamp before encoding
+  so that firmware replay timing is correct regardless of input order.
+  """
+  if not messages:
+    raise ValueError("messages must not be empty")
+  messages = sorted(messages, key=lambda m: m[0])
   t0_ns = messages[0][0]
   records = bytearray()
   for mono_time_ns, addr, bus, data in messages:
@@ -129,7 +136,6 @@ def main():
   records = build_records(messages)
   num_records = len(messages)
 
-  duration_s = (messages[-1][0] - messages[-1][0]) // 1_000_000_000 if len(messages) > 1 else 0
   elapsed_us = (messages[-1][0] - messages[0][0]) // 1000
   duration_s = elapsed_us / 1_000_000
 

--- a/board/jungle/scripts/provision_sd.py
+++ b/board/jungle/scripts/provision_sd.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Provision a panda jungle v2 SD card for CAN replay.
+
+Reads CAN messages from an openpilot rlog/qlog file and writes them to an
+SD card (or binary file) in the panda jungle raw replay format.
+
+Usage:
+  provision_sd.py <rlog_or_qlog> <sd_device_or_output_file>
+
+Examples:
+  # Write directly to an SD card block device (requires root/sudo on Linux):
+  provision_sd.py /data/media/0/realdata/abc123--0/0/rlog /dev/sdb
+
+  # Write to a binary file, then dd to the SD card manually:
+  provision_sd.py route.rlog replay.bin
+  dd if=replay.bin of=/dev/sdb bs=512
+
+SD card binary format written by this script:
+  Sector 0 (512 bytes): header
+    bytes  0-7:  magic b"PNDREPLY"
+    bytes  8-11: uint32 num_records
+    bytes 12-15: uint32 record_size  (= 20)
+    bytes 16-19: uint32 format_version  (= 1)
+    bytes 20-511: zero-padded
+  Sectors 1+: records (20 bytes each)
+    uint32 mono_time_us   - microseconds since replay start (relative)
+    uint32 addr           - CAN address
+    uint8  bus            - CAN bus number (0-2)
+    uint8  len            - data byte length (0-8)
+    uint8  data[8]        - CAN payload (zero-padded)
+    uint16 pad            - reserved (0)
+"""
+
+import argparse
+import struct
+import sys
+
+MAGIC = b"PNDREPLY"
+FORMAT_VERSION = 1
+RECORD_SIZE = 20
+SECTOR_SIZE = 512
+HEADER_SECTOR = 0
+DATA_START_SECTOR = 1
+
+HEADER_FMT = "<8sIII"   # magic, num_records, record_size, format_version
+RECORD_FMT = "<II BB 8s H"  # mono_time_us, addr, bus, len, data[8], pad
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description="Provision panda jungle v2 SD card for CAN replay")
+  parser.add_argument("rlog", help="Path to openpilot rlog or qlog file")
+  parser.add_argument("output", help="SD card block device (e.g. /dev/sdb) or output binary file")
+  return parser.parse_args()
+
+
+def read_can_messages(rlog_path):
+  """Read CAN messages from an openpilot rlog/qlog file.
+
+  Returns list of (mono_time_ns, addr, bus, data) tuples sorted by time.
+  """
+  try:
+    from openpilot.tools.lib.logreader import LogReader
+  except ImportError:
+    try:
+      from tools.lib.logreader import LogReader
+    except ImportError:
+      print("Error: could not import LogReader. Run from an openpilot checkout or install openpilot tools.", file=sys.stderr)
+      sys.exit(1)
+
+  messages = []
+  lr = LogReader(rlog_path)
+  for msg in lr:
+    if msg.which() == "sendcan":
+      for can_msg in msg.sendcan:
+        messages.append((msg.logMonoTime, can_msg.address, can_msg.src, bytes(can_msg.dat)))
+
+  if not messages:
+    print("Error: no sendcan messages found in log file.", file=sys.stderr)
+    sys.exit(1)
+
+  messages.sort(key=lambda m: m[0])
+  return messages
+
+
+def build_records(messages):
+  """Convert (mono_time_ns, addr, bus, data) list to binary record bytes."""
+  t0_ns = messages[0][0]
+  records = bytearray()
+  for mono_time_ns, addr, bus, data in messages:
+    elapsed_us = (mono_time_ns - t0_ns) // 1000
+    if elapsed_us > 0xFFFFFFFF:
+      print(f"Warning: timestamp overflow at {elapsed_us} us, clamping to 32-bit max.", file=sys.stderr)
+      elapsed_us = 0xFFFFFFFF
+
+    data_len = min(len(data), 8)
+    padded_data = data[:data_len].ljust(8, b'\x00')
+
+    record = struct.pack(RECORD_FMT, elapsed_us, addr, bus & 0xFF, data_len, padded_data, 0)
+    assert len(record) == RECORD_SIZE, f"record size mismatch: {len(record)}"
+    records.extend(record)
+
+  return records
+
+
+def build_header(num_records):
+  header_data = struct.pack(HEADER_FMT, MAGIC, num_records, RECORD_SIZE, FORMAT_VERSION)
+  # Pad to one full sector
+  return header_data + b'\x00' * (SECTOR_SIZE - len(header_data))
+
+
+def write_image(output_path, header, records):
+  with open(output_path, 'wb') as f:
+    f.write(header)
+    f.write(records)
+    # Pad final partial sector with zeros
+    remainder = len(records) % SECTOR_SIZE
+    if remainder != 0:
+      f.write(b'\x00' * (SECTOR_SIZE - remainder))
+
+
+def main():
+  args = parse_args()
+
+  print(f"Reading CAN messages from {args.rlog}...")
+  messages = read_can_messages(args.rlog)
+  print(f"  Found {len(messages)} sendcan messages")
+
+  records = build_records(messages)
+  num_records = len(messages)
+
+  duration_s = (messages[-1][0] - messages[-1][0]) // 1_000_000_000 if len(messages) > 1 else 0
+  elapsed_us = (messages[-1][0] - messages[0][0]) // 1000
+  duration_s = elapsed_us / 1_000_000
+
+  header = build_header(num_records)
+
+  total_bytes = len(header) + len(records)
+  total_sectors = (total_bytes + SECTOR_SIZE - 1) // SECTOR_SIZE
+
+  print(f"  Replay duration: {duration_s:.1f} seconds")
+  print(f"  Total records:   {num_records}")
+  print(f"  SD image size:   {total_sectors} sectors ({total_bytes / 1024:.1f} KB)")
+
+  print(f"Writing to {args.output}...")
+  write_image(args.output, header, records)
+  print("Done. Insert SD card into jungle v2 and call sd_replay_start() to begin replay.")
+
+
+if __name__ == "__main__":
+  main()

--- a/board/jungle/stm32h7/llsdmmc.h
+++ b/board/jungle/stm32h7/llsdmmc.h
@@ -1,0 +1,780 @@
+#define	RESP_NONE 0U
+#define	RESP_R1 1U
+#define	RESP_R1b 2U
+#define	RESP_R2 3U
+#define	RESP_R3 4U
+#define	RESP_R6 5U
+#define	RESP_R7 6U
+
+#define CMD0                          0                 // GO_IDLE_STATE          (SDIO:RESP_NONE   SPI:RESP_R1)
+#define CMD2                          2                 // ALL_SEND_CID           (SDIO:RESP_R2     SPI: - )
+#define CMD3                          3                 // SEND_RELATIVE_ADDR     (SDIO:RESP_R6     SPI: - )
+#define CMD7                          7                 // SELECT/DESELECT_CARD   (SDIO:RESP_R1b    SPI: - )
+#define CMD8                          8                 // SEND_IF_COND           (SDIO:RESP_R7     SPI:RESP_R7)
+#define CMD9                          9                 // SEND_CSD               (SDIO:RESP_R2     SPI:RESP_R1+D16)
+#define CMD12                         12                // STOP_TRANSMISSION      (SDIO:RESP_R1b    SPI:RESP_R1b)
+#define CMD13                         13                // SEND_STATUS            (SDIO:RESP_R1     SPI:RESP_R2)
+#define CMD16                         16                // SET_BLOCKLEN           (SDIO:RESP_R1     SPI:RESP_R1)
+#define CMD17                         17                // READ_SINGLE_BLOCK      (SDIO:RESP_R1     SPI:RESP_R1)
+#define CMD18                         18                // READ_MULTIPLE_BLOCK    (SDIO:RESP_R1     SPI:RESP_R1)
+#define CMD24                         24                // WRITE_BLOCK            (SDIO:RESP_R1     SPI:RESP_R1)
+#define CMD25                         25                // WRITE_MULTIPLE_BLOCK   (SDIO:RESP_R1     SPI:RESP_R1)
+#define CMD55                         55                // APP_CMD                (SDIO:RESP_R1     SPI:RESP_R1)
+#define CMD58                         58                // READ_OCR               (SDIO: -          SPI:RESP_R3)
+#define	ACMD6                         6                 // SET_BUS_WIDTH          (SDIO:RESP_R1     SPI: - )
+#define	ACMD23                        23                // SET_WR_BLK_ERASE_COUNT (SDIO:RESP_R1     SPI:RESP_R1)
+#define	ACMD41                        41                // SD_SEND_OP_COND        (SDIO:RESP_R3     SPI:RESP_R1)
+#define	ACMD51                        51                // SEND_SCR               (SDIO:RESP_R1+D8  SPI:RESP_R1+D8)
+
+#define CMD8_VHS1                     0x100             // 2.7-3.6V
+#define CMD8_CHECK                    0xAA              // check pattern
+
+#define	ACMD41_HCS                    0x40000000        // Host Capacity Support (0b: SDSC Only Host, 1b: SDHC or SDXC Supported)
+#define	ACMD41_33_34V                 0x00100000        // 3.3-3.4V
+#define	ACMD41_32_33V                 0x00080000        // 3.2-3.3V
+
+#define	RESP_R3_CCS                   0x40000000        // card capacity status
+#define	RESP_R3_BUSY                  0x80000000        // card power up status bit
+
+#define	RESP_R1_CURRENT_STATE_MASK    0x1E00            // The state of the card field mask
+#define	RESP_R1_CURRENT_STATE_IDLE    0x0000            // idle
+#define	RESP_R1_CURRENT_STATE_READY   0x0200            // ready
+#define	RESP_R1_CURRENT_STATE_IDENT   0x0400            // ident
+#define	RESP_R1_CURRENT_STATE_STBY    0x0600            // stby
+#define	RESP_R1_CURRENT_STATE_TRAN    0x0800            // tran
+#define	RESP_R1_CURRENT_STATE_DATA    0x0A00            // data
+#define	RESP_R1_CURRENT_STATE_RCV     0x0C00            // rcv
+#define	RESP_R1_CURRENT_STATE_PRG     0x0E00            // prg
+#define	RESP_R1_CURRENT_STATE_DIS     0x1000            // dis
+
+#define SCR_SD_BUS_WIDTHS_1           0x10000           // 1 bit (DAT0)
+#define SCR_SD_BUS_WIDTHS_4           0x40000           // 4 bit (DAT0-3)
+#define SCR_SD_SECURITY_MASK          0x700000          // CPRM Security Version field mask
+#define SCR_SD_SECURITY_SDSC          0x200000          // SDSC Card (Security Version 1.01)
+#define SCR_SD_SECURITY_SDHC          0x300000          // SDHC Card (Security Version 2.00)
+#define SCR_SD_SECURITY_SDXC          0x400000          // SDXC Card (Security Version 3.xx)
+
+
+#define SDMMC_INIT_CLK_DIV            0x64U // div 200 (400kHz max)
+#define SDMMC_TRANSFER_CLK_DIV        0x2U // div 4 (PLL1Q/4=20MHz) (25MHz max)
+
+//--------------------------------------------
+#define INIT_PROCESS_COUNT            1000      // Number of attempts to get a ready state
+#define DATATIMEOUT                   0xFFFFFF  // A method for computing a realistic values from CSD is described in the specs
+
+#define SDMMC_DCTRL_BLOCKSIZE_512			(9 << SDMMC_DCTRL_DBLOCKSIZE_Pos )
+#define SDMMC_STA_ERRORS			        (SDMMC_STA_RXOVERR | SDMMC_STA_TXUNDERR | SDMMC_STA_DTIMEOUT | SDMMC_STA_DCRCFAIL )
+#define SDMMC_ICR_STATIC              (SDMMC_ICR_CCRCFAILC | SDMMC_ICR_DCRCFAILC | SDMMC_ICR_CTIMEOUTC | \
+                                       SDMMC_ICR_DTIMEOUTC | SDMMC_ICR_TXUNDERRC | SDMMC_ICR_RXOVERRC  | \
+                                       SDMMC_ICR_CMDRENDC  | SDMMC_ICR_CMDSENTC  | SDMMC_ICR_DATAENDC  | \
+                                       SDMMC_ICR_DBCKENDC )
+
+#define SDMMC_BLOCK_SIZE              512U
+#define SDMMC_BUFFER_SIZE             32U*SDMMC_BLOCK_SIZE
+
+// for FIFO D1 and D2 works, but for IDMA only D1 works
+__attribute__((section(".axisram"), aligned(32))) uint8_t idmabuf[SDMMC_BUFFER_SIZE];
+
+typedef enum
+{
+	sd_err_ok = 0,
+	sd_err_ctimeout,
+	sd_err_ccrcfail,
+	sd_err_dtimeout,
+	sd_err_dcrcfail,
+	sd_err_rxoverr,
+	sd_err_txunderr,
+	sd_err_stbiterr,
+	sd_err_writefail,
+	sd_err_unexpected_command,
+	sd_err_not_supported,
+	sd_err_wrong_status
+} sd_error;
+
+typedef enum
+{
+	CARD_SDSC,
+	CARD_SDHC,
+	CARD_SDXC
+} sd_type;
+
+typedef struct sd_info
+{
+	sd_type    type;            // type of the sd card
+	uint32_t   rca;             // relative card address
+	uint32_t   card_size;       // card size in sectors
+	uint32_t   sect_size;       // sector size in bytes
+	uint32_t   erase_size;      // erase block size in sectors
+} sd_info_t;
+
+static sd_info_t sdinfo;
+
+// Configure GPIO pins for SDMMC1 peripheral (jungle v2 SD card slot)
+void gpio_sdmmc_init(void) {
+  // SDMMC1 data lines D0-D3 and clock on GPIOC
+  set_gpio_pullup(GPIOC, 8, PULL_NONE);
+  set_gpio_alternate(GPIOC, 8, GPIO_AF12_SDMMC1);   // SD_D0
+  set_gpio_pullup(GPIOC, 9, PULL_NONE);
+  set_gpio_alternate(GPIOC, 9, GPIO_AF12_SDMMC1);   // SD_D1
+  set_gpio_pullup(GPIOC, 10, PULL_NONE);
+  set_gpio_alternate(GPIOC, 10, GPIO_AF12_SDMMC1);  // SD_D2
+  set_gpio_pullup(GPIOC, 11, PULL_NONE);
+  set_gpio_alternate(GPIOC, 11, GPIO_AF12_SDMMC1);  // SD_D3
+  set_gpio_pullup(GPIOC, 12, PULL_NONE);
+  set_gpio_alternate(GPIOC, 12, GPIO_AF12_SDMMC1);  // SD_SCLK
+  // SDMMC1 command line on GPIOD
+  set_gpio_alternate(GPIOD, 2, GPIO_AF12_SDMMC1);   // SD_CMD
+  // Set high-speed output mode for all SDMMC pins
+  register_set_bits(&(GPIOC->OSPEEDR), GPIO_OSPEEDR_OSPEED8 | GPIO_OSPEEDR_OSPEED9 | GPIO_OSPEEDR_OSPEED10 | GPIO_OSPEEDR_OSPEED11 | GPIO_OSPEEDR_OSPEED12);
+  register_set_bits(&(GPIOD->OSPEEDR), GPIO_OSPEEDR_OSPEED2);
+}
+
+
+sd_error send_command(uint32_t cmd, uint32_t arg, uint8_t resp, uint32_t *buf) {
+	uint32_t cmd_waitresp = 0;
+
+	switch(resp) {
+	case RESP_NONE:
+		// No response, expect CMDSENT flag
+		cmd_waitresp = 0;
+		break;
+	case RESP_R1:
+	case RESP_R1b:
+	case RESP_R3:
+	case RESP_R6:
+	case RESP_R7:
+		// Short response, expect CMDREND or CCRCFAIL flag
+		cmd_waitresp = SDMMC_CMD_WAITRESP_0;
+		break;
+	case RESP_R2:
+		// Long response, expect CMDREND or CCRCFAIL flag
+		cmd_waitresp = SDMMC_CMD_WAITRESP_0 | SDMMC_CMD_WAITRESP_1;
+		break;
+	}
+
+	SDMMC1->ARG = arg;
+	SDMMC1->CMD = (uint32_t)(cmd & SDMMC_CMD_CMDINDEX) | (cmd_waitresp & SDMMC_CMD_WAITRESP) | SDMMC_CMD_CPSMEN;
+	if (resp == RESP_NONE) {
+		while (!(SDMMC1->STA & SDMMC_STA_CMDSENT));
+		SDMMC1->ICR = SDMMC_ICR_CMDSENTC;
+		return sd_err_ok;
+	}
+	while (!(SDMMC1->STA & (SDMMC_STA_CMDREND | SDMMC_STA_CCRCFAIL | SDMMC_STA_CTIMEOUT)));
+	if (SDMMC1->STA & SDMMC_STA_CTIMEOUT) {
+		SDMMC1->ICR = SDMMC_STA_CTIMEOUT;
+		return sd_err_ctimeout;
+	}
+	// STM32F74xxx STM32F75xxx Errata sheet:
+	// 2.12.1 Wrong CCRCFAIL status after a response without CRC is received (RESP_R3)
+	if ((resp != RESP_R3) && (SDMMC1->STA & SDMMC_STA_CCRCFAIL)) {
+		SDMMC1->ICR = SDMMC_STA_CCRCFAIL;
+		return sd_err_ccrcfail;
+	}
+	SDMMC1->ICR = SDMMC_STA_CMDREND | SDMMC_STA_CCRCFAIL;
+	switch(resp) {
+	case RESP_R1:
+	case RESP_R1b:
+	case RESP_R3:
+	case RESP_R6:
+	case RESP_R7:
+		buf[0] = SDMMC1->RESP1;
+		break;
+	case RESP_R2:
+		buf[0] = SDMMC1->RESP1;
+		buf[1] = SDMMC1->RESP2;
+		buf[2] = SDMMC1->RESP3;
+		buf[3] = SDMMC1->RESP4;
+		break;
+	default:
+		break;
+	}
+	switch(resp) {
+	case RESP_R1:
+	case RESP_R1b:
+	case RESP_R6:
+	case RESP_R7:
+		if (SDMMC1->RESPCMD != cmd) {
+			return sd_err_unexpected_command;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return sd_err_ok;
+}
+
+//--------------------------------------------
+// Reads and parses the SD Configuration Register (SCR),
+// calls only in Transfer State (tran)
+sd_error read_scr(void) {
+	sd_error err;
+	uint32_t cnt;
+	uint32_t *buf = (uint32_t*)idmabuf;
+	uint32_t sd_sec;
+
+	err = sd_err_ok;
+	cnt = 0;
+	// CMD16: Block length to 8 byte
+	if ((err = send_command(CMD16, 8, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// CMD55: Next command is an application specific
+	if ((err = send_command(CMD55, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// Receiving 8 data bytes
+	SDMMC1->DTIMER = DATATIMEOUT;
+	SDMMC1->DLEN = 8;
+	SDMMC1->DCTRL = (SDMMC_DCTRL_DBLOCKSIZE_0 | SDMMC_DCTRL_DBLOCKSIZE_1) | \
+	                 SDMMC_DCTRL_DTDIR | \
+	                 SDMMC_DCTRL_DTEN;
+
+	// ACMD51: Reads the SD Configuration Register (SCR)
+	if ((err = send_command(ACMD51, 0, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	while (!(SDMMC1->STA & (SDMMC_STA_DATAEND | SDMMC_STA_RXOVERR | SDMMC_STA_DCRCFAIL | SDMMC_STA_DTIMEOUT))) {
+		if (!(SDMMC1->STA & SDMMC_STA_RXFIFOE)) {
+			buf[cnt++] = SDMMC1->FIFO;
+		}
+	}
+
+	if (SDMMC1->STA & SDMMC_STA_DTIMEOUT) {
+		err = sd_err_dtimeout;
+	}
+	if (SDMMC1->STA & SDMMC_STA_DCRCFAIL) {
+		err = sd_err_dcrcfail;
+	}
+	if (SDMMC1->STA & SDMMC_STA_RXOVERR) {
+		err = sd_err_rxoverr;
+	}
+
+	SDMMC1->ICR = SDMMC_ICR_STATIC;
+	SDMMC1->DCTRL = 0;
+
+	// swap bytes
+	buf[0] = (buf[0] & 0x0000FFFF) << 16 | (buf[0] & 0xFFFF0000) >> 16;
+	buf[0] = (buf[0] & 0x00FF00FF) << 8  | (buf[0] & 0xFF00FF00) >> 8;
+	buf[1] = (buf[1] & 0x0000FFFF) << 16 | (buf[1] & 0xFFFF0000) >> 16;
+	buf[1] = (buf[1] & 0x00FF00FF) << 8  | (buf[1] & 0xFF00FF00) >> 8;
+
+	sd_sec = buf[0] & SCR_SD_SECURITY_MASK;
+	if (sd_sec == SCR_SD_SECURITY_SDSC) {
+		sdinfo.type = CARD_SDSC;
+	}
+	if (sd_sec == SCR_SD_SECURITY_SDHC) {
+		sdinfo.type = CARD_SDHC;
+	}
+	if (sd_sec == SCR_SD_SECURITY_SDXC) {
+		sdinfo.type = CARD_SDXC;
+	}
+
+	return err;
+}
+
+//--------------------------------------------
+// Reads and parses the Card-Specific Data register (CSD)
+sd_error read_csd(void) {
+	sd_error err;
+	uint32_t buf[4];
+	uint32_t c_size;
+	uint8_t c_size_mult;
+	uint8_t read_bl_len;
+
+	if ((err = send_command(CMD9, sdinfo.rca << 16, RESP_R2, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+
+	if (sdinfo.type == CARD_SDSC) {
+		// CSD Version 1.0
+		read_bl_len = (uint8_t)(buf[1] & 0x000F0000) >> 16;
+
+		c_size  = (buf[1] & 0x00000300) << 2;
+		c_size |= (buf[1] & 0x000000FF) << 2;
+		c_size |= (buf[2] & 0xD0000000) >> 30;
+
+		c_size_mult  = (buf[2] & 0x00030000) >> 15;
+		c_size_mult |= (buf[2] & 0x00008000) >> 15;
+
+		sdinfo.card_size = (c_size + 1) * (1 << (c_size_mult + 2)) * (1 << read_bl_len) / SDMMC_BLOCK_SIZE;
+		sdinfo.sect_size = SDMMC_BLOCK_SIZE;
+		// The erase operation can erase either one or multiple sectors
+		sdinfo.erase_size = 1;
+	} else {
+		// CSD Version 2.0
+		c_size  = (buf[1] & 0x0000003F) << 16;
+		c_size |= (buf[2] & 0xFF000000) >> 16;
+		c_size |= (buf[2] & 0x00FF0000) >> 16;
+
+		sdinfo.card_size = (c_size + 1) * 1024; // in 512 byte sectors
+		sdinfo.sect_size = SDMMC_BLOCK_SIZE;
+		// The erase operation can erase either one or multiple sectors
+		sdinfo.erase_size = 1;
+	}
+	return sd_err_ok;
+}
+
+//--------------------------------------------
+sd_error sdmmc_reset(void) {
+	sd_error err;
+	uint32_t cnt;
+	uint32_t buf[4];
+
+  // Init SD card at 400kHz and one data line
+	SDMMC1->CLKCR = SDMMC_INIT_CLK_DIV | SDMMC_CLKCR_PWRSAV | SDMMC_CLKCR_HWFC_EN;
+	SDMMC1->POWER |= SDMMC_POWER_PWRCTRL;
+  while ((SDMMC1->POWER & SDMMC_POWER_PWRCTRL) == 0) {};
+
+	// command to send the card to SPI mode.
+	send_command(CMD0, 0, RESP_NONE, &buf[0]);
+
+	// The version 2.00 or later host shall issue
+	// CMD8 and verify voltage before card initialization.
+	err = send_command(CMD8, CMD8_VHS1 | CMD8_CHECK, RESP_R7, &buf[0]);
+	if ((err != sd_err_unexpected_command) && (err != sd_err_ok)) {
+		return err;
+	}
+	if (err == sd_err_unexpected_command) {
+		// PLSS version 1.xx
+		for (cnt = 0; cnt < INIT_PROCESS_COUNT; cnt++) {
+			// CMD55: Next command is an application specific
+			if ((err = send_command(CMD55, 0, RESP_R1, &buf[0])) != sd_err_ok) {
+				return err;
+			}
+			// ACMD41 is a synchronization command used to negotiate the operation voltage range
+			// and to poll the cards until they are out of their power-up sequence.
+			if ((err = send_command(ACMD41, ACMD41_32_33V, RESP_R3, &buf[0])) != sd_err_ok) {
+				return err;
+			}
+			if (buf[0] & RESP_R3_BUSY) {
+				sdinfo.type = CARD_SDSC;
+				break;
+			}
+		}
+		if (cnt == INIT_PROCESS_COUNT) {
+			return sd_err_not_supported;
+		}
+	} else {
+		// PLSS version 2.00 or later
+		if (buf[0] != (uint32_t)(CMD8_VHS1 | CMD8_CHECK)) {
+			// voltage not supported
+			return sd_err_not_supported;
+		}
+
+		// 2.7-3.6V supported
+		for (cnt = 0; cnt < INIT_PROCESS_COUNT; cnt++) {
+			// CMD55: Next command is an application specific
+			if ((err = send_command(CMD55, 0, RESP_R1, &buf[0])) != sd_err_ok) {
+				return err;
+			}
+			// ACMD41 is a synchronization command used to negotiate the operation voltage range
+			// and to poll the cards until they are out of their power-up sequence.
+			// ACMD41: Sends host capacity support information (HCS) and asks the
+			// accessed card to send its operating condition register (OCR) content in the
+			// response on the CMD line.
+			if ((err = send_command(ACMD41, ACMD41_HCS | ACMD41_32_33V, RESP_R3, &buf[0])) != sd_err_ok) {
+				return err;
+			}
+			if (buf[0] & RESP_R3_BUSY) {
+				if (buf[0] & RESP_R3_CCS) {
+					// SDHC or SDXC, it will be known later
+					sdinfo.type = CARD_SDHC;
+				} else {
+					sdinfo.type = CARD_SDSC;
+				}
+				break;
+			}
+		}
+		if (cnt == INIT_PROCESS_COUNT) {
+			return sd_err_not_supported;
+		}
+	}
+	// CMD2: Asks any card to send the CID numbers on the CMD line
+	if ((err = send_command(CMD2, 0, RESP_R2, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// CMD3: Ask the card to publish a new relative address (RCA)
+	// ==> Stand-by State (stby)
+	if ((err = send_command(CMD3, 0, RESP_R6, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	sdinfo.rca = buf[0] >> 16;
+	// CMD9: Reads and parses the Card-Specific Data register (CSD)
+	if ((err = read_csd()) != sd_err_ok) {
+		return err;
+	}
+	// CMD7: Command toggles a card between the stand-by and transfer states
+	// ==> Transfer State (tran)
+	if ((err = send_command(CMD7, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// CMD16->CMD55->ACMD51: Reads and parses the SD Configuration Register (SCR)
+	if ((err = read_scr()) != sd_err_ok) {
+		return err;
+	}
+	// CMD55: Next command is an application specific
+	if ((err = send_command(CMD55, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// ACMD6: Defines the 4 bits data bus width to be used for data transfer
+	if ((err = send_command(ACMD6, 0x2, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+  // Switch to fast clock and 4 data lines
+	SDMMC1->CLKCR = SDMMC_TRANSFER_CLK_DIV | SDMMC_CLKCR_WIDBUS_0 | SDMMC_CLKCR_PWRSAV | SDMMC_CLKCR_NEGEDGE;
+
+	return sd_err_ok;
+}
+
+//--------------------------------------------
+sd_error sdmmc_read(uint8_t *rxbuf, uint32_t sector, uint32_t count) {
+	sd_error err;
+	uint32_t buf[4];
+	uint32_t *dbuf;
+	uint32_t cnt;
+	uint32_t sta;
+
+	dbuf = (uint32_t *)&rxbuf[0];
+
+	// CMD13: Asks the selected card to send its status register
+	if ((err = send_command(CMD13, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// not Transfer State (tran)
+	if ((buf[0] & RESP_R1_CURRENT_STATE_MASK) != RESP_R1_CURRENT_STATE_TRAN) {
+		return sd_err_wrong_status;
+	}
+	if (sdinfo.type == CARD_SDSC) {
+		// SDSC uses the 32-bit argument of memory access commands as byte address format
+		// Block length is determined by CMD16, by default - 512 byte
+		sector *= SDMMC_BLOCK_SIZE;
+	}
+	// Receiving 512 bytes data blocks
+	SDMMC1->DTIMER = DATATIMEOUT;
+	SDMMC1->DLEN = count * SDMMC_BLOCK_SIZE;
+	SDMMC1->DCTRL = (SDMMC_DCTRL_DBLOCKSIZE_0 | SDMMC_DCTRL_DBLOCKSIZE_3) | // Data block size: (1001) 512 bytes
+	                                     // (0) DMA disabled
+	                 SDMMC_DCTRL_DTDIR | // Data transfer direction selection: (1) From card to controller
+	                 SDMMC_DCTRL_DTEN;   // (1) Data transfer enabled bit
+
+	if (count == 1) {
+		// CMD17: Reads a block of the size selected by the SET_BLOCKLEN command (SDSC)
+		// or exactly 512 byte (SDHC and SDXC)
+		// ==> Sending-data State (data)
+		if ((err = send_command(CMD17, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	} else {
+		// CMD18: Continuously transfers data blocks from card to host
+		// until interrupted by a STOP_TRANSMISSION command
+		// ==> Sending-data State (data)
+		if ((err = send_command(CMD18, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	}
+
+	while (!(SDMMC1->STA & (SDMMC_STA_RXOVERR | SDMMC_STA_DCRCFAIL | SDMMC_STA_DTIMEOUT | SDMMC_STA_DATAEND))) {
+		while (SDMMC1->STA & SDMMC_STA_RXFIFOHF) {
+			for (cnt = 0; cnt < 8; cnt++) {
+				*(dbuf + cnt) = SDMMC1->FIFO;
+			}
+			dbuf += 8;
+		}
+	}
+
+	SDMMC1->DCTRL = 0;
+
+	if (count > 1) {
+		// CMD12: Forces the card to stop transmission
+		// if count == 1, "operation complete" is automatic
+		// ==> Transfer State (tran)
+		if ((err = send_command(CMD12, 0, RESP_R1b, &buf[0])) != sd_err_ok) {
+			SDMMC1->ICR = SDMMC_ICR_STATIC;
+			return err;
+		}
+	}
+
+	sta = SDMMC1->STA;
+	SDMMC1->ICR = SDMMC_ICR_STATIC;
+
+	if (sta & SDMMC_STA_DTIMEOUT) {
+		return sd_err_dtimeout;
+	}
+	if (sta & SDMMC_STA_DCRCFAIL) {
+		return sd_err_dcrcfail;
+	}
+	if (sta & SDMMC_STA_RXOVERR) {
+		return sd_err_rxoverr;
+	}
+	return sd_err_ok;
+}
+
+// FIXME: IDMA does not work for read, timeout
+sd_error sdmmc_read_idma(uint8_t *rxbuf, uint32_t sector, uint32_t count) {
+	sd_error err;
+	uint32_t buf[4];
+	uint32_t *dbuf;
+	uint32_t sta;
+  uint8_t dir = 1;
+
+	dbuf = (uint32_t *)&rxbuf[0];
+
+  SDMMC1->DCTRL = 0; // reset DPSM
+
+	// CMD13: Asks the selected card to send its status register
+	if ((err = send_command(CMD13, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// not Transfer State (tran)
+	if ((buf[0] & RESP_R1_CURRENT_STATE_MASK) != RESP_R1_CURRENT_STATE_TRAN) {
+		return sd_err_wrong_status;
+	}
+
+	if (sdinfo.type == CARD_SDSC) {
+		// SDSC uses the 32-bit argument of memory access commands as byte address format
+		// Block length is determined by CMD16, by default - 512 byte
+		sector *= SDMMC_BLOCK_SIZE;
+	}
+	// Sending 512 bytes data blocks
+  SDMMC1->DTIMER = DATATIMEOUT;
+  SDMMC1->DCTRL |= SDMMC_DCTRL_FIFORST;
+  SDMMC1->DLEN = count * SDMMC_BLOCK_SIZE;
+  SDMMC1->MASK=0; // TODO: mask only FIFO interrupts??
+  SDMMC1->IDMABASE0 = (uint32_t)dbuf;
+  SDMMC1->DCTRL = SDMMC_DCTRL_BLOCKSIZE_512 | (dir & SDMMC_DCTRL_DTDIR);  //Direction. 0=Controller to card, 1=Card to Controller
+
+
+	if (count == 1) {
+		// CMD17: Reads a block of the size selected by the SET_BLOCKLEN command (SDSC)
+		// or exactly 512 byte (SDHC and SDXC)
+		// ==> Sending-data State (data)
+		if ((err = send_command(CMD17, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	} else {
+		// CMD18: Continuously transfers data blocks from card to host
+		// until interrupted by a STOP_TRANSMISSION command
+		// ==> Sending-data State (data)
+		if ((err = send_command(CMD18, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	}
+
+  SDMMC1->ICR = SDMMC_ICR_STATIC;
+  SDMMC1->IDMACTRL = SDMMC_IDMA_IDMAEN;
+	SDMMC1->DCTRL |= SDMMC_DCTRL_DTEN; //DPSM is enabled
+
+  // TODO: this should be changed for IRQ instead of blocking
+  while((SDMMC1->STA & (SDMMC_STA_DATAEND|SDMMC_STA_ERRORS)) == 0){__NOP();};
+
+	SDMMC1->DCTRL = 0;
+
+	if (count > 1) {
+		// CMD12: Forces the card to stop transmission
+		// if count == 1, "operation complete" is automatic
+		// ==> Transfer State (tran)
+		if ((err = send_command(CMD12, 0, RESP_R1b, &buf[0])) != sd_err_ok) {
+			SDMMC1->ICR = SDMMC_ICR_STATIC;
+			return err;
+		}
+	}
+
+	sta = SDMMC1->STA;
+	SDMMC1->ICR = SDMMC_ICR_STATIC;
+
+	if (sta & SDMMC_STA_DTIMEOUT) {
+		return sd_err_dtimeout;
+	}
+	if (sta & SDMMC_STA_DCRCFAIL) {
+		return sd_err_dcrcfail;
+	}
+	if (sta & SDMMC_STA_TXUNDERR) {
+		return sd_err_txunderr;
+	}
+	return sd_err_ok;
+}
+
+//--------------------------------------------
+sd_error sdmmc_write(uint8_t *txbuf, uint32_t sector, uint32_t count) {
+	sd_error err;
+	uint32_t buf[4];
+	uint32_t *dbuf;
+	uint32_t cnt;
+	uint32_t sta;
+
+	dbuf = (uint32_t *)&txbuf[0];
+
+	// CMD13: Asks the selected card to send its status register
+	if ((err = send_command(CMD13, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// not Transfer State (tran)
+	if ((buf[0] & RESP_R1_CURRENT_STATE_MASK) != RESP_R1_CURRENT_STATE_TRAN) {
+		return sd_err_wrong_status;
+	}
+
+	if (sdinfo.type == CARD_SDSC) {
+		// SDSC uses the 32-bit argument of memory access commands as byte address format
+		// Block length is determined by CMD16, by default - 512 byte
+		sector *= SDMMC_BLOCK_SIZE;
+	}
+	// Sending 512 bytes data blocks
+	SDMMC1->DTIMER = DATATIMEOUT;
+	SDMMC1->DLEN = count * SDMMC_BLOCK_SIZE;
+	SDMMC1->DCTRL = SDMMC_DCTRL_BLOCKSIZE_512 | // Data block size: (1001) 512 bytes
+	                                     // (0) DMA disabled
+	                                     // Data transfer direction selection: (0) From controller to card
+	                 SDMMC_DCTRL_DTEN;   // (1) Data transfer enabled bit
+
+	if (count == 1) {
+		// CMD24: Write a block of the size selected by the SET_BLOCKLEN command (SDSC)
+		// or exactly 512 byte (SDHC and SDXC)
+		// ==> Receive-data State (rcv)
+		if ((err = send_command(CMD24, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	} else {
+		// CMD55: Next command is an application specific
+		if ((err = send_command(CMD55, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+		// ACMD23: Set the number of write blocks to be pre-erased before writing 
+		// (to be used for faster Multiple Block WR command)
+		if ((err = send_command(ACMD23, count, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+		// CMD25: Continuously writes blocks of data until a STOP_TRANSMISSION follows.
+		// ==> Receive-data State (rcv)
+		if ((err = send_command(CMD25, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	}
+	while (!(SDMMC1->STA & (SDMMC_STA_TXUNDERR | SDMMC_STA_DCRCFAIL | SDMMC_STA_DTIMEOUT | SDMMC_STA_DATAEND | SDMMC_STA_DBCKEND))) {
+		while (SDMMC1->STA & SDMMC_STA_TXFIFOHE) {
+			for (cnt = 0; cnt < 8; cnt++) {
+				SDMMC1->FIFO = *(dbuf + cnt);
+			}
+			dbuf += 8;
+		}
+	}
+	SDMMC1->DCTRL = 0;
+
+	if (count > 1) {
+		// CMD12: Forces the card to stop receiving
+		// if count == 1, "transfer end" is automatic
+		// ==> Programming State (prg) ==> Transfer State (tran)
+		if ((err = send_command(CMD12, 0, RESP_R1b, &buf[0])) != sd_err_ok) {
+			SDMMC1->ICR = SDMMC_ICR_STATIC;
+			return err;
+		}
+	}
+
+	sta = SDMMC1->STA;
+	SDMMC1->ICR = SDMMC_ICR_STATIC;
+
+	if (sta & SDMMC_STA_DTIMEOUT) {
+		return sd_err_dtimeout;
+	}
+	if (sta & SDMMC_STA_DCRCFAIL) {
+		return sd_err_dcrcfail;
+	}
+	if (sta & SDMMC_STA_TXUNDERR) {
+		return sd_err_txunderr;
+	}
+
+	return sd_err_ok;
+}
+
+
+sd_error sdmmc_write_idma(uint8_t *txbuf, uint32_t sector, uint32_t count) {
+	sd_error err;
+	uint32_t buf[4];
+	uint32_t *dbuf;
+	uint32_t sta;
+  uint8_t dir = 0;
+
+	dbuf = (uint32_t *)&txbuf[0];
+
+  SDMMC1->DCTRL = 0; // reset DPSM
+
+	// CMD13: Asks the selected card to send its status register
+	if ((err = send_command(CMD13, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+		return err;
+	}
+	// not Transfer State (tran)
+	if ((buf[0] & RESP_R1_CURRENT_STATE_MASK) != RESP_R1_CURRENT_STATE_TRAN) {
+		return sd_err_wrong_status;
+	}
+
+	if (sdinfo.type == CARD_SDSC) {
+		// SDSC uses the 32-bit argument of memory access commands as byte address format
+		// Block length is determined by CMD16, by default - 512 byte
+		sector *= SDMMC_BLOCK_SIZE;
+	}
+	// Sending 512 bytes data blocks
+  SDMMC1->DTIMER = DATATIMEOUT;
+  SDMMC1->DCTRL |= SDMMC_DCTRL_FIFORST;
+  SDMMC1->DLEN = count * SDMMC_BLOCK_SIZE;
+  SDMMC1->MASK=0; // TODO: mask only FIFO interrupts??
+  SDMMC1->IDMABASE0 = (uint32_t)dbuf;
+  SDMMC1->DCTRL = SDMMC_DCTRL_BLOCKSIZE_512 | (dir & SDMMC_DCTRL_DTDIR);  //Direction. 0=Controller to card, 1=Card to Controller
+
+
+	if (count == 1) {
+		// CMD24: Write a block of the size selected by the SET_BLOCKLEN command (SDSC)
+		// or exactly 512 byte (SDHC and SDXC)
+		// ==> Receive-data State (rcv)
+		if ((err = send_command(CMD24, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	} else {
+		// CMD55: Next command is an application specific
+		if ((err = send_command(CMD55, sdinfo.rca << 16, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+		// ACMD23: Set the number of write blocks to be pre-erased before writing 
+		// (to be used for faster Multiple Block WR command)
+		if ((err = send_command(ACMD23, count, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+		// CMD25: Continuously writes blocks of data until a STOP_TRANSMISSION follows.
+		// ==> Receive-data State (rcv)
+		if ((err = send_command(CMD25, sector, RESP_R1, &buf[0])) != sd_err_ok) {
+			return err;
+		}
+	}
+
+  SDMMC1->ICR = SDMMC_ICR_STATIC;
+  SDMMC1->IDMACTRL = SDMMC_IDMA_IDMAEN;
+	SDMMC1->DCTRL |= SDMMC_DCTRL_DTEN; //DPSM is enabled
+
+  // TODO: this should be changed for IRQ instead of blocking
+  while((SDMMC1->STA & (SDMMC_STA_DATAEND|SDMMC_STA_ERRORS)) == 0){__NOP();};
+
+	SDMMC1->DCTRL = 0;
+
+	if (count > 1) {
+		// CMD12: Forces the card to stop receiving
+		// if count == 1, "transfer end" is automatic
+		// ==> Programming State (prg) ==> Transfer State (tran)
+		if ((err = send_command(CMD12, 0, RESP_R1b, &buf[0])) != sd_err_ok) {
+			SDMMC1->ICR = SDMMC_ICR_STATIC;
+			return err;
+		}
+	}
+
+	sta = SDMMC1->STA;
+	SDMMC1->ICR = SDMMC_ICR_STATIC;
+
+	if (sta & SDMMC_STA_DTIMEOUT) {
+		return sd_err_dtimeout;
+	}
+	if (sta & SDMMC_STA_DCRCFAIL) {
+		return sd_err_dcrcfail;
+	}
+	if (sta & SDMMC_STA_TXUNDERR) {
+		return sd_err_txunderr;
+	}
+	return sd_err_ok;
+}

--- a/board/jungle/stm32h7/sd_replay.h
+++ b/board/jungle/stm32h7/sd_replay.h
@@ -85,6 +85,7 @@ static bool sd_replay_fill_buffer(void) {
 }
 
 void sd_replay_init(void) {
+  COMPILE_TIME_ASSERT(sizeof(sd_can_record_t) == SD_RECORD_SIZE);
   // Read header from sector 0
   sd_error err = sdmmc_read_idma(idmabuf, SD_HEADER_SECTOR, 1U);
   if (err != sd_err_ok) {
@@ -152,20 +153,20 @@ void sd_replay_tick(void) {
     }
 
     if (rec->bus < PANDA_CAN_CNT) {
-      uint8_t dlc = rec->len;  // for standard CAN, len == DLC for 0-8
-      if (dlc > 8U) {
-        dlc = 8U;
+      uint8_t data_len = rec->len;
+      if (data_len > 8U) {
+        data_len = 8U;
       }
 
       CANPacket_t pkt = {0};
       pkt.fd       = 0U;
       pkt.bus      = rec->bus;
-      pkt.data_len_code = dlc;
+      pkt.data_len_code = data_len;
       pkt.returned = 0U;
       pkt.rejected = 0U;
       pkt.extended = (rec->addr >= 0x800U) ? 1U : 0U;
       pkt.addr     = rec->addr;
-      (void)memcpy(pkt.data, rec->data, dlc);
+      (void)memcpy(pkt.data, rec->data, data_len);
       can_set_checksum(&pkt);
       can_send(&pkt, pkt.bus, true);
     }

--- a/board/jungle/stm32h7/sd_replay.h
+++ b/board/jungle/stm32h7/sd_replay.h
@@ -1,0 +1,188 @@
+#pragma once
+
+// SD card CAN replay support for panda jungle v2.
+//
+// SD card binary format (raw sectors, no filesystem):
+//
+// Sector 0 — header (512 bytes):
+//   bytes  0-7:  magic "PNDREPLY"
+//   bytes  8-11: uint32_t num_records
+//   bytes 12-15: uint32_t record_size  (must equal sizeof(sd_can_record_t) = 20)
+//   bytes 16-19: uint32_t format_version  (= 1)
+//   remaining bytes: zero-padded
+//
+// Sectors 1+ — records (20 bytes each):
+//   struct sd_can_record_t (see below)
+//
+// Records must be sorted by mono_time_us ascending.
+// Use board/jungle/scripts/provision_sd.py to write this format.
+
+#define SD_REPLAY_MAGIC        "PNDREPLY"
+#define SD_REPLAY_MAGIC_LEN    8U
+#define SD_REPLAY_FORMAT_VER   1U
+#define SD_RECORD_SIZE         20U
+#define SD_HEADER_SECTOR       0U
+#define SD_DATA_START_SECTOR   1U
+
+// Number of sectors to read at once into idmabuf (idmabuf = 32 * 512 = 16384 bytes)
+#define SD_READ_SECTORS        32U
+#define SD_RECORDS_PER_BUF     (SD_READ_SECTORS * SDMMC_BLOCK_SIZE / SD_RECORD_SIZE)  // = 819
+
+typedef struct __attribute__((packed)) {
+  uint32_t mono_time_us;  // microseconds since replay start (relative, starts at 0)
+  uint32_t addr;          // CAN address
+  uint8_t  bus;           // CAN bus number (0-2)
+  uint8_t  len;           // data byte length (0-8)
+  uint8_t  data[8];       // CAN data payload (zero-padded if len < 8)
+  uint16_t pad;           // reserved, must be 0
+} sd_can_record_t;
+
+typedef struct __attribute__((packed)) {
+  uint8_t  magic[SD_REPLAY_MAGIC_LEN];
+  uint32_t num_records;
+  uint32_t record_size;
+  uint32_t format_version;
+} sd_replay_header_t;
+
+typedef enum {
+  SD_REPLAY_IDLE    = 0U,
+  SD_REPLAY_ACTIVE  = 1U,
+  SD_REPLAY_DONE    = 2U,
+  SD_REPLAY_ERROR   = 3U,
+} sd_replay_state_t;
+
+sd_replay_state_t sd_replay_state    = SD_REPLAY_IDLE;
+uint32_t sd_replay_total_records     = 0U;
+uint32_t sd_replay_current_record    = 0U;
+
+static uint32_t sd_replay_start_us   = 0U;
+static uint32_t sd_buf_record_idx    = 0U;   // index within current idmabuf
+static uint32_t sd_buf_record_count  = 0U;   // valid records in current idmabuf
+static uint32_t sd_next_sector       = 0U;   // next SD sector to read
+
+static bool sd_replay_fill_buffer(void) {
+  uint32_t sectors_remaining = (sd_replay_total_records * SD_RECORD_SIZE + SDMMC_BLOCK_SIZE - 1U) / SDMMC_BLOCK_SIZE
+                               - (sd_next_sector - SD_DATA_START_SECTOR);
+  if (sectors_remaining == 0U) {
+    sd_buf_record_count = 0U;
+    return false;
+  }
+  uint32_t sectors_to_read = MIN(SD_READ_SECTORS, sectors_remaining);
+  sd_error err = sdmmc_read_idma(idmabuf, sd_next_sector, sectors_to_read);
+  if (err != sd_err_ok) {
+    sd_replay_state = SD_REPLAY_ERROR;
+    return false;
+  }
+  sd_next_sector += sectors_to_read;
+
+  // how many complete records fit in the bytes we just read
+  uint32_t bytes_read = sectors_to_read * SDMMC_BLOCK_SIZE;
+  uint32_t records_in_buf = bytes_read / SD_RECORD_SIZE;
+  uint32_t records_left = sd_replay_total_records - sd_replay_current_record;
+  sd_buf_record_count = MIN(records_in_buf, records_left);
+  sd_buf_record_idx = 0U;
+  return true;
+}
+
+void sd_replay_init(void) {
+  // Read header from sector 0
+  sd_error err = sdmmc_read_idma(idmabuf, SD_HEADER_SECTOR, 1U);
+  if (err != sd_err_ok) {
+    return;
+  }
+
+  sd_replay_header_t hdr;
+  (void)memcpy(&hdr, idmabuf, sizeof(hdr));
+
+  if ((memcmp(hdr.magic, SD_REPLAY_MAGIC, SD_REPLAY_MAGIC_LEN) != 0) ||
+      (hdr.record_size != SD_RECORD_SIZE) ||
+      (hdr.format_version != SD_REPLAY_FORMAT_VER) ||
+      (hdr.num_records == 0U)) {
+    print("SD replay: no valid replay image found\n");
+    return;
+  }
+
+  sd_replay_total_records = hdr.num_records;
+  sd_replay_current_record = 0U;
+  sd_replay_state = SD_REPLAY_IDLE;
+  print("SD replay: found "); puth(sd_replay_total_records); print(" records\n");
+}
+
+void sd_replay_start(void) {
+  if (sd_replay_total_records == 0U) {
+    print("SD replay: no records loaded\n");
+    return;
+  }
+  sd_replay_current_record = 0U;
+  sd_buf_record_idx        = 0U;
+  sd_buf_record_count      = 0U;
+  sd_next_sector           = SD_DATA_START_SECTOR;
+  sd_replay_start_us       = microsecond_timer_get();
+  sd_replay_state          = SD_REPLAY_ACTIVE;
+  print("SD replay: started\n");
+}
+
+void sd_replay_stop(void) {
+  sd_replay_state = SD_REPLAY_IDLE;
+  print("SD replay: stopped\n");
+}
+
+// Call from main loop when sd_replay_state == SD_REPLAY_ACTIVE.
+void sd_replay_tick(void) {
+  // Refill buffer when empty
+  if (sd_buf_record_idx >= sd_buf_record_count) {
+    if (!sd_replay_fill_buffer()) {
+      if (sd_replay_state == SD_REPLAY_ACTIVE) {
+        sd_replay_state = SD_REPLAY_DONE;
+        print("SD replay: done\n");
+      }
+      return;
+    }
+  }
+
+  uint32_t now_us = microsecond_timer_get();
+  uint32_t elapsed_us = now_us - sd_replay_start_us;
+
+  // Send all records whose scheduled time has arrived
+  while (sd_buf_record_idx < sd_buf_record_count) {
+    sd_can_record_t *rec = (sd_can_record_t *)(idmabuf + (sd_buf_record_idx * SD_RECORD_SIZE));
+
+    if (elapsed_us < rec->mono_time_us) {
+      break;  // not yet time for this record
+    }
+
+    if (rec->bus < PANDA_CAN_CNT) {
+      uint8_t dlc = rec->len;  // for standard CAN, len == DLC for 0-8
+      if (dlc > 8U) {
+        dlc = 8U;
+      }
+
+      CANPacket_t pkt = {0};
+      pkt.fd       = 0U;
+      pkt.bus      = rec->bus;
+      pkt.data_len_code = dlc;
+      pkt.returned = 0U;
+      pkt.rejected = 0U;
+      pkt.extended = (rec->addr >= 0x800U) ? 1U : 0U;
+      pkt.addr     = rec->addr;
+      (void)memcpy(pkt.data, rec->data, dlc);
+      can_set_checksum(&pkt);
+      can_send(&pkt, pkt.bus, true);
+    }
+
+    sd_buf_record_idx++;
+    sd_replay_current_record++;
+
+    if (sd_replay_current_record >= sd_replay_total_records) {
+      sd_replay_state = SD_REPLAY_DONE;
+      print("SD replay: done\n");
+      return;
+    }
+
+    // Update elapsed time for next record comparison
+    now_us = microsecond_timer_get();
+    elapsed_us = now_us - sd_replay_start_us;
+  }
+
+  // When current buffer is exhausted, top it up on the next tick
+}

--- a/plan/issue-1981.md
+++ b/plan/issue-1981.md
@@ -1,0 +1,223 @@
+# Plan: Jungle V2 SD Card CAN Replay (Issue #1981)
+
+## Context
+
+The panda jungle v2 has an SD card slot that is currently unused. Developers who want to replay openpilot CAN routes must run a separate Python host script (`can_replay.py`) that streams messages over USB. The goal is to support fully autonomous replay from the SD card so the jungle can replay routes without a host PC, using openpilot route data written to the card in advance.
+
+The upstream `sdmmc_jungle` branch already has a working SDMMC driver (`llsdmmc.h`) with read/write and IDMA support. This plan ports that driver to the current branch and builds the replay system on top of it.
+
+---
+
+## Architecture
+
+```
+Python provisioning script  →  SD card (raw binary format)
+                                       ↓
+                           Jungle V2 firmware reads SD card
+                           in main loop, sends CAN at correct time
+```
+
+---
+
+## 1. SD Card Binary Format
+
+Raw sectors, no filesystem. Simple and easy to provision.
+
+**Sector 0 (header, 512 bytes):**
+```c
+struct __attribute__((packed)) sd_replay_header_t {
+  uint8_t  magic[8];      // "PNDREPLY"
+  uint32_t num_records;   // total number of CAN records
+  uint32_t record_size;   // must equal 20
+  uint32_t format_version; // = 1
+  // rest of sector is zero-padded
+};
+```
+
+**Sectors 1+ (records, 20 bytes each):**
+```c
+struct __attribute__((packed)) sd_can_record_t {
+  uint32_t mono_time_us;  // microseconds since replay start (relative)
+  uint32_t addr;          // CAN address (standard or extended)
+  uint8_t  bus;           // 0-2
+  uint8_t  len;           // data byte length (0-8)
+  uint8_t  data[8];       // CAN data (right-padded with zeros if len < 8)
+  uint16_t pad;           // alignment padding to 20 bytes
+};
+```
+
+Records are stored sorted by `mono_time_us` ascending. 20 bytes × records_per_buffer = 819 records per 16 KB IDMA buffer.
+
+---
+
+## 2. Firmware Changes
+
+### 2a. Port SDMMC driver
+
+**New file:** `board/jungle/stm32h7/llsdmmc.h`
+
+Copy from `upstream/sdmmc_jungle:board/jungle/stm32h7/llsdmmc.h`. This file provides:
+- `sdmmc_reset()` — card init/detect
+- `sdmmc_read_idma(buf, sector, count)` — fast DMA reads
+- `sdmmc_write_idma(buf, sector, count)` — fast DMA writes
+- `gpio_sdmmc_init()` — configure SDMMC GPIO pins
+
+**Modify:** `board/jungle/main.c`
+
+Add after other includes:
+```c
+#ifdef STM32H7
+  #include "board/jungle/stm32h7/llsdmmc.h"
+#endif
+```
+
+### 2b. SD replay state machine
+
+**New file:** `board/jungle/stm32h7/sd_replay.h`
+
+State machine integrated into the main loop:
+
+```c
+typedef enum {
+  SD_REPLAY_IDLE    = 0,
+  SD_REPLAY_ACTIVE  = 1,
+  SD_REPLAY_DONE    = 2,
+  SD_REPLAY_ERROR   = 3,
+} sd_replay_state_t;
+
+extern sd_replay_state_t sd_replay_state;
+extern uint32_t sd_replay_total_records;
+extern uint32_t sd_replay_current_record;
+
+void sd_replay_init(void);
+void sd_replay_start(void);
+void sd_replay_stop(void);
+void sd_replay_tick(void);   // called from main loop
+```
+
+**sd_replay_tick() logic:**
+1. If state != ACTIVE, return.
+2. If internal buffer is empty, read next 16KB chunk from SD card via `sdmmc_read_idma()` into `idmabuf`.
+3. Process records from buffer: for each record, check `(microsecond_timer_get() - replay_start_us) >= record.mono_time_us`.
+4. When timing matches, build a `CANPacket_t` from the record and call `can_send()`.
+5. Advance buffer pointer; request next SD read when buffer runs low.
+6. When `sd_replay_current_record >= sd_replay_total_records`, set state to `SD_REPLAY_DONE`.
+
+**Modify `board/jungle/main.c` — main loop:**
+
+Replace the `generated_can_traffic` block in the `for(cnt=0;;cnt++)` loop:
+
+```c
+if (sd_replay_state == SD_REPLAY_ACTIVE) {
+  sd_replay_tick();
+  continue;
+}
+```
+
+Add SD init after `can_init_all()`:
+```c
+#ifdef STM32H7
+  gpio_sdmmc_init();
+  if (sdmmc_reset() == sd_err_ok) {
+    sd_replay_init();
+  }
+#endif
+```
+
+### 2c. New USB control commands
+
+**Modify `board/jungle/main_comms.h`** — add to `comms_control_handler()`:
+
+```c
+// **** 0xa5: SD replay control (param1: 0=stop, 1=start)
+case 0xa5:
+  if (req->param1 == 1U) {
+    sd_replay_start();
+  } else {
+    sd_replay_stop();
+  }
+  break;
+
+// **** 0xa6: Get SD replay status
+case 0xa6: {
+  struct {
+    uint8_t  state;         // sd_replay_state_t
+    uint32_t total_records;
+    uint32_t current_record;
+  } __attribute__((packed)) status;
+  status.state = (uint8_t)sd_replay_state;
+  status.total_records = sd_replay_total_records;
+  status.current_record = sd_replay_current_record;
+  memcpy(resp, &status, sizeof(status));
+  resp_len = sizeof(status);
+  break;
+}
+```
+
+---
+
+## 3. Python Library Changes
+
+**Modify `board/jungle/__init__.py`** — add methods to `PandaJungle`:
+
+```python
+def sd_replay_start(self):
+    self._handle.controlWrite(PandaJungle.REQUEST_OUT, 0xa5, 1, 0, b'')
+
+def sd_replay_stop(self):
+    self._handle.controlWrite(PandaJungle.REQUEST_OUT, 0xa5, 0, 0, b'')
+
+def sd_replay_status(self):
+    dat = self._handle.controlRead(PandaJungle.REQUEST_IN, 0xa6, 0, 0, 9)
+    state, total, current = struct.unpack("<BII", dat)
+    return {"state": state, "total_records": total, "current_record": current}
+```
+
+---
+
+## 4. Provisioning Script
+
+**New file:** `board/jungle/scripts/provision_sd.py`
+
+```
+Usage:
+  provision_sd.py <rlog_or_qlog> <sd_device_or_output_file>
+
+Examples:
+  provision_sd.py /data/media/0/realdata/abc123--0/0/rlog /dev/sdb
+  provision_sd.py route.rlog replay.bin
+```
+
+**Implementation steps:**
+1. Parse CAN messages from openpilot rlog using `cereal`/`openpilot.tools.lib.logreader.LogReader`
+2. Extract `(mono_time_us, addr, bus, data)` tuples from `sendcan` events
+3. Normalize timestamps to start at 0 (subtract first message time)
+4. Write header to sector 0 (512 bytes)
+5. Write records in 20-byte structs starting at sector 1
+6. Write to block device directly (`open(dev, 'wb')`) or to a binary file
+
+The script should print a summary: total records written, time span, estimated replay duration.
+
+---
+
+## Critical Files
+
+| File | Action |
+|------|--------|
+| `board/jungle/stm32h7/llsdmmc.h` | **Create** — copy from `upstream/sdmmc_jungle` |
+| `board/jungle/stm32h7/sd_replay.h` | **Create** — new replay state machine |
+| `board/jungle/main.c` | **Modify** — add SD init + replay tick in main loop |
+| `board/jungle/main_comms.h` | **Modify** — add 0xa5/0xa6 USB commands |
+| `board/jungle/__init__.py` | **Modify** — add Python API methods |
+| `board/jungle/scripts/provision_sd.py` | **Create** — provisioning script |
+
+---
+
+## Verification
+
+1. **Build firmware**: `scons board=jungle` — verify compiles without errors
+2. **Flash & basic SD test**: insert SD card, check serial debug output for "SDMMC init done"
+3. **Provision SD card**: `python provision_sd.py <rlog> /dev/sdX` → verify header + records written
+4. **Replay test**: Start replay via Python, verify CAN messages appear on a panda CAN sniffer
+5. **Timing test**: Measure timestamps of received CAN messages, verify relative timing matches original rlog within acceptable tolerance (±5ms)
+6. **Status polling**: Call `sd_replay_status()` during replay, verify current_record increments and reaches total_records at completion

--- a/tests/hitl/test_jungle_sd.py
+++ b/tests/hitl/test_jungle_sd.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+HITL tests for jungle v2 SD card CAN replay USB commands (0xa5, 0xa6).
+
+Requires a physical panda jungle v2. Skipped automatically when NO_JUNGLE=1
+or when the jungle fixture is unavailable (see conftest.py).
+"""
+import struct
+import unittest
+
+import pytest
+
+from panda import PandaJungle
+
+SD_REPLAY_IDLE   = 0
+SD_REPLAY_ACTIVE = 1
+SD_REPLAY_DONE   = 2
+SD_REPLAY_ERROR  = 3
+
+
+class TestJungleSDReplay(unittest.TestCase):
+  @pytest.fixture(autouse=True)
+  def _attach_jungle(self, panda_jungle):
+    self.jungle = panda_jungle
+
+  # ------------------------------------------------------------------
+  # 0xa6: status command
+  # ------------------------------------------------------------------
+
+  def test_sd_status_returns_dict(self):
+    status = self.jungle.sd_replay_status()
+    self.assertIn("state", status)
+    self.assertIn("total_records", status)
+    self.assertIn("current_record", status)
+
+  def test_sd_status_state_in_range(self):
+    status = self.jungle.sd_replay_status()
+    self.assertIn(status["state"], (SD_REPLAY_IDLE, SD_REPLAY_ACTIVE, SD_REPLAY_DONE, SD_REPLAY_ERROR))
+
+  def test_sd_status_raw_packet_size(self):
+    """Raw 0xa6 response must be exactly 9 bytes parseable as <BII."""
+    dat = self.jungle._handle.controlRead(PandaJungle.REQUEST_IN, 0xa6, 0, 0, 9)
+    self.assertEqual(len(dat), 9)
+    state, total, current = struct.unpack("<BII", dat)
+    self.assertIn(state, (SD_REPLAY_IDLE, SD_REPLAY_ACTIVE, SD_REPLAY_DONE, SD_REPLAY_ERROR))
+    self.assertGreaterEqual(total, 0)
+    self.assertGreaterEqual(current, 0)
+
+  def test_sd_status_no_valid_image(self):
+    """Without a provisioned SD image, firmware should stay IDLE with 0 records."""
+    status = self.jungle.sd_replay_status()
+    # If no SD card or no valid image was written, sd_replay_init() leaves
+    # total_records == 0 and state == IDLE.
+    if status["total_records"] == 0:
+      self.assertEqual(status["state"], SD_REPLAY_IDLE)
+    # If a card IS present with a valid image, total_records > 0 is fine —
+    # we just verify it's not claiming to be mid-replay without being started.
+    else:
+      self.assertNotEqual(status["state"], SD_REPLAY_ACTIVE)
+
+  # ------------------------------------------------------------------
+  # 0xa5: start / stop commands
+  # ------------------------------------------------------------------
+
+  def test_sd_stop_is_idempotent(self):
+    """Calling stop twice must not corrupt state."""
+    self.jungle.sd_replay_stop()
+    self.jungle.sd_replay_stop()
+    status = self.jungle.sd_replay_status()
+    self.assertEqual(status["state"], SD_REPLAY_IDLE)
+
+  def test_sd_start_without_image_does_not_hang_active(self):
+    """Start with no valid image must not leave state stuck as ACTIVE."""
+    status_before = self.jungle.sd_replay_status()
+    if status_before["total_records"] != 0:
+      pytest.skip("SD card has a valid image; skipping no-image start test")
+
+    self.jungle.sd_replay_start()
+    status = self.jungle.sd_replay_status()
+    # sd_replay_start() checks total_records before activating;
+    # with 0 records it should stay IDLE.
+    self.assertNotEqual(status["state"], SD_REPLAY_ACTIVE)
+
+    # Leave clean
+    self.jungle.sd_replay_stop()
+
+  def test_sd_stop_after_start(self):
+    """Start then immediately stop should return to IDLE."""
+    status_before = self.jungle.sd_replay_status()
+    if status_before["total_records"] == 0:
+      pytest.skip("No valid SD image; start would be a no-op")
+
+    self.jungle.sd_replay_start()
+    self.jungle.sd_replay_stop()
+    status = self.jungle.sd_replay_status()
+    self.assertEqual(status["state"], SD_REPLAY_IDLE)
+
+  def test_sd_current_record_resets_on_start(self):
+    """current_record must reset to 0 each time replay is started."""
+    status_before = self.jungle.sd_replay_status()
+    if status_before["total_records"] == 0:
+      pytest.skip("No valid SD image loaded")
+
+    self.jungle.sd_replay_start()
+    status = self.jungle.sd_replay_status()
+    self.assertEqual(status["current_record"], 0)
+
+    self.jungle.sd_replay_stop()
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/hitl/test_jungle_sd.py
+++ b/tests/hitl/test_jungle_sd.py
@@ -6,7 +6,6 @@ Requires a physical panda jungle v2. Skipped automatically when NO_JUNGLE=1
 or when the jungle fixture is unavailable (see conftest.py).
 """
 import struct
-import unittest
 
 import pytest
 
@@ -18,95 +17,91 @@ SD_REPLAY_DONE   = 2
 SD_REPLAY_ERROR  = 3
 
 
-class TestJungleSDReplay(unittest.TestCase):
-  @pytest.fixture(autouse=True)
-  def _attach_jungle(self, panda_jungle):
-    self.jungle = panda_jungle
+# ------------------------------------------------------------------
+# 0xa6: status command
+# ------------------------------------------------------------------
 
-  # ------------------------------------------------------------------
-  # 0xa6: status command
-  # ------------------------------------------------------------------
+def test_sd_status_returns_dict(panda_jungle):
+  status = panda_jungle.sd_replay_status()
+  assert "state" in status
+  assert "total_records" in status
+  assert "current_record" in status
 
-  def test_sd_status_returns_dict(self):
-    status = self.jungle.sd_replay_status()
-    self.assertIn("state", status)
-    self.assertIn("total_records", status)
-    self.assertIn("current_record", status)
+def test_sd_status_state_in_range(panda_jungle):
+  status = panda_jungle.sd_replay_status()
+  assert status["state"] in (SD_REPLAY_IDLE, SD_REPLAY_ACTIVE, SD_REPLAY_DONE, SD_REPLAY_ERROR)
 
-  def test_sd_status_state_in_range(self):
-    status = self.jungle.sd_replay_status()
-    self.assertIn(status["state"], (SD_REPLAY_IDLE, SD_REPLAY_ACTIVE, SD_REPLAY_DONE, SD_REPLAY_ERROR))
+def test_sd_status_raw_packet_size(panda_jungle):
+  """Raw 0xa6 response must be exactly 9 bytes parseable as <BII."""
+  dat = panda_jungle._handle.controlRead(PandaJungle.REQUEST_IN, 0xa6, 0, 0, 9)
+  assert len(dat) == 9
+  state, total, current = struct.unpack("<BII", dat)
+  assert state in (SD_REPLAY_IDLE, SD_REPLAY_ACTIVE, SD_REPLAY_DONE, SD_REPLAY_ERROR)
+  assert total >= 0
+  assert current >= 0
 
-  def test_sd_status_raw_packet_size(self):
-    """Raw 0xa6 response must be exactly 9 bytes parseable as <BII."""
-    dat = self.jungle._handle.controlRead(PandaJungle.REQUEST_IN, 0xa6, 0, 0, 9)
-    self.assertEqual(len(dat), 9)
-    state, total, current = struct.unpack("<BII", dat)
-    self.assertIn(state, (SD_REPLAY_IDLE, SD_REPLAY_ACTIVE, SD_REPLAY_DONE, SD_REPLAY_ERROR))
-    self.assertGreaterEqual(total, 0)
-    self.assertGreaterEqual(current, 0)
+def test_sd_status_no_valid_image(panda_jungle):
+  """Without a provisioned SD image, firmware should stay IDLE with 0 records."""
+  status = panda_jungle.sd_replay_status()
+  # If no SD card or no valid image was written, sd_replay_init() leaves
+  # total_records == 0 and state == IDLE.
+  if status["total_records"] == 0:
+    assert status["state"] == SD_REPLAY_IDLE
+  # If a card IS present with a valid image, total_records > 0 is fine —
+  # we just verify it's not claiming to be mid-replay without being started.
+  else:
+    assert status["state"] != SD_REPLAY_ACTIVE
 
-  def test_sd_status_no_valid_image(self):
-    """Without a provisioned SD image, firmware should stay IDLE with 0 records."""
-    status = self.jungle.sd_replay_status()
-    # If no SD card or no valid image was written, sd_replay_init() leaves
-    # total_records == 0 and state == IDLE.
-    if status["total_records"] == 0:
-      self.assertEqual(status["state"], SD_REPLAY_IDLE)
-    # If a card IS present with a valid image, total_records > 0 is fine —
-    # we just verify it's not claiming to be mid-replay without being started.
-    else:
-      self.assertNotEqual(status["state"], SD_REPLAY_ACTIVE)
 
-  # ------------------------------------------------------------------
-  # 0xa5: start / stop commands
-  # ------------------------------------------------------------------
+# ------------------------------------------------------------------
+# 0xa5: start / stop commands
+# ------------------------------------------------------------------
 
-  def test_sd_stop_is_idempotent(self):
-    """Calling stop twice must not corrupt state."""
-    self.jungle.sd_replay_stop()
-    self.jungle.sd_replay_stop()
-    status = self.jungle.sd_replay_status()
-    self.assertEqual(status["state"], SD_REPLAY_IDLE)
+def test_sd_stop_is_idempotent(panda_jungle):
+  """Calling stop twice must not corrupt state."""
+  panda_jungle.sd_replay_stop()
+  panda_jungle.sd_replay_stop()
+  status = panda_jungle.sd_replay_status()
+  assert status["state"] == SD_REPLAY_IDLE
 
-  def test_sd_start_without_image_does_not_hang_active(self):
-    """Start with no valid image must not leave state stuck as ACTIVE."""
-    status_before = self.jungle.sd_replay_status()
-    if status_before["total_records"] != 0:
-      pytest.skip("SD card has a valid image; skipping no-image start test")
+def test_sd_start_without_image_does_not_hang_active(panda_jungle):
+  """Start with no valid image must not leave state stuck as ACTIVE."""
+  status_before = panda_jungle.sd_replay_status()
+  if status_before["total_records"] != 0:
+    pytest.skip("SD card has a valid image; skipping no-image start test")
 
-    self.jungle.sd_replay_start()
-    status = self.jungle.sd_replay_status()
-    # sd_replay_start() checks total_records before activating;
-    # with 0 records it should stay IDLE.
-    self.assertNotEqual(status["state"], SD_REPLAY_ACTIVE)
+  panda_jungle.sd_replay_start()
+  status = panda_jungle.sd_replay_status()
+  # sd_replay_start() checks total_records before activating;
+  # with 0 records it should stay IDLE.
+  assert status["state"] != SD_REPLAY_ACTIVE
 
-    # Leave clean
-    self.jungle.sd_replay_stop()
+  # Leave clean
+  panda_jungle.sd_replay_stop()
 
-  def test_sd_stop_after_start(self):
-    """Start then immediately stop should return to IDLE."""
-    status_before = self.jungle.sd_replay_status()
-    if status_before["total_records"] == 0:
-      pytest.skip("No valid SD image; start would be a no-op")
+def test_sd_stop_after_start(panda_jungle):
+  """Start then immediately stop should return to IDLE."""
+  status_before = panda_jungle.sd_replay_status()
+  if status_before["total_records"] == 0:
+    pytest.skip("No valid SD image; start would be a no-op")
 
-    self.jungle.sd_replay_start()
-    self.jungle.sd_replay_stop()
-    status = self.jungle.sd_replay_status()
-    self.assertEqual(status["state"], SD_REPLAY_IDLE)
+  panda_jungle.sd_replay_start()
+  panda_jungle.sd_replay_stop()
+  status = panda_jungle.sd_replay_status()
+  assert status["state"] == SD_REPLAY_IDLE
 
-  def test_sd_current_record_resets_on_start(self):
-    """current_record must reset to 0 each time replay is started."""
-    status_before = self.jungle.sd_replay_status()
-    if status_before["total_records"] == 0:
-      pytest.skip("No valid SD image loaded")
+def test_sd_current_record_resets_on_start(panda_jungle):
+  """current_record must reset to 0 each time replay is started."""
+  status_before = panda_jungle.sd_replay_status()
+  if status_before["total_records"] == 0:
+    pytest.skip("No valid SD image loaded")
 
-    self.jungle.sd_replay_start()
-    status = self.jungle.sd_replay_status()
-    self.assertEqual(status["current_record"], 0)
+  panda_jungle.sd_replay_start()
+  status = panda_jungle.sd_replay_status()
+  assert status["current_record"] == 0
 
-    self.jungle.sd_replay_stop()
+  panda_jungle.sd_replay_stop()
 
 
 if __name__ == "__main__":
-  unittest.main()
+  pytest.main([__file__, "-v"])

--- a/tests/usbprotocol/test_sd_provision.py
+++ b/tests/usbprotocol/test_sd_provision.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import importlib.util
+import pathlib
+import struct
+import tempfile
+import unittest
+
+# provision_sd.py is a standalone script, not part of a package — load by path.
+_script = pathlib.Path(__file__).parents[2] / "board/jungle/scripts/provision_sd.py"
+_spec = importlib.util.spec_from_file_location("provision_sd", _script)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+build_header  = _mod.build_header
+build_records = _mod.build_records
+write_image   = _mod.write_image
+HEADER_FMT    = _mod.HEADER_FMT
+MAGIC         = _mod.MAGIC
+FORMAT_VERSION = _mod.FORMAT_VERSION
+RECORD_FMT    = _mod.RECORD_FMT
+RECORD_SIZE   = _mod.RECORD_SIZE
+SECTOR_SIZE   = _mod.SECTOR_SIZE
+
+# One nanosecond in microseconds
+_US = 1000
+
+
+def _make_messages(n, t0_ns=0, step_ns=1_000_000):
+  """Generate n synthetic (mono_time_ns, addr, bus, data) messages."""
+  return [(t0_ns + i * step_ns, 0x100 + i, i % 3, bytes([i % 256] * 8)) for i in range(n)]
+
+
+def _unpack_record(raw):
+  """Return (mono_time_us, addr, bus, data_len, data, pad) from 20-byte record."""
+  return struct.unpack(RECORD_FMT, raw)
+
+
+class TestSDHeader(unittest.TestCase):
+  def test_magic(self):
+    header = build_header(10)
+    self.assertEqual(header[:8], MAGIC)
+
+  def test_record_count(self):
+    for n in (0, 1, 100, 65535):
+      header = build_header(n)
+      _, num_records, _, _ = struct.unpack(HEADER_FMT, header[:struct.calcsize(HEADER_FMT)])
+      self.assertEqual(num_records, n)
+
+  def test_record_size_field(self):
+    header = build_header(1)
+    _, _, record_size, _ = struct.unpack(HEADER_FMT, header[:struct.calcsize(HEADER_FMT)])
+    self.assertEqual(record_size, RECORD_SIZE)
+
+  def test_format_version(self):
+    header = build_header(1)
+    _, _, _, fmt_ver = struct.unpack(HEADER_FMT, header[:struct.calcsize(HEADER_FMT)])
+    self.assertEqual(fmt_ver, FORMAT_VERSION)
+
+  def test_sector_padding(self):
+    for n in (0, 1, 999):
+      self.assertEqual(len(build_header(n)), SECTOR_SIZE)
+
+  def test_tail_is_zero(self):
+    header = build_header(5)
+    self.assertEqual(header[struct.calcsize(HEADER_FMT):], b'\x00' * (SECTOR_SIZE - struct.calcsize(HEADER_FMT)))
+
+
+class TestSDRecord(unittest.TestCase):
+  def test_record_size(self):
+    msgs = _make_messages(10)
+    raw = build_records(msgs)
+    self.assertEqual(len(raw) % RECORD_SIZE, 0)
+    self.assertEqual(len(raw) // RECORD_SIZE, len(msgs))
+
+  def test_timestamp_first_is_zero(self):
+    msgs = _make_messages(5, t0_ns=5_000_000_000)
+    raw = build_records(msgs)
+    mono_time_us = _unpack_record(raw[:RECORD_SIZE])[0]
+    self.assertEqual(mono_time_us, 0)
+
+  def test_timestamp_relative_conversion(self):
+    # 1 ms apart in nanoseconds → 1000 µs apart
+    msgs = _make_messages(3, t0_ns=0, step_ns=1_000_000)
+    raw = build_records(msgs)
+    times = [_unpack_record(raw[i * RECORD_SIZE:(i + 1) * RECORD_SIZE])[0] for i in range(3)]
+    self.assertEqual(times, [0, 1000, 2000])
+
+  def test_timestamp_overflow_clamp(self):
+    # Just beyond uint32 max (in nanoseconds from t0)
+    overflow_ns = (0xFFFFFFFF + 1) * _US  # 1 µs past max
+    msgs = [(0, 0x100, 0, b'\x00' * 8), (overflow_ns, 0x200, 0, b'\x00' * 8)]
+    raw = build_records(msgs)
+    clamped = _unpack_record(raw[RECORD_SIZE:])[0]
+    self.assertEqual(clamped, 0xFFFFFFFF)
+
+  def test_data_padding_short(self):
+    msgs = [(0, 0x100, 0, b'\xAB\xCD')]  # 2 bytes
+    raw = build_records(msgs)
+    _, _, _, data_len, data, _ = _unpack_record(raw)
+    self.assertEqual(data_len, 2)
+    self.assertEqual(data, b'\xAB\xCD\x00\x00\x00\x00\x00\x00')
+
+  def test_data_truncation_long(self):
+    msgs = [(0, 0x100, 0, b'\xAA' * 12)]  # 12 bytes, must truncate to 8
+    raw = build_records(msgs)
+    _, _, _, data_len, data, _ = _unpack_record(raw)
+    self.assertEqual(data_len, 8)
+    self.assertEqual(data, b'\xAA' * 8)
+
+  def test_bus_mask(self):
+    msgs = [(0, 0x100, 256, b'\x00' * 8)]  # bus=256 overflows uint8
+    raw = build_records(msgs)
+    _, _, bus, _, _, _ = _unpack_record(raw)
+    self.assertEqual(bus, 0)  # 256 & 0xFF == 0
+
+  def test_pad_field_zero(self):
+    msgs = _make_messages(5)
+    raw = build_records(msgs)
+    for i in range(5):
+      pad = _unpack_record(raw[i * RECORD_SIZE:(i + 1) * RECORD_SIZE])[5]
+      self.assertEqual(pad, 0)
+
+  def test_addr_preserved(self):
+    msgs = [(0, 0x1FFFFFFF, 0, b'\x00' * 8)]  # max 29-bit address
+    raw = build_records(msgs)
+    _, addr, _, _, _, _ = _unpack_record(raw)
+    self.assertEqual(addr, 0x1FFFFFFF)
+
+
+class TestSDImage(unittest.TestCase):
+  def _write_tmp(self, msgs):
+    records = build_records(msgs)
+    header = build_header(len(msgs))
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+      write_image(f.name, header, records)
+      return f.name
+
+  def test_output_sector_aligned(self):
+    import os
+    for n in (1, 25, 819, 820):  # straddles sector boundary
+      path = self._write_tmp(_make_messages(n))
+      self.assertEqual(os.path.getsize(path) % SECTOR_SIZE, 0, f"n={n} not sector-aligned")
+
+  def test_header_at_sector_0(self):
+    path = self._write_tmp(_make_messages(3))
+    with open(path, 'rb') as f:
+      sector0 = f.read(SECTOR_SIZE)
+    self.assertEqual(sector0[:8], MAGIC)
+
+  def test_records_start_at_sector_1(self):
+    msgs = _make_messages(1)
+    path = self._write_tmp(msgs)
+    with open(path, 'rb') as f:
+      f.seek(SECTOR_SIZE)
+      raw_record = f.read(RECORD_SIZE)
+    mono_time_us, addr, bus, _, _, _ = _unpack_record(raw_record)
+    self.assertEqual(mono_time_us, 0)
+    self.assertEqual(addr, msgs[0][1])
+    self.assertEqual(bus, msgs[0][2])
+
+  def test_round_trip(self):
+    msgs = _make_messages(50)
+    records_raw = build_records(msgs)
+    t0_ns = msgs[0][0]
+    for i, (mono_time_ns, addr, bus, data) in enumerate(msgs):
+      record = records_raw[i * RECORD_SIZE:(i + 1) * RECORD_SIZE]
+      r_time, r_addr, r_bus, r_len, r_data, r_pad = _unpack_record(record)
+      expected_us = (mono_time_ns - t0_ns) // _US
+      self.assertEqual(r_time, expected_us)
+      self.assertEqual(r_addr, addr)
+      self.assertEqual(r_bus, bus)
+      self.assertEqual(r_len, len(data))
+      self.assertEqual(r_data, data)
+      self.assertEqual(r_pad, 0)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/usbprotocol/test_sd_provision.py
+++ b/tests/usbprotocol/test_sd_provision.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import os
 import pathlib
 import struct
 import tempfile
@@ -139,7 +140,6 @@ class TestSDRecord(unittest.TestCase):
 
 class TestSDImage(unittest.TestCase):
   def _write_tmp(self, msgs):
-    import os
     records = build_records(msgs)
     header = build_header(len(msgs))
     with tempfile.NamedTemporaryFile(delete=False) as f:

--- a/tests/usbprotocol/test_sd_provision.py
+++ b/tests/usbprotocol/test_sd_provision.py
@@ -21,7 +21,7 @@ RECORD_FMT    = _mod.RECORD_FMT
 RECORD_SIZE   = _mod.RECORD_SIZE
 SECTOR_SIZE   = _mod.SECTOR_SIZE
 
-# One nanosecond in microseconds
+# nanoseconds per microsecond
 _US = 1000
 
 
@@ -120,6 +120,16 @@ class TestSDRecord(unittest.TestCase):
       pad = _unpack_record(raw[i * RECORD_SIZE:(i + 1) * RECORD_SIZE])[5]
       self.assertEqual(pad, 0)
 
+  def test_sort_order(self):
+    # Reverse-order input must produce ascending timestamps in output
+    msgs = [(2_000_000, 0x100, 0, b'\x00' * 8),
+            (1_000_000, 0x101, 0, b'\x00' * 8),
+            (0,         0x102, 0, b'\x00' * 8)]
+    raw = build_records(msgs)
+    times = [_unpack_record(raw[i * RECORD_SIZE:(i + 1) * RECORD_SIZE])[0] for i in range(3)]
+    self.assertEqual(times, sorted(times))
+    self.assertEqual(times[0], 0)
+
   def test_addr_preserved(self):
     msgs = [(0, 0x1FFFFFFF, 0, b'\x00' * 8)]  # max 29-bit address
     raw = build_records(msgs)
@@ -129,11 +139,14 @@ class TestSDRecord(unittest.TestCase):
 
 class TestSDImage(unittest.TestCase):
   def _write_tmp(self, msgs):
+    import os
     records = build_records(msgs)
     header = build_header(len(msgs))
     with tempfile.NamedTemporaryFile(delete=False) as f:
-      write_image(f.name, header, records)
-      return f.name
+      path = f.name
+    write_image(path, header, records)
+    self.addCleanup(os.unlink, path)
+    return path
 
   def test_output_sector_aligned(self):
     import os


### PR DESCRIPTION
This PR adds support for replaying can messages from SD card.
All tests passed, except hardware since I do not have jungle v2. I also did initial code review before submitting PR.

Please review and let me know if any changes or improvements are required. I can also split this into smaller and more readable PR-s if needed.
I would also like to lock the bounty for issue 1981