### PR TITLE
os: add support for windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,10 +34,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-latest', 'ubuntu-latest']
+        os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: ${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash -e {0}' }}
     steps:
       - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        if: contains(matrix.os, 'windows')
+        with:
+          msystem: CLANG64
       - run: ./test.sh
 
   windows:

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .*.swo
 *.o
 *.so
+*.dll
 *.os
 *.d
 *.dump

--- a/SConscript
+++ b/SConscript
@@ -102,7 +102,7 @@ def build_project(project_name, project, main, extra_flags):
     BUILDERS={
       'Objcopy': Builder(generator=objcopy, suffix='.bin', src_suffix='.elf')
     },
-    tools=["default", "compilation_db"],
+    tools=["mingw" if os.name == "nt" else "default", "compilation_db"],  # default picks MSVC on Windows
   )
 
   startup = env.Object(project["STARTUP_FILE"])

--- a/SConscript
+++ b/SConscript
@@ -1,4 +1,5 @@
 import os
+import sys
 import hashlib
 import base64
 import opendbc
@@ -125,7 +126,9 @@ def build_project(project_name, project, main, extra_flags):
   ], LINKFLAGS=[f"-Wl,--section-start,.isr_vector={project['APP_START_ADDRESS']}"] + flags)
   main_bin = env.Objcopy(f"{project_dir}/main.bin", main_elf)
   sign_py = File(f"./board/crypto/sign.py").srcnode().relpath
-  env.Command(f"./board/obj/{project_name}.bin.signed", main_bin, f"SETLEN=1 {sign_py} $SOURCE $TARGET {cert_fn}")
+  # cmd.exe on Windows runs neither a script by its shebang nor a VAR=value prefix
+  env.Command(f"./board/obj/{project_name}.bin.signed", main_bin, f'"{sys.executable}" {sign_py} $SOURCE $TARGET {cert_fn}',
+              ENV={**env["ENV"], "SETLEN": "1"})
 
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,3 +72,14 @@ python_files = "test_*.py"
 testpaths = [
   "tests/"
 ]
+
+# --- TODO REMOVE AFTER DEPENDENCY PR MERGES (commaai/dependencies#107): fork-only index of the comma-deps Windows wheels until PyPI has them; not for upstream ---
+[[tool.uv.index]]
+name = "comma-deps-windows"
+url = "https://github.com/AmyJeanes/commaai-dependencies/releases/download/windows-post111/index.html"
+format = "flat"
+explicit = true
+
+[tool.uv.sources]
+comma-deps-gcc-arm-none-eabi = [{ index = "comma-deps-windows", marker = "sys_platform == 'win32'" }]
+comma-deps-cppcheck = [{ index = "comma-deps-windows", marker = "sys_platform == 'win32'" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dev = [
   "pytest-timeout",
   "ruff",
   "setuptools",
-  "gcc-arm-none-eabi @ git+https://github.com/commaai/dependencies.git@release-gcc-arm-none-eabi#subdirectory=gcc-arm-none-eabi",
-  "cppcheck @ git+https://github.com/commaai/dependencies.git@release-cppcheck#subdirectory=cppcheck",
+  "comma-deps-gcc-arm-none-eabi ; python_full_version >= '3.12'",  # the wheels need 3.12
+  "comma-deps-cppcheck ; python_full_version >= '3.12'",
 ]
 
 [build-system]

--- a/scripts/debug_console.py
+++ b/scripts/debug_console.py
@@ -16,6 +16,15 @@ claim = os.getenv("CLAIM") is not None
 no_color = os.getenv("NO_COLOR") is not None
 no_reconnect = os.getenv("NO_RECONNECT") is not None
 
+
+def _stdin_has_line() -> bool:
+  # select() only works on sockets on Windows, so poll the console with msvcrt there
+  if sys.platform == "win32":
+    import msvcrt
+    return bool(msvcrt.kbhit())
+  return select.select([sys.stdin], [], [], 0) == ([sys.stdin], [], [])
+
+
 if __name__ == "__main__":
   while True:
     try:
@@ -50,7 +59,7 @@ if __name__ == "__main__":
               sys.stdout.flush()
             else:
               break
-          if select.select([sys.stdin], [], [], 0) == ([sys.stdin], [], []):
+          if _stdin_has_line():
             ln = sys.stdin.readline()
             if claim:
               panda.serial_write(port_number, ln)

--- a/scripts/som_debug.sh
+++ b/scripts/som_debug.sh
@@ -2,6 +2,6 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-cd $DIR
+cd "$DIR"
 
 PYTHONUNBUFFERED=1 NO_COLOR=1 CLAIM=1 PORT=4 ./debug_console.py

--- a/setup.sh
+++ b/setup.sh
@@ -19,6 +19,8 @@ elif [[ $PLATFORM == "Linux" ]]; then
   sudo apt-get install -y --no-install-recommends \
     curl ca-certificates gcc git \
     python3-dev
+elif [[ $PLATFORM == MINGW* ]]; then
+  pacman -S --needed --noconfirm mingw-w64-clang-x86_64-{clang,git,uv}  # MSYS2 CLANG64 shell; the ARM toolchain comes from uv
 else
   echo "WARNING: unsupported platform. skipping apt/brew install."
 fi
@@ -35,4 +37,4 @@ fi
 
 export UV_PROJECT_ENVIRONMENT="$DIR/.venv"
 uv sync --all-extras --upgrade
-source "$DIR/.venv/bin/activate"
+source "$DIR"/.venv/*/activate  # bin/, or Scripts/ on Windows

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,7 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-cd $DIR
+cd "$DIR"
 
 PLATFORM=$(uname -s)
 
@@ -31,7 +31,7 @@ if ! command -v uv &>/dev/null; then
 
   # doesn't require sourcing on all platforms
   set +e
-  source $HOME/.local/bin/env
+  source "$HOME/.local/bin/env"
   set -e
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-cd $DIR
+cd "$DIR"
 
 # *** env setup ***
 source ./setup.sh

--- a/tests/libpanda/SConscript
+++ b/tests/libpanda/SConscript
@@ -1,6 +1,8 @@
+import os
 import opendbc
 
 env = Environment(
+  ENV=os.environ,  # like the firmware build: on Windows clang is only on the MSYS2 shell's PATH
   CFLAGS=[
     '-nostdlib',
     '-fno-builtin',
@@ -9,7 +11,12 @@ env = Environment(
     '-Wno-pointer-to-int-cast',
   ],
   CPPPATH=[".", "../../", "../../board/", opendbc.INCLUDE_PATH],
+  tools=["mingw" if os.name == "nt" else "default"],  # default picks MSVC on Windows
 )
+if os.name == "nt":
+  env["CC"] = "clang"  # the mingw tool assumes gcc
+  env["no_import_lib"] = 1  # nothing links against the DLL
+  env.Append(CFLAGS=["-mno-ms-bitfields"])  # the firmware's packed layout
 
 panda = env.SharedObject("panda.os", "panda.c")
-libpanda = env.SharedLibrary("libpanda.so", [panda])
+libpanda = env.SharedLibrary("libpanda.dll" if os.name == "nt" else "libpanda.so", [panda])

--- a/tests/libpanda/libpanda_py.py
+++ b/tests/libpanda/libpanda_py.py
@@ -1,11 +1,12 @@
 import os
+import sys
 from cffi import FFI
 from typing import Any, Protocol
 
 from panda import LEN_TO_DLC
 
 libpanda_dir = os.path.dirname(os.path.abspath(__file__))
-libpanda_fn = os.path.join(libpanda_dir, "libpanda.so")
+libpanda_fn = os.path.join(libpanda_dir, "libpanda.dll" if sys.platform == "win32" else "libpanda.so")
 
 ffi = FFI()
 
@@ -14,9 +15,10 @@ typedef struct {
   unsigned char fd : 1;
   unsigned char bus : 3;
   unsigned char data_len_code : 4;
-  unsigned char rejected : 1;
-  unsigned char returned : 1;
-  unsigned char extended : 1;
+  // unsigned int like addr: same layout under GCC, and the one cffi's MSVC rules also lay out like the firmware
+  unsigned int rejected : 1;
+  unsigned int returned : 1;
+  unsigned int extended : 1;
   unsigned int addr : 29;
   unsigned char checksum;
   unsigned char data[64];

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -13,7 +13,7 @@ NC='\033[0m'
 : "${CPPCHECK_DIR:=$(python -c "import cppcheck; print(cppcheck.DIR)")}"
 
 # ensure checked in coverage table is up to date
-cd $DIR
+cd "$DIR"
 if [ -z "$SKIP_TABLES_DIFF" ]; then
   python $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
   if ! git diff --quiet coverage_table; then
@@ -22,7 +22,7 @@ if [ -z "$SKIP_TABLES_DIFF" ]; then
   fi
 fi
 
-cd $PANDA_DIR
+cd "$PANDA_DIR"
 if [ -z "${SKIP_BUILD}" ]; then
   scons
 fi
@@ -71,7 +71,7 @@ cppcheck $PANDA_OPTS -DSTM32H7 -DSTM32H725xx -I $PANDA_DIR/board/stm32h7/inc/ $P
 printf "\n${GREEN}Success!${NC} took $SECONDS seconds\n"
 
 # ensure list of checkers is up to date
-cd $DIR
+cd "$DIR"
 if [ -z "$SKIP_TABLES_DIFF" ] && ! git diff --quiet $CHECKLIST; then
   echo -e "\n${YELLOW}WARNING: Cppcheck checkers.txt report has changed. Review and commit...${NC}"
   exit 4

--- a/tests/misra/test_misra.sh
+++ b/tests/misra/test_misra.sh
@@ -3,19 +3,19 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 PANDA_DIR=$(realpath $DIR/../../)
-OPENDBC_ROOT=$(python3 -c "import opendbc; print(opendbc.INCLUDE_PATH)")
+OPENDBC_ROOT=$(python -c "import opendbc; print(opendbc.INCLUDE_PATH)")
 
 GREEN="\e[1;32m"
 YELLOW="\e[1;33m"
 RED="\e[1;31m"
 NC='\033[0m'
 
-: "${CPPCHECK_DIR:=$(python3 -c "import cppcheck; print(cppcheck.DIR)")}"
+: "${CPPCHECK_DIR:=$(python -c "import cppcheck; print(cppcheck.DIR)")}"
 
 # ensure checked in coverage table is up to date
 cd $DIR
 if [ -z "$SKIP_TABLES_DIFF" ]; then
-  python3 $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
+  python $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
   if ! git diff --quiet coverage_table; then
     echo -e "${YELLOW}MISRA coverage table doesn't match. Update and commit:${NC}"
     exit 3

--- a/tests/misra/test_mutation.py
+++ b/tests/misra/test_mutation.py
@@ -53,7 +53,7 @@ patterns = [
   r"$a #define TEST 1\n#undef TEST\n",
 ]
 
-all_files = glob.glob('board/**', root_dir=ROOT, recursive=True)
+all_files = [f.replace(os.sep, '/') for f in glob.glob('board/**', root_dir=ROOT, recursive=True)]  # Windows globs with backslashes
 files = sorted(f for f in all_files if f.endswith(('.c', '.h')) and not f.startswith(IGNORED_PATHS))
 assert len(files) > 50, all(d in files for d in ('board/main.c', 'board/stm32h7/llfdcan.h'))
 
@@ -84,6 +84,7 @@ def test_misra_mutation(fn, patch, should_fail):
         f.write(content)
 
     # run test
-    r = subprocess.run("SKIP_TABLES_DIFF=1 panda/tests/misra/test_misra.sh", cwd=tmp, shell=True)
+    # shutil.which: a bare "bash" is the WSL launcher on Windows
+    r = subprocess.run([shutil.which("bash"), "panda/tests/misra/test_misra.sh"], cwd=tmp, env={**os.environ, "SKIP_TABLES_DIFF": "1"})
     failed = r.returncode != 0
     assert failed == should_fail


### PR DESCRIPTION
Native Windows support for panda's firmware build and libpanda test library (MSYS2 CLANG64, clang), plus a windows-latest CI entry. openpilot's Windows build uses this to build and flash panda.

- SCons uses the mingw tool with clang on Windows (the default picks MSVC); the `.dll` target and cffi path are named per platform.
- CANPacket_t keeps its wire layout: the DLL builds with `-mno-ms-bitfields` and the flag bitfields are declared `unsigned int` so cffi's MSVC rules match the firmware. Linux/macOS layout unchanged (same fix as opendbc's libsafety).
- The signing step runs `sign.py` through the SCons interpreter (cmd.exe honours neither a shebang nor a `VAR=value` prefix).
- The dev toolchain and cppcheck come from their PyPI wheels; the setup and test scripts use the venv's `python`.

Line endings were split out and comma has already merged them.

Draft: the one `TEMP` commit at the tip (marked `TODO REMOVE`) drops once [commaai/dependencies#107](https://github.com/commaai/dependencies/pull/107) publishes the win_amd64 toolchain/cppcheck wheels; it points uv at a pre-release index meanwhile.

Part of a six-repo series: [commaai/openpilot#38810](https://github.com/commaai/openpilot/pull/38810), [commaai/msgq#709](https://github.com/commaai/msgq/pull/709), [commaai/opendbc#3724](https://github.com/commaai/opendbc/pull/3724), [commaai/rednose#61](https://github.com/commaai/rednose/pull/61), [commaai/dependencies#107](https://github.com/commaai/dependencies/pull/107). dependencies merges first; the rest independently.

Generated with Claude, human-reviewed and tested locally and in CI.
