### PR TITLE
make can hook v2 specific

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -202,8 +202,8 @@ void ignition_can_hook(CANPacket_t *msg) {
     }
   }
 
-  // body exception
-  if (((msg->bus == 0U) || (msg->bus == 2U)) && (msg->addr == 0x201U)) {
+  // body v2 exception
+  if (((msg->bus == 0U) || (msg->bus == 2U)) && (msg->addr == 0x222U)) {
     ignition_can = true;
     ignition_can_cnt = 0U;
   }


### PR DESCRIPTION
make can ignition hook v2 specific

having this increases the time it takes for v1 ignition shut off time