### PR TITLE
Include firmware in pandacan package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pandacan"
-version = "0.0.10"
+version = "0.0.11"
 description = "Code powering the comma.ai panda"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"  # macOS doesn't work with 3.13 due to pycapnp from opendbc
@@ -15,9 +15,7 @@ dependencies = [
   "libusb1",
   "libusb-package",
   "opendbc @ git+https://github.com/commaai/opendbc.git@master#egg=opendbc",
-
-  # runtime dependency on comma four
-  #"spidev; platform_system == 'Linux'",
+  "spidev; platform_system == 'Linux'",
 ]
 
 [project.optional-dependencies]
@@ -50,8 +48,13 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"panda.board" = ["health.h"]
-"panda.board.jungle" = ["jungle_health.h"]
+"panda" = [
+  "board/health.h",
+  "board/jungle/jungle_health.h",
+  "board/obj/*.bin.signed",
+  "board/obj/bootstub.*.bin",
+  "board/obj/version",
+]
 
 [tool.setuptools.package-dir]
 panda = "."

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -29,7 +29,7 @@ except ImportError:
   # TODO: remove this on next AGNOS update
   pass
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'
 
 CANPACKET_HEAD_SIZE = 0x6
 DLC_TO_LEN = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]


### PR DESCRIPTION
pandacan currently installs the Python API and packet headers, but the wheel does not carry the generated firmware artifacts needed for flashing/recovering panda, jungle, and body devices.

This updates the package data so prepared wheel builds include signed apps, bootstubs, the firmware version file, and packet-version headers. It also promotes the Linux SPI transport dependency to a runtime dependency so downstream users such as openpilot can depend on pandacan directly.

Validation:
- `.venv/bin/ruff check .`
- `.venv/bin/pytest tests/usbprotocol`
- built `pandacan-0.0.11` wheel and verified required firmware/header files and `spidev` metadata are present
- opened openpilot validation PR: https://github.com/commaai/openpilot/pull/38062