### PR TITLE
fix: use false/true instead of 0/1 for bool assignments (MISRA 10.3)

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -38,7 +38,7 @@ can_ring *can_queues[PANDA_CAN_CNT] = {&can_tx1_q, &can_tx2_q, &can_tx3_q};
 
 // ********************* interrupt safe queue *********************
 bool can_pop(can_ring *q, CANPacket_t *elem) {
-  bool ret = 0;
+  bool ret = false;
 
   ENTER_CRITICAL();
   if (q->w_ptr != q->r_ptr) {
@@ -48,7 +48,7 @@ bool can_pop(can_ring *q, CANPacket_t *elem) {
     } else {
       q->r_ptr += 1U;
     }
-    ret = 1;
+    ret = true;
   }
   EXIT_CRITICAL();
 

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -19,3 +19,6 @@ unusedFunction:*/interrupt_handlers*.h
 # cppcheck from 2.5 -> 2.13. they are listed here to separate the update from
 # fixing the violations and all are intended to be removed soon after
 misra-c2012-2.5   # unused macros. a few legit, rest aren't common between F4/H7 builds. should we do this in the unusedFunction pass?
+
+# TODO: remove after opendbc PR #3256 or equivalent is merged
+misra-c2012-10.3:*/opendbc/safety/modes/toyota.h


### PR DESCRIPTION
## Summary

Enforces MISRA rule 10.3 for bool assignments by catching integer literals 0/1 used where false/true are expected. Fixes #2105.

## Changes

### panda
- **board/drivers/can_common.h**: Replace `bool ret = 0` with `bool ret = false` and `ret = 1` with `ret = true` in `can_pop()`
- **tests/misra/suppressions.txt**: Add MISRA 10.3 suppression for opendbc safety/toyota.h (this will be fixed upstream via opendbc#3256)

### cppcheck

The upstream cppcheck MISRA addon has been enhanced to catch `bool <- 0/1` assignments in C99 and later (cppcheck-opensource/cppcheck#8340, cppcheck-opensource/cppcheck#8388). This PR fixes the violations found by the enhanced rule.

## Verification

```
$ cppcheck --addon=misra --std=c11 board/main.c | grep misra-c2012-10.3
# (no output — all violations fixed)
```