### PR TITLE
Add MISRA check for integer bool literals

### DIFF
--- a/board/body/bldc/bldc.h
+++ b/board/body/bldc/bldc.h
@@ -41,8 +41,8 @@ volatile uint16_t batt_percentage = 0;
 volatile int rpm_left = 0;
 volatile int rpm_right = 0;
 
-volatile bool enable_motors = 0;        // initially motors are disabled for safety
-static bool enableFin = 0;
+volatile bool enable_motors = false;    // initially motors are disabled for safety
+static bool enableFin = false;
 
 static const uint16_t pwm_res = ( (uint32_t)CORE_FREQ * 1000000U / 2U ) / PWM_FREQ;
 
@@ -233,9 +233,9 @@ void bldc_step(void) {
 
   // Safety: Don't enable if offsets are bogus (e.g. ADC failed)
   if (offsetrrA == 0 || offsetrrC == 0 || !enable_motors) {
-    enableFin = 0;
+    enableFin = false;
   } else {
-    enableFin = 1;
+    enableFin = true;
   }
 
   // Read Hall Sensors

--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -38,7 +38,7 @@ can_ring *can_queues[PANDA_CAN_CNT] = {&can_tx1_q, &can_tx2_q, &can_tx3_q};
 
 // ********************* interrupt safe queue *********************
 bool can_pop(can_ring *q, CANPacket_t *elem) {
-  bool ret = 0;
+  bool ret = false;
 
   ENTER_CRITICAL();
   if (q->w_ptr != q->r_ptr) {
@@ -48,7 +48,7 @@ bool can_pop(can_ring *q, CANPacket_t *elem) {
     } else {
       q->r_ptr += 1U;
     }
-    ret = 1;
+    ret = true;
   }
   EXIT_CRITICAL();
 

--- a/tests/misra/bool_literals.py
+++ b/tests/misra/bool_literals.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+import re
+
+import cppcheck
+
+
+INTEGER_BOOL_LITERAL = re.compile(r"^[01]([uUlL]*)$")
+
+
+def _is_external_token(token):
+  if token is None or token.file is None:
+    return False
+  filename = token.file.replace("\\", "/")
+  return "/.venv/" in filename or "/site-packages/" in filename
+
+
+def _is_bool_token(token):
+  if token is None:
+    return False
+  if token.valueType is not None and token.valueType.type == "bool":
+    return True
+  return token.variable is not None and token.variable.typeEndToken is not None and token.variable.typeEndToken.str == "bool"
+
+
+def _is_integer_bool_literal(token):
+  return (
+    token is not None and
+    token.isNumber and
+    token.macroName not in ("true", "false") and
+    INTEGER_BOOL_LITERAL.match(token.str) is not None
+  )
+
+
+@cppcheck.checker
+def integer_literal_bool(cfg, data):
+  for token in cfg.tokenlist:
+    if token.str != "=":
+      continue
+
+    lhs = token.astOperand1
+    rhs = token.astOperand2
+    if not _is_external_token(rhs) and _is_bool_token(lhs) and _is_integer_bool_literal(rhs):
+      cppcheck.reportError(rhs, "style", "use true/false for bool values", "integerLiteralBool")

--- a/tests/misra/checkers.txt
+++ b/tests/misra/checkers.txt
@@ -5,7 +5,7 @@ Cppcheck checkers list from test_misra.sh:
 
 
 TEST variant options:
---enable=all --disable=unusedFunction --addon=misra -DSTM32H7 -DSTM32H725xx -I /board/stm32h7/inc/ /board/main.c
+--enable=all --disable=unusedFunction --addon=misra --addon=tests/misra/bool_literals.py -DSTM32H7 -DSTM32H725xx -I /board/stm32h7/inc/ /board/main.c
 
 
 Critical errors

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -59,7 +59,7 @@ cppcheck() {
   fi
 }
 
-PANDA_OPTS="--enable=all --disable=unusedFunction --addon=misra"
+PANDA_OPTS="--enable=all --disable=unusedFunction --addon=misra --addon=tests/misra/bool_literals.py"
 
 printf "\n${GREEN}** PANDA H7 CODE **${NC}\n"
 cppcheck $PANDA_OPTS -DSTM32H7 -DSTM32H725xx -I $PANDA_DIR/board/stm32h7/inc/ $PANDA_DIR/board/main.c

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -27,6 +27,7 @@ IGNORED_PATHS = (
 
 mutations = [
   (None, None, False),  # no mods, should pass
+  ("board/drivers/can_common.h", "$a bool tx = 0;", True),
   ("board/stm32h7/llfdcan.h", "s/return ret;/if (true) { return ret; } else { return false; }/g", True),
 ]
 
@@ -62,8 +63,8 @@ rng = random.Random(len(files))
 for p in patterns:
   mutations.append((rng.choice(files), p, True))
 
-# sample to keep CI fast, but always include the no-mutation case
-mutations = [mutations[0]] + rng.sample(mutations[1:], min(2, len(mutations) - 1))
+# sample to keep CI fast, but always include the no-mutation and local addon cases
+mutations = mutations[:2] + rng.sample(mutations[2:], min(1, len(mutations) - 2))
 
 @pytest.mark.parametrize("fn, patch, should_fail", mutations)
 def test_misra_mutation(fn, patch, should_fail):


### PR DESCRIPTION
## Summary
- add a cppcheck addon to report integer 0/1 literals assigned to bools
- run the addon with the existing MISRA check
- fix existing Panda bool literal assignments and add a mutation case

## Verification
- tests/misra/test_misra.sh
- pytest -q tests/misra/test_mutation.py