### PR TITLE
bootkick: wake on CAN

### DIFF
--- a/board/drivers/bootkick.h
+++ b/board/drivers/bootkick.h
@@ -2,18 +2,18 @@
 
 bool bootkick_reset_triggered = false;
 
-void bootkick_tick(bool ignition, bool recent_heartbeat) {
+void bootkick_tick(bool wake_up, bool recent_heartbeat) {
   static uint16_t bootkick_last_serial_ptr = 0;
   static uint8_t waiting_to_boot_countdown = 0;
   static uint8_t boot_reset_countdown = 0;
   static uint8_t bootkick_harness_status_prev = HARNESS_STATUS_NC;
-  static bool bootkick_ign_prev = false;
+  static bool bootkick_wake_up_prev = false;
   static BootState boot_state = BOOT_BOOTKICK;
   BootState boot_state_prev = boot_state;
   const bool harness_inserted = (harness.status != bootkick_harness_status_prev) && (harness.status != HARNESS_STATUS_NC);
 
-  if ((ignition && !bootkick_ign_prev) || harness_inserted) {
-    // bootkick on rising edge of ignition or harness insertion
+  if ((wake_up && !bootkick_wake_up_prev) || harness_inserted) {
+    // bootkick on rising edge of wake-up or harness insertion
     boot_state = BOOT_BOOTKICK;
   } else if (recent_heartbeat) {
     // disable bootkick once openpilot is up
@@ -55,7 +55,7 @@ void bootkick_tick(bool ignition, bool recent_heartbeat) {
   }
 
   // update state
-  bootkick_ign_prev = ignition;
+  bootkick_wake_up_prev = wake_up;
   bootkick_harness_status_prev = harness.status;
   bootkick_last_serial_ptr = uart_ring_som_debug.w_ptr_tx;
   if (waiting_to_boot_countdown > 0U) {

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -191,6 +191,8 @@ void ignition_can_hook(CANPacket_t *msg) {
       if ((counter == ((prev_counter_tesla + 1) % 16)) && (prev_counter_tesla != -1)) {
         // VCFRONT_LVPowerState->VCFRONT_vehiclePowerState
         int power_state = (msg->data[0] >> 5U) & 0x3U;
+        wake_on_can = power_state != 0x0;   // VEHICLE_POWER_STATE_OFF=0
+        wake_on_can_cnt = 0U;
         ignition_can = power_state == 0x3;  // VEHICLE_POWER_STATE_DRIVE=3
         ignition_can_cnt = 0U;
       }

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -7,7 +7,9 @@ uint32_t rx_buffer_overflow = 0;
 
 can_health_t can_health[PANDA_CAN_CNT] = {{0}, {0}, {0}};
 
-// Ignition detected from CAN meessages
+// Wake-up and ignition detected from CAN messages
+bool wake_on_can = false;
+uint32_t wake_on_can_cnt = 0U;
 bool ignition_can = false;
 uint32_t ignition_can_cnt = 0U;
 

--- a/board/drivers/drivers.h
+++ b/board/drivers/drivers.h
@@ -11,7 +11,7 @@
 
 extern bool bootkick_reset_triggered;
 
-void bootkick_tick(bool ignition, bool recent_heartbeat);
+void bootkick_tick(bool wake_up, bool recent_heartbeat);
 
 // ******************** can_common ********************
 
@@ -41,7 +41,9 @@ extern uint32_t rx_buffer_overflow;
 
 extern can_health_t can_health[PANDA_CAN_CNT];
 
-// Ignition detected from CAN meessages
+// Wake-up and ignition detected from CAN messages
+extern bool wake_on_can;
+extern uint32_t wake_on_can_cnt;
 extern bool ignition_can;
 extern uint32_t ignition_can_cnt;
 

--- a/board/main.c
+++ b/board/main.c
@@ -173,7 +173,8 @@ static void tick_handler(void) {
 
       // tick drivers at 1Hz
       bool started = harness_check_ignition() || ignition_can;
-      bootkick_tick(started, recent_heartbeat);
+      bool wake_up = started || wake_on_can;
+      bootkick_tick(wake_up, recent_heartbeat);
 
       // increase heartbeat counter and cap it at the uint32 limit
       if (heartbeat_counter < UINT32_MAX) {
@@ -251,11 +252,15 @@ static void tick_handler(void) {
       if (ignition_can_cnt > 2U) {
         ignition_can = false;
       }
+      if (wake_on_can_cnt > 2U) {
+        wake_on_can = false;
+      }
 
       // on to the next one
       uptime_cnt += 1U;
       safety_mode_cnt += 1U;
       ignition_can_cnt += 1U;
+      wake_on_can_cnt += 1U;
 
       // synchronous safety check
       safety_tick(&current_safety_config);


### PR DESCRIPTION
Separates SOM waking up from ignition (going on-road) logic. Optional, but lets the device start booting early. 

For now this is only wired for Tesla. The comma device will wake the moment a door is opened or the car is woken up remotely (e.g. with _Keep Accessory Power On_).

SOM shutdown is still controlled by openpilot - if ignition was not seen the device will turn off after [1hr](https://github.com/commaai/openpilot/blob/d1e069210fc38a2c0752f04bed05074eaf3704ff/system/hardware/power_monitoring.py#L125) - waiting for the driver to start driving.
If the car sits in accessory mode for long time (>1hr), the the ignition signal or car restart will be needed to boot again.