### PR TITLE
disable dac before stop mode

### DIFF
--- a/board/sys/power_saving.h
+++ b/board/sys/power_saving.h
@@ -74,6 +74,9 @@ static void enter_stop_mode(void) {
   ADC1->CR |= ADC_CR_DEEPPWD;
   ADC2->CR &= ~(ADC_CR_ADEN);
   ADC2->CR |= ADC_CR_DEEPPWD;
+  
+  // disable DACs
+  sound_stop_dac();
 
   // disable DTS
   register_clear_bits(&(DTS->CFGR1), DTS_CFGR1_TS1_START);


### PR DESCRIPTION
RM0468 pg. 277

The ADC or DAC can also consume power during Stop mode, unless they are disabled
before entering this mode. To disable them, the ADON bit in the ADC_CR2 register and
the ENx bit in the DAC_CR register must both be written to 0.