### PR TITLE
Include firmware artifacts in pandacan package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include board/obj *.bin *.bin.signed version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
+include-package-data = false
 packages = [
   "panda",
   "panda.python",
@@ -50,7 +51,12 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"panda.board" = ["health.h"]
+"panda.board" = [
+  "health.h",
+  "obj/*.bin",
+  "obj/*.bin.signed",
+  "obj/version",
+]
 "panda.board.jungle" = ["jungle_health.h"]
 
 [tool.setuptools.package-dir]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,18 @@
+import tomllib
+from pathlib import Path
+
+
+def test_firmware_artifacts_are_packaged():
+  pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+  package_data = pyproject["tool"]["setuptools"]["package-data"]
+
+  board_data = package_data["panda.board"]
+  assert "obj/*.bin" in board_data
+  assert "obj/*.bin.signed" in board_data
+  assert "obj/version" in board_data
+
+
+def test_firmware_artifacts_are_in_sdist_manifest():
+  manifest = Path("MANIFEST.in").read_text()
+
+  assert "recursive-include board/obj *.bin *.bin.signed version" in manifest


### PR DESCRIPTION
Fixes commaai/panda#2239

This includes the firmware artifacts under board/obj in both wheel package data and sdist manifests, so the pip package can include the runtime files used by Panda flashing/recovery code.

Validation:
- Built wheel locally with pip wheel
- Verified board/obj firmware paths are included in the wheel when firmware artifacts exist
- Added packaging regression tests