### PR TITLE
Add fake STM GPIO simulation for libpanda tests

### DIFF
--- a/board/fake_stm.h
+++ b/board/fake_stm.h
@@ -7,8 +7,8 @@
 
 #define ALLOW_DEBUG
 
-#define ENTER_CRITICAL() 0
-#define EXIT_CRITICAL() 0
+#define ENTER_CRITICAL() do {} while (0);
+#define EXIT_CRITICAL() do {} while (0);
 
 void print(const char *a) {
   printf("%s", a);
@@ -30,4 +30,41 @@ uint32_t microsecond_timer_get(void) {
   return MICROSECOND_TIMER->CNT;
 }
 
-typedef uint32_t GPIO_TypeDef;
+typedef struct {
+  uint32_t MODER;
+  uint32_t OTYPER;
+  uint32_t OSPEEDR;
+  uint32_t PUPDR;
+  uint32_t IDR;
+  uint32_t ODR;
+  uint32_t AFR[2];
+} GPIO_TypeDef;
+
+GPIO_TypeDef fake_GPIOA;
+GPIO_TypeDef fake_GPIOB;
+GPIO_TypeDef fake_GPIOC;
+GPIO_TypeDef fake_GPIOD;
+GPIO_TypeDef fake_GPIOE;
+GPIO_TypeDef fake_GPIOF;
+GPIO_TypeDef fake_GPIOG;
+GPIO_TypeDef fake_GPIOH;
+
+#define GPIOA (&fake_GPIOA)
+#define GPIOB (&fake_GPIOB)
+#define GPIOC (&fake_GPIOC)
+#define GPIOD (&fake_GPIOD)
+#define GPIOE (&fake_GPIOE)
+#define GPIOF (&fake_GPIOF)
+#define GPIOG (&fake_GPIOG)
+#define GPIOH (&fake_GPIOH)
+
+void fake_stm_reset_gpio(void) {
+  fake_GPIOA = (GPIO_TypeDef){0};
+  fake_GPIOB = (GPIO_TypeDef){0};
+  fake_GPIOC = (GPIO_TypeDef){0};
+  fake_GPIOD = (GPIO_TypeDef){0};
+  fake_GPIOE = (GPIO_TypeDef){0};
+  fake_GPIOF = (GPIO_TypeDef){0};
+  fake_GPIOG = (GPIO_TypeDef){0};
+  fake_GPIOH = (GPIO_TypeDef){0};
+}

--- a/tests/libpanda/libpanda_py.py
+++ b/tests/libpanda/libpanda_py.py
@@ -29,6 +29,22 @@ int set_safety_hooks(uint16_t mode, uint16_t param);
 
 ffi.cdef("""
 typedef struct {
+  uint32_t MODER;
+  uint32_t OTYPER;
+  uint32_t OSPEEDR;
+  uint32_t PUPDR;
+  uint32_t IDR;
+  uint32_t ODR;
+  uint32_t AFR[2];
+} GPIO_TypeDef;
+
+void fake_stm_reset_gpio(void);
+GPIO_TypeDef *fake_stm_get_gpio(uint8_t port);
+void fake_stm_set_gpio_output(uint8_t port, uint8_t pin, bool enabled);
+""")
+
+ffi.cdef("""
+typedef struct {
   volatile uint32_t w_ptr;
   volatile uint32_t r_ptr;
   uint32_t fifo_size;

--- a/tests/libpanda/panda.c
+++ b/tests/libpanda/panda.c
@@ -17,12 +17,41 @@ void can_tx_comms_resume_spi(void) { };
 #include "boards/board_declarations.h"
 #include "opendbc/safety/safety.h"
 #include "main_definitions.h"
+#include "drivers/registers.h"
+#include "drivers/gpio.h"
 #include "drivers/can_common.h"
 
 can_ring *rx_q = &can_rx_q;
 can_ring *tx1_q = &can_tx1_q;
 can_ring *tx2_q = &can_tx2_q;
 can_ring *tx3_q = &can_tx3_q;
+
+GPIO_TypeDef *fake_stm_get_gpio(uint8_t port) {
+  switch (port) {
+    case 0U:
+      return GPIOA;
+    case 1U:
+      return GPIOB;
+    case 2U:
+      return GPIOC;
+    case 3U:
+      return GPIOD;
+    case 4U:
+      return GPIOE;
+    case 5U:
+      return GPIOF;
+    case 6U:
+      return GPIOG;
+    case 7U:
+      return GPIOH;
+    default:
+      return NULL;
+  }
+}
+
+void fake_stm_set_gpio_output(uint8_t port, uint8_t pin, bool enabled) {
+  set_gpio_output(fake_stm_get_gpio(port), pin, enabled);
+}
 
 #include "comms_definitions.h"
 #include "can_comms.h"

--- a/tests/libpanda/test_fake_stm_gpio.py
+++ b/tests/libpanda/test_fake_stm_gpio.py
@@ -1,0 +1,21 @@
+from panda.tests.libpanda import libpanda_py
+
+
+GPIOB = 1
+MODE_OUTPUT = 1
+
+
+def test_fake_stm_tracks_gpio_output_and_mode():
+  libpanda_py.libpanda.fake_stm_reset_gpio()
+
+  gpio = libpanda_py.libpanda.fake_stm_get_gpio(GPIOB)
+  assert gpio.ODR == 0
+  assert gpio.MODER == 0
+
+  libpanda_py.libpanda.fake_stm_set_gpio_output(GPIOB, 7, True)
+  assert gpio.ODR & (1 << 7)
+  assert ((gpio.MODER >> (7 * 2)) & 0b11) == MODE_OUTPUT
+
+  libpanda_py.libpanda.fake_stm_set_gpio_output(GPIOB, 7, False)
+  assert (gpio.ODR & (1 << 7)) == 0
+  assert ((gpio.MODER >> (7 * 2)) & 0b11) == MODE_OUTPUT


### PR DESCRIPTION
## Summary

- Add a fake STM GPIO register block for libpanda tests.
- Expose small libpanda helpers to reset/read fake GPIO ports and drive an output pin.
- Add a regression test that verifies `set_gpio_output()` updates `ODR` and `MODER`.

## Context

This is a focused first step toward #2203. The issue asks for simulated GPIO hardware so CI can assert important initialization behavior without HITL. Previously `fake_stm.h` modeled `GPIO_TypeDef` as a plain `uint32_t`, so tests could not inspect register state after GPIO helpers ran.

## Verification

```text
.venv/bin/scons -Q tests/libpanda/libpanda.so
PYTHONPATH=.. .venv/bin/python -m pytest -q -o addopts='' tests/libpanda/test_fake_stm_gpio.py
PYTHONPATH=.. .venv/bin/python -m pytest -q -o addopts='' tests/usbprotocol/test_comms.py tests/libpanda/test_fake_stm_gpio.py
```

Result:

```text
6 passed, 3 subtests passed in 1.76s
```

Refs #2203
