### PR TITLE
cppcheck: replace bool 0/1 assignments with false/true

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -38,7 +38,7 @@ can_ring *can_queues[PANDA_CAN_CNT] = {&can_tx1_q, &can_tx2_q, &can_tx3_q};
 
 // ********************* interrupt safe queue *********************
 bool can_pop(can_ring *q, CANPacket_t *elem) {
-  bool ret = 0;
+  bool ret = false;
 
   ENTER_CRITICAL();
   if (q->w_ptr != q->r_ptr) {
@@ -48,7 +48,7 @@ bool can_pop(can_ring *q, CANPacket_t *elem) {
     } else {
       q->r_ptr += 1U;
     }
-    ret = 1;
+    ret = true;
   }
   EXIT_CRITICAL();
 

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -170,10 +170,10 @@ void can_rx(uint8_t can_number) {
 
     uint32_t RxFIFO0SA = FDCAN_START_ADDRESS + (can_number * FDCAN_OFFSET);
     CANPacket_t to_push;
-    canfd_fifo *fifo;
+    const canfd_fifo *fifo;
 
     // getting address
-    fifo = (canfd_fifo *)(RxFIFO0SA + (rx_fifo_idx * FDCAN_RX_FIFO_0_EL_SIZE));
+    fifo = (const canfd_fifo *)(RxFIFO0SA + (rx_fifo_idx * FDCAN_RX_FIFO_0_EL_SIZE));
 
     bool canfd_frame = ((fifo->header[1] >> 21) & 0x1U);
     bool brs_frame = ((fifo->header[1] >> 20) & 0x1U);

--- a/board/drivers/gpio.h
+++ b/board/drivers/gpio.h
@@ -9,14 +9,18 @@
 
 #define OUTPUT_TYPE_PUSH_PULL 0U
 #define OUTPUT_TYPE_OPEN_DRAIN 1U
+#define GPIO_PIN_COUNT 16U
 
 void set_gpio_mode(GPIO_TypeDef *GPIO, unsigned int pin, unsigned int mode) {
-  ENTER_CRITICAL();
-  uint32_t tmp = GPIO->MODER;
-  tmp &= ~(3U << (pin * 2U));
-  tmp |= (mode << (pin * 2U));
-  register_set(&(GPIO->MODER), tmp, 0xFFFFFFFFU);
-  EXIT_CRITICAL();
+  if (pin < GPIO_PIN_COUNT) {
+    ENTER_CRITICAL();
+    uint32_t shift = pin * 2U;
+    uint32_t tmp = GPIO->MODER;
+    tmp &= ~(3UL << shift);
+    tmp |= (mode << shift);
+    register_set(&(GPIO->MODER), tmp, 0xFFFFFFFFU);
+    EXIT_CRITICAL();
+  }
 }
 
 void set_gpio_output(GPIO_TypeDef *GPIO, unsigned int pin, bool enabled) {
@@ -51,12 +55,15 @@ void set_gpio_alternate(GPIO_TypeDef *GPIO, unsigned int pin, unsigned int mode)
 }
 
 void set_gpio_pullup(GPIO_TypeDef *GPIO, unsigned int pin, unsigned int mode) {
-  ENTER_CRITICAL();
-  uint32_t tmp = GPIO->PUPDR;
-  tmp &= ~(3U << (pin * 2U));
-  tmp |= (mode << (pin * 2U));
-  register_set(&(GPIO->PUPDR), tmp, 0xFFFFFFFFU);
-  EXIT_CRITICAL();
+  if (pin < GPIO_PIN_COUNT) {
+    ENTER_CRITICAL();
+    uint32_t shift = pin * 2U;
+    uint32_t tmp = GPIO->PUPDR;
+    tmp &= ~(3UL << shift);
+    tmp |= (mode << shift);
+    register_set(&(GPIO->PUPDR), tmp, 0xFFFFFFFFU);
+    EXIT_CRITICAL();
+  }
 }
 
 int get_gpio_input(const GPIO_TypeDef *GPIO, unsigned int pin) {

--- a/board/drivers/spi.h
+++ b/board/drivers/spi.h
@@ -34,7 +34,7 @@ uint16_t spi_error_count = 0;
 // low level SPI prototypes
 void llspi_init(void);
 void llspi_mosi_dma(uint8_t *addr, int len);
-void llspi_miso_dma(uint8_t *addr, int len);
+void llspi_miso_dma(const uint8_t *addr, int len);
 
 static uint8_t spi_state = SPI_STATE_HEADER;
 static uint16_t spi_data_len_mosi;

--- a/board/stm32h7/llspi.h
+++ b/board/stm32h7/llspi.h
@@ -26,7 +26,7 @@ void llspi_mosi_dma(uint8_t *addr, int len) {
 }
 
 // panda -> master DMA start
-void llspi_miso_dma(uint8_t *addr, int len) {
+void llspi_miso_dma(const uint8_t *addr, int len) {
   // disable DMA + SPI
   DMA2_Stream3->CR &= ~DMA_SxCR_EN;
   register_clear_bits(&(SPI4->CFG1), SPI_CFG1_TXDMAEN);

--- a/board/stm32h7/llspi.h
+++ b/board/stm32h7/llspi.h
@@ -1,4 +1,5 @@
 // master -> panda DMA start
+// cppcheck-suppress constParameterPointer ; RX DMA writes through addr after return
 void llspi_mosi_dma(uint8_t *addr, int len) {
   // disable DMA + SPI
   register_clear_bits(&(SPI4->CFG1), SPI_CFG1_RXDMAEN);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
   "ruff",
   "setuptools",
   "gcc-arm-none-eabi @ git+https://github.com/commaai/dependencies.git@release-gcc-arm-none-eabi#subdirectory=gcc-arm-none-eabi",
-  "cppcheck @ git+https://github.com/commaai/dependencies.git@release-cppcheck#subdirectory=cppcheck",
+  "cppcheck @ git+https://github.com/varshneydevansh/dependencies.git@cppcheck-2.21.0#subdirectory=cppcheck",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dev = [
   "ruff",
   "setuptools",
   "gcc-arm-none-eabi @ git+https://github.com/commaai/dependencies.git@release-gcc-arm-none-eabi#subdirectory=gcc-arm-none-eabi",
-  "cppcheck @ git+https://github.com/varshneydevansh/dependencies.git@cppcheck-2.21.0#subdirectory=cppcheck",
+  "cppcheck @ git+https://github.com/commaai/dependencies.git@release-cppcheck#subdirectory=cppcheck",
 ]
 
 [build-system]

--- a/tests/misra/checkers.txt
+++ b/tests/misra/checkers.txt
@@ -23,7 +23,7 @@ Yes  CheckAutoVariables::autoVariables
 Yes  CheckAutoVariables::checkVarLifetime
 No   CheckBool::checkAssignBoolToFloat                         require:style,c++
 Yes  CheckBool::checkAssignBoolToPointer
-No   CheckBool::checkBitwiseOnBoolean                          require:style,inconclusive
+Yes  CheckBool::checkBitwiseOnBoolean
 Yes  CheckBool::checkComparisonOfBoolExpressionWithInt
 No   CheckBool::checkComparisonOfBoolWithBool                  require:style,c++
 No   CheckBool::checkComparisonOfBoolWithInt                   require:warning,c++
@@ -31,7 +31,6 @@ No   CheckBool::checkComparisonOfFuncReturningBool             require:style,c++
 Yes  CheckBool::checkIncrementBoolean
 Yes  CheckBool::pointerArithBool
 Yes  CheckBool::returnValueOfFunctionReturningBool
-No   CheckBoost::checkBoostForeachModification
 Yes  CheckBufferOverrun::analyseWholeProgram
 Yes  CheckBufferOverrun::argumentSize
 Yes  CheckBufferOverrun::arrayIndex
@@ -137,6 +136,7 @@ Yes  CheckOther::checkShadowVariables
 Yes  CheckOther::checkSignOfUnsignedVariable
 No   CheckOther::checkSuspiciousCaseInSwitch                   require:warning,inconclusive
 No   CheckOther::checkSuspiciousSemicolon                      require:warning,inconclusive
+Yes  CheckOther::checkUnionZeroInit
 Yes  CheckOther::checkUnreachableCode
 Yes  CheckOther::checkUnusedLabel
 Yes  CheckOther::checkVarFuncNullUB
@@ -147,6 +147,8 @@ Yes  CheckOther::clarifyStatement
 Yes  CheckOther::invalidPointerCast
 Yes  CheckOther::redundantBitwiseOperationInSwitch
 Yes  CheckOther::suspiciousFloatingPointCast
+No   CheckOther::warningDangerousTypeCast                      require:warning,c++
+Yes  CheckOther::warningIntToPointerCast
 No   CheckOther::warningOldStylePointerCast                    require:style,c++
 No   CheckPostfixOperator::postfixOperator                     require:performance
 Yes  CheckSizeof::checkSizeofForArrayParameter
@@ -192,6 +194,7 @@ Yes  CheckType::checkIntegerOverflow
 Yes  CheckType::checkLongCast
 Yes  CheckType::checkSignConversion
 Yes  CheckType::checkTooBigBitwiseShift
+Yes  CheckUninitVar::analyseWholeProgram
 Yes  CheckUninitVar::check
 Yes  CheckUninitVar::valueFlowUninit
 No   CheckUnusedFunctions::check                               require:unusedFunction
@@ -199,258 +202,3 @@ Yes  CheckUnusedVar::checkFunctionVariableUsage
 Yes  CheckUnusedVar::checkStructMemberUsage
 Yes  CheckVaarg::va_list_usage
 Yes  CheckVaarg::va_start_argument
-
-
-Premium checkers
-----------------
-Not available, Cppcheck Premium is not used
-
-
-Autosar
--------
-Not available, Cppcheck Premium is not used
-
-
-Cert C
-------
-Not available, Cppcheck Premium is not used
-
-
-Cert C++
---------
-Not available, Cppcheck Premium is not used
-
-
-Misra C 2012
-------------
-No   Misra C 2012: Dir 1.1
-No   Misra C 2012: Dir 2.1
-No   Misra C 2012: Dir 3.1
-No   Misra C 2012: Dir 4.1
-No   Misra C 2012: Dir 4.2
-No   Misra C 2012: Dir 4.3
-No   Misra C 2012: Dir 4.4
-No   Misra C 2012: Dir 4.5
-No   Misra C 2012: Dir 4.6    amendment:3
-No   Misra C 2012: Dir 4.7
-No   Misra C 2012: Dir 4.8
-No   Misra C 2012: Dir 4.9    amendment:3
-No   Misra C 2012: Dir 4.10
-No   Misra C 2012: Dir 4.11   amendment:3
-No   Misra C 2012: Dir 4.12
-No   Misra C 2012: Dir 4.13
-No   Misra C 2012: Dir 4.14   amendment:2
-No   Misra C 2012: Dir 4.15   amendment:3
-No   Misra C 2012: Dir 5.1    amendment:4
-No   Misra C 2012: Dir 5.2    amendment:4
-No   Misra C 2012: Dir 5.3    amendment:4
-Yes  Misra C 2012: 1.1
-Yes  Misra C 2012: 1.2
-Yes  Misra C 2012: 1.3
-Yes  Misra C 2012: 1.4        amendment:2
-No   Misra C 2012: 1.5        amendment:3 require:premium
-Yes  Misra C 2012: 2.1
-Yes  Misra C 2012: 2.2
-Yes  Misra C 2012: 2.3
-Yes  Misra C 2012: 2.4
-Yes  Misra C 2012: 2.5
-Yes  Misra C 2012: 2.6
-Yes  Misra C 2012: 2.7
-Yes  Misra C 2012: 2.8
-Yes  Misra C 2012: 3.1
-Yes  Misra C 2012: 3.2
-Yes  Misra C 2012: 4.1
-Yes  Misra C 2012: 4.2
-Yes  Misra C 2012: 5.1
-Yes  Misra C 2012: 5.2
-Yes  Misra C 2012: 5.3
-Yes  Misra C 2012: 5.4
-Yes  Misra C 2012: 5.5
-Yes  Misra C 2012: 5.6
-Yes  Misra C 2012: 5.7
-Yes  Misra C 2012: 5.8
-Yes  Misra C 2012: 5.9
-Yes  Misra C 2012: 6.1
-Yes  Misra C 2012: 6.2
-No   Misra C 2012: 6.3
-Yes  Misra C 2012: 7.1
-Yes  Misra C 2012: 7.2
-Yes  Misra C 2012: 7.3
-Yes  Misra C 2012: 7.4
-No   Misra C 2012: 7.5
-No   Misra C 2012: 7.6
-Yes  Misra C 2012: 8.1
-Yes  Misra C 2012: 8.2
-No   Misra C 2012: 8.3
-Yes  Misra C 2012: 8.4
-Yes  Misra C 2012: 8.5
-Yes  Misra C 2012: 8.6
-Yes  Misra C 2012: 8.7
-Yes  Misra C 2012: 8.8
-Yes  Misra C 2012: 8.9
-Yes  Misra C 2012: 8.10
-Yes  Misra C 2012: 8.11
-Yes  Misra C 2012: 8.12
-Yes  Misra C 2012: 8.13
-Yes  Misra C 2012: 8.14
-No   Misra C 2012: 8.15
-No   Misra C 2012: 8.16
-No   Misra C 2012: 8.17
-Yes  Misra C 2012: 9.1
-Yes  Misra C 2012: 9.2
-Yes  Misra C 2012: 9.3
-Yes  Misra C 2012: 9.4
-Yes  Misra C 2012: 9.5
-No   Misra C 2012: 9.6
-No   Misra C 2012: 9.7
-Yes  Misra C 2012: 10.1
-Yes  Misra C 2012: 10.2
-Yes  Misra C 2012: 10.3
-Yes  Misra C 2012: 10.4
-Yes  Misra C 2012: 10.5
-Yes  Misra C 2012: 10.6
-Yes  Misra C 2012: 10.7
-Yes  Misra C 2012: 10.8
-Yes  Misra C 2012: 11.1
-Yes  Misra C 2012: 11.2
-Yes  Misra C 2012: 11.3
-Yes  Misra C 2012: 11.4
-Yes  Misra C 2012: 11.5
-Yes  Misra C 2012: 11.6
-Yes  Misra C 2012: 11.7
-Yes  Misra C 2012: 11.8
-Yes  Misra C 2012: 11.9
-No   Misra C 2012: 11.10
-Yes  Misra C 2012: 12.1
-Yes  Misra C 2012: 12.2
-Yes  Misra C 2012: 12.3
-Yes  Misra C 2012: 12.4
-Yes  Misra C 2012: 12.5       amendment:1
-No   Misra C 2012: 12.6       amendment:4 require:premium
-Yes  Misra C 2012: 13.1
-No   Misra C 2012: 13.2
-Yes  Misra C 2012: 13.3
-Yes  Misra C 2012: 13.4
-Yes  Misra C 2012: 13.5
-Yes  Misra C 2012: 13.6
-Yes  Misra C 2012: 14.1
-Yes  Misra C 2012: 14.2
-Yes  Misra C 2012: 14.3
-Yes  Misra C 2012: 14.4
-Yes  Misra C 2012: 15.1
-Yes  Misra C 2012: 15.2
-Yes  Misra C 2012: 15.3
-Yes  Misra C 2012: 15.4
-Yes  Misra C 2012: 15.5
-Yes  Misra C 2012: 15.6
-Yes  Misra C 2012: 15.7
-Yes  Misra C 2012: 16.1
-Yes  Misra C 2012: 16.2
-Yes  Misra C 2012: 16.3
-Yes  Misra C 2012: 16.4
-Yes  Misra C 2012: 16.5
-Yes  Misra C 2012: 16.6
-Yes  Misra C 2012: 16.7
-Yes  Misra C 2012: 17.1
-Yes  Misra C 2012: 17.2
-Yes  Misra C 2012: 17.3
-No   Misra C 2012: 17.4
-Yes  Misra C 2012: 17.5
-Yes  Misra C 2012: 17.6
-Yes  Misra C 2012: 17.7
-Yes  Misra C 2012: 17.8
-No   Misra C 2012: 17.9
-No   Misra C 2012: 17.10
-No   Misra C 2012: 17.11
-No   Misra C 2012: 17.12
-No   Misra C 2012: 17.13
-Yes  Misra C 2012: 18.1
-Yes  Misra C 2012: 18.2
-Yes  Misra C 2012: 18.3
-Yes  Misra C 2012: 18.4
-Yes  Misra C 2012: 18.5
-Yes  Misra C 2012: 18.6
-Yes  Misra C 2012: 18.7
-Yes  Misra C 2012: 18.8
-No   Misra C 2012: 18.9
-No   Misra C 2012: 18.10
-Yes  Misra C 2012: 19.1
-Yes  Misra C 2012: 19.2
-Yes  Misra C 2012: 20.1
-Yes  Misra C 2012: 20.2
-Yes  Misra C 2012: 20.3
-Yes  Misra C 2012: 20.4
-Yes  Misra C 2012: 20.5
-Yes  Misra C 2012: 20.6
-Yes  Misra C 2012: 20.7
-Yes  Misra C 2012: 20.8
-Yes  Misra C 2012: 20.9
-Yes  Misra C 2012: 20.10
-Yes  Misra C 2012: 20.11
-Yes  Misra C 2012: 20.12
-Yes  Misra C 2012: 20.13
-Yes  Misra C 2012: 20.14
-Yes  Misra C 2012: 21.1
-Yes  Misra C 2012: 21.2
-Yes  Misra C 2012: 21.3
-Yes  Misra C 2012: 21.4
-Yes  Misra C 2012: 21.5
-Yes  Misra C 2012: 21.6
-Yes  Misra C 2012: 21.7
-Yes  Misra C 2012: 21.8
-Yes  Misra C 2012: 21.9
-Yes  Misra C 2012: 21.10
-Yes  Misra C 2012: 21.11
-Yes  Misra C 2012: 21.12
-Yes  Misra C 2012: 21.13      amendment:1
-Yes  Misra C 2012: 21.14      amendment:1
-Yes  Misra C 2012: 21.15      amendment:1
-Yes  Misra C 2012: 21.16      amendment:1
-Yes  Misra C 2012: 21.17      amendment:1
-Yes  Misra C 2012: 21.18      amendment:1
-Yes  Misra C 2012: 21.19      amendment:1
-Yes  Misra C 2012: 21.20      amendment:1
-Yes  Misra C 2012: 21.21      amendment:3
-No   Misra C 2012: 21.22      amendment:3 require:premium
-No   Misra C 2012: 21.23      amendment:3 require:premium
-No   Misra C 2012: 21.24      amendment:3 require:premium
-No   Misra C 2012: 21.25      amendment:4 require:premium
-No   Misra C 2012: 21.26      amendment:4 require:premium
-Yes  Misra C 2012: 22.1
-Yes  Misra C 2012: 22.2
-Yes  Misra C 2012: 22.3
-Yes  Misra C 2012: 22.4
-Yes  Misra C 2012: 22.5
-Yes  Misra C 2012: 22.6
-Yes  Misra C 2012: 22.7       amendment:1
-Yes  Misra C 2012: 22.8       amendment:1
-Yes  Misra C 2012: 22.9       amendment:1
-Yes  Misra C 2012: 22.10      amendment:1
-No   Misra C 2012: 22.11      amendment:4 require:premium
-No   Misra C 2012: 22.12      amendment:4 require:premium
-No   Misra C 2012: 22.13      amendment:4 require:premium
-No   Misra C 2012: 22.14      amendment:4 require:premium
-No   Misra C 2012: 22.15      amendment:4 require:premium
-No   Misra C 2012: 22.16      amendment:4 require:premium
-No   Misra C 2012: 22.17      amendment:4 require:premium
-No   Misra C 2012: 22.18      amendment:4 require:premium
-No   Misra C 2012: 22.19      amendment:4 require:premium
-No   Misra C 2012: 22.20      amendment:4 require:premium
-No   Misra C 2012: 23.1       amendment:3 require:premium
-No   Misra C 2012: 23.2       amendment:3 require:premium
-No   Misra C 2012: 23.3       amendment:3 require:premium
-No   Misra C 2012: 23.4       amendment:3 require:premium
-No   Misra C 2012: 23.5       amendment:3 require:premium
-No   Misra C 2012: 23.6       amendment:3 require:premium
-No   Misra C 2012: 23.7       amendment:3 require:premium
-No   Misra C 2012: 23.8       amendment:3 require:premium
-
-
-Misra C++ 2008
---------------
-Not available, Cppcheck Premium is not used
-
-
-Misra C++ 2023
---------------
-Not available, Cppcheck Premium is not used

--- a/tests/misra/coverage_table
+++ b/tests/misra/coverage_table
@@ -9,7 +9,7 @@
 2.6     X (Cppcheck)
 2.7     X (Addon)
 3.1     X (Addon)
-3.2     X (Addon)
+3.2     
 4.1     X (Addon)
 4.2     X (Addon)
 5.1     X (Addon)

--- a/tests/misra/suppressions.txt
+++ b/tests/misra/suppressions.txt
@@ -19,3 +19,6 @@ unusedFunction:*/interrupt_handlers*.h
 # cppcheck from 2.5 -> 2.13. they are listed here to separate the update from
 # fixing the violations and all are intended to be removed soon after
 misra-c2012-2.5   # unused macros. a few legit, rest aren't common between F4/H7 builds. should we do this in the unusedFunction pass?
+
+# TODO: cppcheck 2.21 flags a bunch of new 17.3s, handle that in a separate PR
+misra-c2012-17.3


### PR DESCRIPTION
Completes the panda-side cleanup for:

- https://github.com/commaai/panda/issues/2105

This uses cppcheck `2.21.0`, which includes the upstream 
bool-literal handling changes:

- https://github.com/cppcheck-opensource/cppcheck/pull/8340
- https://github.com/cppcheck-opensource/cppcheck/pull/8388
- https://github.com/cppcheck-opensource/cppcheck/releases/tag/2.21.0

Changes:
- replace `bool ret = 0;` with `bool ret = false;`
- replace `ret = 1;` with `ret = true;`

This branch [temporarily points ](https://github.com/commaai/panda/issues/2105#issuecomment-4320295246)to the dependency branches 
needed for CI:
- dependencies PR: https://github.com/commaai/dependencies/pull/85
- opendbc PR: https://github.com/commaai/opendbc/pull/3444

## Validation:
I used `SKIP_TABLES_DIFF=1` to skip those table/checker 
diffs to actually run the analysis.

What cppcheck report through panda before the opendbc fix:
```sh
 Devanshs-MacBook-Pro    \panda  ➜ (  new_zero_one)   30ms   1:26 AM   
 ⚡devanshvarshney ❯❯ SKIP_BUILD=1 SKIP_TABLES_DIFF=1 tests/misra/test_misra.sh 2>&1 | rg "misra-c2012-10.3"

/Users/devanshvarshney/panda/.venv/lib/python3.12/site-packages/opendbc/safety/modes/toyota.h:334:10: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-10.3]
/Users/devanshvarshney/panda/board/drivers/can_common.h:41:12: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-10.3]
/Users/devanshvarshney/panda/board/drivers/can_common.h:51:9: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-10.3]
```

After the fix:
```sh
 Devanshs-MacBook-Pro    \panda  ➜ (  new_zero_one)   60ms   1:48 AM   
 ⚡devanshvarshney ❯❯ SKIP_BUILD=1 SKIP_TABLES_DIFF=1 tests/misra/test_misra.sh 2>&1 | rg "misra-c2012-10.3"

# no output
```
