### PR TITLE
Include firmware and build files in pandacan package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pandacan"
-version = "0.0.10"
+version = "0.0.11"
 description = "Code powering the comma.ai panda"
 readme = "README.md"
 requires-python = ">=3.11,<3.13"  # macOS doesn't work with 3.13 due to pycapnp from opendbc
@@ -15,9 +15,7 @@ dependencies = [
   "libusb1",
   "libusb-package",
   "opendbc @ git+https://github.com/commaai/opendbc.git@master#egg=opendbc",
-
-  # runtime dependency on comma four
-  #"spidev; platform_system == 'Linux'",
+  "spidev; platform_system == 'Linux'",
 ]
 
 [project.optional-dependencies]
@@ -50,8 +48,21 @@ packages = [
 ]
 
 [tool.setuptools.package-data]
-"panda.board" = ["health.h"]
-"panda.board.jungle" = ["jungle_health.h"]
+"panda" = [
+  "SConscript",
+  "SConstruct",
+  "board/**/*.c",
+  "board/**/*.h",
+  "board/**/*.ld",
+  "board/**/*.py",
+  "board/**/*.s",
+  "board/certs/*",
+  "board/obj/*.bin.signed",
+  "board/obj/bootstub.*.bin",
+  "board/obj/version",
+  "tests/libpanda/SConscript",
+  "tests/libpanda/panda.c",
+]
 
 [tool.setuptools.package-dir]
 panda = "."

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -29,7 +29,7 @@ except ImportError:
   # TODO: remove this on next AGNOS update
   pass
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'
 
 CANPACKET_HEAD_SIZE = 0x6
 DLC_TO_LEN = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]


### PR DESCRIPTION
pandacan currently installs the Python API and a couple of headers, but downstream users need a more complete package to use panda without a git submodule.

This PR updates the package so prepared wheels include the signed firmware, bootstubs, packet headers, board source/build files, certs, and libpanda build files. It also moves the Linux SPI transport dependency into pandacan so consumers do not need to declare panda internals directly.

Validation:
- `.venv/bin/ruff check .`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/pytest`
- `PATH=$PWD/.venv/bin:$PATH .venv/bin/scons`
- built a local `pandacan-0.0.11` wheel and verified required firmware/build files plus `spidev` metadata are present

Openpilot validation PR: https://github.com/commaai/openpilot/pull/38074