### PR TITLE
check harness relay state

### DIFF
--- a/board/drivers/can_common.h
+++ b/board/drivers/can_common.h
@@ -177,7 +177,12 @@ bool can_check_checksum(CANPacket_t *packet) {
 }
 
 void can_send(CANPacket_t *to_push, uint8_t bus_number, bool skip_tx_hook) {
-  if (skip_tx_hook || safety_tx_hook(to_push) != 0) {
+  bool relay_ok = true;
+  #if !defined(PANDA_JUNGLE) && !defined(PANDA_BODY)
+  relay_ok = !relay_monitor_malfunction();
+  #endif
+
+  if (relay_ok && (skip_tx_hook || safety_tx_hook(to_push) != 0)) {
     if (bus_number < PANDA_CAN_CNT) {
       // add CAN packet to send queue
       tx_buffer_overflow += can_push(can_queues[bus_number], to_push) ? 0U : 1U;

--- a/board/drivers/drivers.h
+++ b/board/drivers/drivers.h
@@ -153,6 +153,11 @@ void set_intercept_relay(bool intercept, bool ignition_relay);
 bool harness_check_ignition(void);
 void harness_tick(void);
 void harness_init(void);
+void relay_monitor_init(void);
+void relay_monitor_set_state(bool relay_open);
+void relay_monitor_rx(const CANPacket_t *msg);
+void relay_monitor_tick(void);
+bool relay_monitor_malfunction(void);
 
 // ******************** interrupts ********************
 

--- a/board/drivers/fdcan.h
+++ b/board/drivers/fdcan.h
@@ -193,6 +193,12 @@ void can_rx(uint8_t can_number) {
     }
     can_set_checksum(&to_push);
 
+    #if !defined(PANDA_JUNGLE) && !defined(PANDA_BODY)
+    if (harness.status != HARNESS_STATUS_NC) {
+      relay_monitor_rx(&to_push);
+    }
+    #endif
+
     // forwarding (panda only)
     int bus_fwd_num = safety_fwd_hook(bus_number, to_push.addr);
     if (bus_fwd_num < 0) {

--- a/board/drivers/harness.h
+++ b/board/drivers/harness.h
@@ -28,6 +28,10 @@ void set_intercept_relay(bool intercept, bool ignition_relay) {
   if (!(drive_relay || ignition_relay)) {
     harness.relay_driven = false;
   }
+
+  #ifndef BOOTSTUB
+  relay_monitor_set_state(drive_relay);
+  #endif
 }
 
 bool harness_check_ignition(void) {
@@ -92,6 +96,10 @@ void harness_tick(void) {
 }
 
 void harness_init(void) {
+  #ifndef BOOTSTUB
+  relay_monitor_init();
+  #endif
+
   // init OBD_SBUx_RELAY
   set_gpio_output_type(current_board->harness_config->GPIO_relay_SBU1, current_board->harness_config->pin_relay_SBU1, OUTPUT_TYPE_OPEN_DRAIN);
   set_gpio_output_type(current_board->harness_config->GPIO_relay_SBU2, current_board->harness_config->pin_relay_SBU2, OUTPUT_TYPE_OPEN_DRAIN);

--- a/board/drivers/relay.h
+++ b/board/drivers/relay.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#define RELAY_CHECK_UNKNOWN 0U
+#define RELAY_CHECK_PASS 1U
+#define RELAY_CHECK_FAIL 2U
+
+#define RELAY_MATCH_CACHE_SIZE 8U
+#define RELAY_MATCH_TIMEOUT_US 1000U
+#define RELAY_SETTLE_TIMEOUT_US 1000000U
+#define RELAY_OBSERVATION_TIMEOUT_US 3000000U
+#define RELAY_MIN_MATCHES 5U
+#define RELAY_MIN_MESSAGES 100U
+
+// A closed harness relay electrically joins buses 0 and 2, so both CAN
+// controllers receive the same frames. An open relay isolates the buses.
+typedef struct {
+  CANPacket_t packet;
+  uint32_t timestamp;
+  bool valid;
+} relay_packet_t;
+
+typedef struct {
+  bool relay_open;
+  bool observation_complete;
+  uint32_t state_change_timestamp;
+  uint16_t rx_count[2];
+  uint8_t match_count;
+  uint8_t cache_index[2];
+  relay_packet_t cache[2][RELAY_MATCH_CACHE_SIZE];
+  uint8_t closed_check;
+  uint8_t open_check;
+} relay_monitor_t;
+
+extern relay_monitor_t relay_monitor;
+relay_monitor_t relay_monitor;
+
+static bool relay_packets_equal(const CANPacket_t *a, const CANPacket_t *b) {
+  bool equal = (a->fd == b->fd) &&
+               (a->extended == b->extended) &&
+               (a->addr == b->addr) &&
+               (a->data_len_code == b->data_len_code);
+
+  for (uint8_t i = 0U; i < GET_LEN(a); i++) {
+    if (a->data[i] != b->data[i]) {
+      equal = false;
+    }
+  }
+  return equal;
+}
+
+void relay_monitor_set_state(bool relay_open) {
+  relay_monitor.relay_open = relay_open;
+  relay_monitor.observation_complete = false;
+  relay_monitor.state_change_timestamp = microsecond_timer_get();
+  relay_monitor.rx_count[0] = 0U;
+  relay_monitor.rx_count[1] = 0U;
+  relay_monitor.match_count = 0U;
+  relay_monitor.cache_index[0] = 0U;
+  relay_monitor.cache_index[1] = 0U;
+
+  for (uint8_t bus = 0U; bus < 2U; bus++) {
+    for (uint8_t i = 0U; i < RELAY_MATCH_CACHE_SIZE; i++) {
+      relay_monitor.cache[bus][i].valid = false;
+    }
+  }
+}
+
+void relay_monitor_init(void) {
+  relay_monitor.closed_check = RELAY_CHECK_UNKNOWN;
+  relay_monitor.open_check = RELAY_CHECK_UNKNOWN;
+  relay_monitor_set_state(false);
+}
+
+void relay_monitor_rx(const CANPacket_t *msg) {
+  const uint32_t now = microsecond_timer_get();
+  const bool valid_packet = !relay_monitor.observation_complete &&
+                            (get_ts_elapsed(now, relay_monitor.state_change_timestamp) >= RELAY_SETTLE_TIMEOUT_US) &&
+                            ((msg->bus == 0U) || (msg->bus == 2U));
+  if (valid_packet) {
+    const uint8_t bus = msg->bus / 2U;
+    const uint8_t other_bus = 1U - bus;
+    if (relay_monitor.rx_count[bus] < UINT16_MAX) {
+      relay_monitor.rx_count[bus] += 1U;
+    }
+
+    for (uint8_t i = 0U; i < RELAY_MATCH_CACHE_SIZE; i++) {
+      relay_packet_t *cached = &relay_monitor.cache[other_bus][i];
+      if (cached->valid &&
+          (get_ts_elapsed(now, cached->timestamp) <= RELAY_MATCH_TIMEOUT_US) &&
+          relay_packets_equal(msg, &cached->packet)) {
+        if (relay_monitor.match_count < UINT8_MAX) {
+          relay_monitor.match_count += 1U;
+        }
+        cached->valid = false;
+        break;
+      }
+    }
+
+    relay_packet_t *cached = &relay_monitor.cache[bus][relay_monitor.cache_index[bus]];
+    cached->packet = *msg;
+    cached->timestamp = now;
+    cached->valid = true;
+    relay_monitor.cache_index[bus] = (relay_monitor.cache_index[bus] + 1U) % RELAY_MATCH_CACHE_SIZE;
+  }
+}
+
+void relay_monitor_tick(void) {
+  if (!relay_monitor.observation_complete) {
+    const uint32_t elapsed = get_ts_elapsed(microsecond_timer_get(), relay_monitor.state_change_timestamp);
+    if (elapsed >= RELAY_SETTLE_TIMEOUT_US) {
+      uint8_t result = RELAY_CHECK_UNKNOWN;
+      if (relay_monitor.match_count >= RELAY_MIN_MATCHES) {
+        result = relay_monitor.relay_open ? RELAY_CHECK_FAIL : RELAY_CHECK_PASS;
+      } else if (elapsed >= (RELAY_SETTLE_TIMEOUT_US + RELAY_OBSERVATION_TIMEOUT_US)) {
+        const bool enough_traffic = relay_monitor.relay_open ?
+                                    ((relay_monitor.rx_count[0] >= RELAY_MIN_MESSAGES) ||
+                                     (relay_monitor.rx_count[1] >= RELAY_MIN_MESSAGES)) :
+                                    ((relay_monitor.rx_count[0] >= RELAY_MIN_MESSAGES) &&
+                                     (relay_monitor.rx_count[1] >= RELAY_MIN_MESSAGES));
+        if (enough_traffic) {
+          result = relay_monitor.relay_open ? RELAY_CHECK_PASS : RELAY_CHECK_FAIL;
+        }
+      } else {
+      }
+
+      if (result != RELAY_CHECK_UNKNOWN) {
+        if (relay_monitor.relay_open) {
+          relay_monitor.open_check = result;
+        } else {
+          relay_monitor.closed_check = result;
+        }
+        relay_monitor.observation_complete = true;
+      } else if (elapsed >= (RELAY_SETTLE_TIMEOUT_US + RELAY_OBSERVATION_TIMEOUT_US)) {
+        relay_monitor.observation_complete = true;
+      } else {
+      }
+    }
+  }
+}
+
+bool relay_monitor_malfunction(void) {
+  return (relay_monitor.closed_check == RELAY_CHECK_FAIL) ||
+         (relay_monitor.open_check == RELAY_CHECK_FAIL);
+}

--- a/board/main.c
+++ b/board/main.c
@@ -16,6 +16,8 @@
 
 #include "board/drivers/can_common.h"
 
+#include "board/drivers/relay.h"
+
 #include "board/drivers/fdcan.h"
 
 #include "board/sys/power_saving.h"
@@ -119,6 +121,7 @@ static void tick_handler(void) {
   static uint8_t prev_harness_status = HARNESS_STATUS_NC;
   static uint8_t loop_counter = 0U;
   static bool relay_malfunction_prev = false;
+  static bool stock_ecu_detected_prev = false;
 
   if (TICK_TIMER->SR != 0U) {
 
@@ -128,21 +131,37 @@ static void tick_handler(void) {
     // tick drivers at 8Hz
     fan_tick();
     harness_tick();
+    relay_monitor_tick();
     simple_watchdog_kick();
     sound_tick();
 
-    if (relay_malfunction_prev != relay_malfunction) {
-      if (relay_malfunction) {
+    const bool relay_malfunction_current = relay_monitor_malfunction();
+    if (relay_malfunction_prev != relay_malfunction_current) {
+      if (relay_malfunction_current) {
         fault_occurred(FAULT_RELAY_MALFUNCTION);
       } else {
         fault_recovered(FAULT_RELAY_MALFUNCTION);
       }
     }
-    relay_malfunction_prev = relay_malfunction;
+    relay_malfunction_prev = relay_malfunction_current;
+
+    // opendbc's relay_malfunction flag detects stock control messages, not the
+    // physical state of the harness relay.
+    if (stock_ecu_detected_prev != relay_malfunction) {
+      if (relay_malfunction) {
+        fault_occurred(FAULT_STOCK_ECU_DETECTED);
+      } else {
+        fault_recovered(FAULT_STOCK_ECU_DETECTED);
+      }
+    }
+    stock_ecu_detected_prev = relay_malfunction;
 
     // re-init everything that uses harness status
     if (harness.status != prev_harness_status) {
       prev_harness_status = harness.status;
+      if (harness.status == HARNESS_STATUS_NC) {
+        relay_monitor_init();
+      }
       can_set_orientation(harness.status == HARNESS_STATUS_FLIPPED);
 
       // re-init everything that uses harness status

--- a/board/sys/sys.h
+++ b/board/sys/sys.h
@@ -46,6 +46,7 @@ extern uint8_t global_critical_depth;
 #define FAULT_SIREN_MALFUNCTION             (1UL << 25)
 #define FAULT_HEARTBEAT_LOOP_WATCHDOG       (1UL << 26)
 #define FAULT_INTERRUPT_RATE_SOUND_DMA      (1UL << 27)
+#define FAULT_STOCK_ECU_DETECTED            (1UL << 28)
 
 // Permanent faults
 #define PERMANENT_FAULTS 0U

--- a/tests/libpanda/libpanda_py.py
+++ b/tests/libpanda/libpanda_py.py
@@ -47,6 +47,15 @@ int comms_can_read(uint8_t *data, uint32_t max_len);
 void comms_can_write(uint8_t *data, uint32_t len);
 void comms_can_reset(void);
 uint32_t can_slots_empty(can_ring *q);
+
+void relay_test_set_timer(uint32_t t);
+uint8_t relay_test_get_closed_check(void);
+uint8_t relay_test_get_open_check(void);
+void relay_monitor_init(void);
+void relay_monitor_set_state(bool relay_open);
+void relay_monitor_rx(CANPacket_t *msg);
+void relay_monitor_tick(void);
+bool relay_monitor_malfunction(void);
 """)
 
 class CANPacket:

--- a/tests/libpanda/panda.c
+++ b/tests/libpanda/panda.c
@@ -17,7 +17,20 @@ void can_tx_comms_resume_spi(void) { };
 #include "boards/board_declarations.h"
 #include "opendbc/safety/safety.h"
 #include "main_definitions.h"
+#include "drivers/relay.h"
 #include "drivers/can_common.h"
+
+void relay_test_set_timer(uint32_t t) {
+  MICROSECOND_TIMER->CNT = t;
+}
+
+uint8_t relay_test_get_closed_check(void) {
+  return relay_monitor.closed_check;
+}
+
+uint8_t relay_test_get_open_check(void) {
+  return relay_monitor.open_check;
+}
 
 can_ring *rx_q = &can_rx_q;
 can_ring *tx1_q = &can_tx1_q;

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -1,0 +1,106 @@
+from panda.tests.libpanda import libpanda_py
+
+
+lpp = libpanda_py.libpanda
+
+RELAY_CHECK_UNKNOWN = 0
+RELAY_CHECK_PASS = 1
+RELAY_CHECK_FAIL = 2
+
+RELAY_SETTLE_TIMEOUT_US = 1_000_000
+RELAY_OBSERVATION_TIMEOUT_US = 3_000_000
+
+
+def send_packet(bus, address, data, timestamp):
+  lpp.relay_test_set_timer(timestamp)
+  packet = libpanda_py.make_CANPacket(address, bus, data)
+  lpp.relay_monitor_rx(packet)
+
+
+def send_matching_packets(count, start_time):
+  for i in range(count):
+    data = i.to_bytes(8, "little")
+    send_packet(0, 0x100 + i, data, start_time + i * 1000)
+    send_packet(2, 0x100 + i, data, start_time + i * 1000 + 100)
+
+
+def send_distinct_packets(count, start_time):
+  for i in range(count):
+    send_packet(0, 0x100, i.to_bytes(8, "little"), start_time + i * 1000)
+    send_packet(2, 0x200, i.to_bytes(8, "little"), start_time + i * 1000 + 100)
+
+
+def send_one_sided_packets(count, start_time):
+  for i in range(count):
+    send_packet(0, 0x100, i.to_bytes(8, "little"), start_time + i * 1000)
+
+
+def finish_observation():
+  lpp.relay_test_set_timer(RELAY_SETTLE_TIMEOUT_US + RELAY_OBSERVATION_TIMEOUT_US)
+  lpp.relay_monitor_tick()
+
+
+class TestRelayMonitor:
+  def setup_method(self):
+    lpp.relay_test_set_timer(0)
+    lpp.relay_monitor_init()
+
+  def teardown_method(self):
+    lpp.relay_monitor_init()
+
+  def test_closed(self):
+    send_matching_packets(5, RELAY_SETTLE_TIMEOUT_US)
+    lpp.relay_monitor_tick()
+
+    assert lpp.relay_test_get_closed_check() == RELAY_CHECK_PASS
+    assert not lpp.relay_monitor_malfunction()
+
+  def test_stuck_open(self):
+    send_distinct_packets(100, RELAY_SETTLE_TIMEOUT_US)
+    finish_observation()
+
+    assert lpp.relay_test_get_closed_check() == RELAY_CHECK_FAIL
+    assert lpp.relay_monitor_malfunction()
+
+  def test_open(self):
+    lpp.relay_monitor_set_state(True)
+    send_one_sided_packets(100, RELAY_SETTLE_TIMEOUT_US)
+    finish_observation()
+
+    assert lpp.relay_test_get_open_check() == RELAY_CHECK_PASS
+    assert not lpp.relay_monitor_malfunction()
+
+  def test_stuck_closed(self):
+    lpp.relay_monitor_set_state(True)
+    send_matching_packets(5, RELAY_SETTLE_TIMEOUT_US)
+    lpp.relay_monitor_tick()
+
+    assert lpp.relay_test_get_open_check() == RELAY_CHECK_FAIL
+    assert lpp.relay_monitor_malfunction()
+
+  def test_insufficient_traffic_is_inconclusive(self):
+    send_distinct_packets(99, RELAY_SETTLE_TIMEOUT_US)
+    finish_observation()
+
+    assert lpp.relay_test_get_closed_check() == RELAY_CHECK_UNKNOWN
+    assert not lpp.relay_monitor_malfunction()
+
+  def test_failed_check_latches_until_retested(self):
+    send_distinct_packets(100, RELAY_SETTLE_TIMEOUT_US)
+    finish_observation()
+    assert lpp.relay_monitor_malfunction()
+
+    lpp.relay_test_set_timer(10_000_000)
+    lpp.relay_monitor_set_state(True)
+    send_distinct_packets(100, 11_000_000)
+    lpp.relay_test_set_timer(14_000_000)
+    lpp.relay_monitor_tick()
+    assert lpp.relay_test_get_open_check() == RELAY_CHECK_PASS
+    assert lpp.relay_monitor_malfunction()
+
+    lpp.relay_test_set_timer(20_000_000)
+    lpp.relay_monitor_set_state(False)
+    send_matching_packets(5, 21_000_000)
+    lpp.relay_monitor_tick()
+    assert lpp.relay_test_get_closed_check() == RELAY_CHECK_PASS
+    assert not lpp.relay_monitor_malfunction()


### PR DESCRIPTION
Checks the harness relay in both states using mirrored CAN traffic. Separates stock ECU detection from relay faults.